### PR TITLE
fix(api): require a write permission for temporary push access endpoints

### DIFF
--- a/apps/api/src/docker-registry/controllers/docker-registry.controller.auth.spec.ts
+++ b/apps/api/src/docker-registry/controllers/docker-registry.controller.auth.spec.ts
@@ -14,6 +14,7 @@ import {
   getResourceAccessGuards,
   getRequiredOrganizationMemberRole,
   getRequiredOrganizationResourcePermissions,
+  getRequiredAnyOrganizationResourcePermissions,
   expectArrayMatch,
   createCoverageTracker,
   isPublicEndpoint,
@@ -58,6 +59,10 @@ describe('[AUTH] DockerRegistryController', () => {
     expectArrayMatch(getAuthContextGuards(DockerRegistryController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(DockerRegistryController, methodName)).toBeUndefined()
     expect(getRequiredOrganizationResourcePermissions(DockerRegistryController, methodName)).toBeUndefined()
+    expectArrayMatch(getRequiredAnyOrganizationResourcePermissions(DockerRegistryController, methodName), [
+      OrganizationResourcePermission.WRITE_SNAPSHOTS,
+      OrganizationResourcePermission.WRITE_SANDBOXES,
+    ])
   })
 
   it('findOne', () => {

--- a/apps/api/src/docker-registry/controllers/docker-registry.controller.ts
+++ b/apps/api/src/docker-registry/controllers/docker-registry.controller.ts
@@ -28,6 +28,7 @@ import { CustomHeaders } from '../../common/constants/header.constants'
 import { IsOrganizationAuthContext } from '../../common/decorators/auth-context.decorator'
 import { OrganizationAuthContext } from '../../common/interfaces/organization-auth-context.interface'
 import { RequiredOrganizationResourcePermissions } from '../../organization/decorators/required-organization-resource-permissions.decorator'
+import { RequiredAnyOrganizationResourcePermissions } from '../../organization/decorators/required-any-organization-resource-permissions.decorator'
 import { OrganizationResourcePermission } from '../../organization/enums/organization-resource-permission.enum'
 import { OrganizationAuthContextGuard } from '../../organization/guards/organization-auth-context.guard'
 import { Audit, MASKED_AUDIT_VALUE, TypedRequest } from '../../audit/decorators/audit.decorator'
@@ -122,6 +123,10 @@ export class DockerRegistryController {
     description: 'Temporary registry access has been generated',
     type: RegistryPushAccessDto,
   })
+  @RequiredAnyOrganizationResourcePermissions([
+    OrganizationResourcePermission.WRITE_SNAPSHOTS,
+    OrganizationResourcePermission.WRITE_SANDBOXES,
+  ])
   async getTransientPushAccess(
     @IsOrganizationAuthContext() authContext: OrganizationAuthContext,
     @Query('regionId') regionId?: string,

--- a/apps/api/src/object-storage/controllers/object-storage.controller.auth.spec.ts
+++ b/apps/api/src/object-storage/controllers/object-storage.controller.auth.spec.ts
@@ -6,9 +6,11 @@
 import { ObjectStorageController } from './object-storage.controller'
 import { OrganizationAuthContextGuard } from '../../organization/guards/organization-auth-context.guard'
 import { AuthStrategyType } from '../../auth/enums/auth-strategy-type.enum'
+import { OrganizationResourcePermission } from '../../organization/enums/organization-resource-permission.enum'
 import {
   getAuthContextGuards,
   getAllowedAuthStrategies,
+  getRequiredAnyOrganizationResourcePermissions,
   expectArrayMatch,
   createCoverageTracker,
   isPublicEndpoint,
@@ -25,5 +27,9 @@ describe('[AUTH] ObjectStorageController', () => {
       AuthStrategyType.JWT,
     ])
     expectArrayMatch(getAuthContextGuards(ObjectStorageController, methodName), [OrganizationAuthContextGuard])
+    expectArrayMatch(getRequiredAnyOrganizationResourcePermissions(ObjectStorageController, methodName), [
+      OrganizationResourcePermission.WRITE_SNAPSHOTS,
+      OrganizationResourcePermission.WRITE_SANDBOXES,
+    ])
   })
 })

--- a/apps/api/src/object-storage/controllers/object-storage.controller.ts
+++ b/apps/api/src/object-storage/controllers/object-storage.controller.ts
@@ -14,6 +14,8 @@ import { IsOrganizationAuthContext } from '../../common/decorators/auth-context.
 import { AuthenticatedRateLimitGuard } from '../../common/guards/authenticated-rate-limit.guard'
 import { AuthStrategy } from '../../auth/decorators/auth-strategy.decorator'
 import { AuthStrategyType } from '../../auth/enums/auth-strategy-type.enum'
+import { RequiredAnyOrganizationResourcePermissions } from '../../organization/decorators/required-any-organization-resource-permissions.decorator'
+import { OrganizationResourcePermission } from '../../organization/enums/organization-resource-permission.enum'
 
 @Controller('object-storage')
 @ApiTags('object-storage')
@@ -37,6 +39,10 @@ export class ObjectStorageController {
     description: 'Temporary storage access has been generated',
     type: StorageAccessDto,
   })
+  @RequiredAnyOrganizationResourcePermissions([
+    OrganizationResourcePermission.WRITE_SNAPSHOTS,
+    OrganizationResourcePermission.WRITE_SANDBOXES,
+  ])
   async getPushAccess(@IsOrganizationAuthContext() authContext: OrganizationAuthContext): Promise<StorageAccessDto> {
     return this.objectStorageService.getPushAccess(authContext.organizationId)
   }

--- a/apps/api/src/organization/decorators/required-any-organization-resource-permissions.decorator.ts
+++ b/apps/api/src/organization/decorators/required-any-organization-resource-permissions.decorator.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Reflector } from '@nestjs/core'
+import { OrganizationResourcePermission } from '../enums/organization-resource-permission.enum'
+
+/**
+ * Marks a controller or handler as requiring at least one of the specified resource permissions.
+ *
+ * Evaluated by `OrganizationAuthContextGuard`.
+ */
+export const RequiredAnyOrganizationResourcePermissions = Reflector.createDecorator<OrganizationResourcePermission[]>()

--- a/apps/api/src/organization/guards/organization-auth-context.guard.spec.ts
+++ b/apps/api/src/organization/guards/organization-auth-context.guard.spec.ts
@@ -23,6 +23,7 @@ import { createMockExecutionContext } from '../../test/helpers/execution-context
 import { OrganizationResourcePermission } from '../enums/organization-resource-permission.enum'
 import { RequiredOrganizationMemberRole } from '../decorators/required-organization-member-role.decorator'
 import { RequiredOrganizationResourcePermissions } from '../decorators/required-organization-resource-permissions.decorator'
+import { RequiredAnyOrganizationResourcePermissions } from '../decorators/required-any-organization-resource-permissions.decorator'
 
 describe('[AUTH] OrganizationAuthContextGuard', () => {
   let guard: OrganizationAuthContextGuard
@@ -168,6 +169,91 @@ describe('[AUTH] OrganizationAuthContextGuard', () => {
     const user = createMockUserAuthContext({ organizationId: MOCK_ORGANIZATION_ID })
     const { context } = createMockExecutionContext({ user })
     await expect(guard.canActivate(context)).rejects.toThrow(AccessDeniedException)
+  })
+
+  it('should allow member when @RequiredAnyOrganizationResourcePermissions matches a held permission', async () => {
+    mockReflector.getAllAndOverride.mockImplementation((key: any) => {
+      if (key === RequiredAnyOrganizationResourcePermissions) {
+        return [OrganizationResourcePermission.WRITE_SNAPSHOTS, OrganizationResourcePermission.WRITE_SANDBOXES]
+      }
+      return undefined
+    })
+    const user = createMockUserAuthContext({ organizationId: MOCK_ORGANIZATION_ID })
+    const { context } = createMockExecutionContext({ user })
+    const result = await guard.canActivate(context)
+    expect(result).toBe(true)
+  })
+
+  it('should reject member when @RequiredAnyOrganizationResourcePermissions matches no held permission', async () => {
+    mockReflector.getAllAndOverride.mockImplementation((key: any) => {
+      if (key === RequiredAnyOrganizationResourcePermissions) {
+        return [OrganizationResourcePermission.WRITE_SNAPSHOTS, OrganizationResourcePermission.DELETE_SANDBOXES]
+      }
+      return undefined
+    })
+    const user = createMockUserAuthContext({ organizationId: MOCK_ORGANIZATION_ID })
+    const { context } = createMockExecutionContext({ user })
+    await expect(guard.canActivate(context)).rejects.toThrow(AccessDeniedException)
+  })
+
+  it('should allow member when both all-of and any-of permission requirements are satisfied', async () => {
+    mockReflector.getAllAndOverride.mockImplementation((key: any) => {
+      if (key === RequiredOrganizationResourcePermissions) {
+        return [OrganizationResourcePermission.WRITE_SANDBOXES]
+      }
+      if (key === RequiredAnyOrganizationResourcePermissions) {
+        return [OrganizationResourcePermission.WRITE_SNAPSHOTS, OrganizationResourcePermission.WRITE_SANDBOXES]
+      }
+      return undefined
+    })
+    const user = createMockUserAuthContext({ organizationId: MOCK_ORGANIZATION_ID })
+    const { context } = createMockExecutionContext({ user })
+    const result = await guard.canActivate(context)
+    expect(result).toBe(true)
+  })
+
+  it('should reject member when all-of permissions are satisfied but any-of permissions are not', async () => {
+    mockReflector.getAllAndOverride.mockImplementation((key: any) => {
+      if (key === RequiredOrganizationResourcePermissions) {
+        return [OrganizationResourcePermission.WRITE_SANDBOXES]
+      }
+      if (key === RequiredAnyOrganizationResourcePermissions) {
+        return [OrganizationResourcePermission.WRITE_SNAPSHOTS]
+      }
+      return undefined
+    })
+    const user = createMockUserAuthContext({ organizationId: MOCK_ORGANIZATION_ID })
+    const { context } = createMockExecutionContext({ user })
+    await expect(guard.canActivate(context)).rejects.toThrow(AccessDeniedException)
+  })
+
+  it('should reject member when any-of permissions are satisfied but all-of permissions are not', async () => {
+    mockReflector.getAllAndOverride.mockImplementation((key: any) => {
+      if (key === RequiredOrganizationResourcePermissions) {
+        return [OrganizationResourcePermission.DELETE_SANDBOXES]
+      }
+      if (key === RequiredAnyOrganizationResourcePermissions) {
+        return [OrganizationResourcePermission.WRITE_SANDBOXES]
+      }
+      return undefined
+    })
+    const user = createMockUserAuthContext({ organizationId: MOCK_ORGANIZATION_ID })
+    const { context } = createMockExecutionContext({ user })
+    await expect(guard.canActivate(context)).rejects.toThrow(AccessDeniedException)
+  })
+
+  it('should allow owner without API key when @RequiredAnyOrganizationResourcePermissions is set', async () => {
+    mockOrgUserService.findOne.mockResolvedValue(testOwner)
+    mockReflector.getAllAndOverride.mockImplementation((key: any) => {
+      if (key === RequiredAnyOrganizationResourcePermissions) {
+        return [OrganizationResourcePermission.WRITE_SNAPSHOTS, OrganizationResourcePermission.WRITE_SANDBOXES]
+      }
+      return undefined
+    })
+    const user = createMockUserAuthContext({ organizationId: MOCK_ORGANIZATION_ID })
+    const { context } = createMockExecutionContext({ user })
+    const result = await guard.canActivate(context)
+    expect(result).toBe(true)
   })
 
   it('should enrich request.user with organization data', async () => {

--- a/apps/api/src/organization/guards/organization-auth-context.guard.ts
+++ b/apps/api/src/organization/guards/organization-auth-context.guard.ts
@@ -12,6 +12,7 @@ import { OrganizationService } from '../services/organization.service'
 import { OrganizationUserService } from '../services/organization-user.service'
 import { RequiredOrganizationMemberRole } from '../decorators/required-organization-member-role.decorator'
 import { RequiredOrganizationResourcePermissions } from '../decorators/required-organization-resource-permissions.decorator'
+import { RequiredAnyOrganizationResourcePermissions } from '../decorators/required-any-organization-resource-permissions.decorator'
 import { OrganizationMemberRole } from '../enums/organization-member-role.enum'
 import { UserAuthContext, isUserAuthContext } from '../../common/interfaces/user-auth-context.interface'
 import { OrganizationAuthContext } from '../../common/interfaces/organization-auth-context.interface'
@@ -24,7 +25,8 @@ import { AccessDeniedException } from '../../common/exceptions/access-denied.exc
 /**
  * Guard that validates access to an organization, enforces role/permission requirements, and enriches the auth context with organization data.
  *
- * Enforces the `@RequiredOrganizationMemberRole` and `@RequiredOrganizationResourcePermissions` decorators.
+ * Enforces the `@RequiredOrganizationMemberRole`, `@RequiredOrganizationResourcePermissions` and
+ * `@RequiredAnyOrganizationResourcePermissions` decorators.
  */
 @Injectable()
 export class OrganizationAuthContextGuard extends AuthContextGuard {
@@ -153,7 +155,8 @@ export class OrganizationAuthContextGuard extends AuthContextGuard {
   /**
    * Checks if the organization user has authorization for the required role and(or) permissions.
    *
-   * Enforces the `RequiredOrganizationMemberRole` and `RequiredOrganizationResourcePermissions` decorators.
+   * Enforces the `RequiredOrganizationMemberRole`, `RequiredOrganizationResourcePermissions` and
+   * `RequiredAnyOrganizationResourcePermissions` decorators.
    */
   private isAuthorized(
     context: ExecutionContext,
@@ -179,7 +182,12 @@ export class OrganizationAuthContextGuard extends AuthContextGuard {
       context.getClass(),
     ])
 
-    if (!requiredPermissions) {
+    const requiredAnyPermissions = this.reflector.getAllAndOverride(RequiredAnyOrganizationResourcePermissions, [
+      context.getHandler(),
+      context.getClass(),
+    ])
+
+    if (!requiredPermissions && !requiredAnyPermissions) {
       return true
     }
 
@@ -187,6 +195,14 @@ export class OrganizationAuthContextGuard extends AuthContextGuard {
       ? new Set(authContext.apiKey.permissions)
       : new Set(organizationUser.assignedRoles.flatMap((role) => role.permissions))
 
-    return requiredPermissions.every((permission) => assignedPermissions.has(permission))
+    if (requiredPermissions && !requiredPermissions.every((permission) => assignedPermissions.has(permission))) {
+      return false
+    }
+
+    if (requiredAnyPermissions && !requiredAnyPermissions.some((permission) => assignedPermissions.has(permission))) {
+      return false
+    }
+
+    return true
   }
 }

--- a/apps/api/src/test/helpers/controller-metadata.helper.ts
+++ b/apps/api/src/test/helpers/controller-metadata.helper.ts
@@ -16,6 +16,7 @@ import { SystemRole } from '../../user/enums/system-role.enum'
 import { RequiredOrganizationMemberRole } from '../../organization/decorators/required-organization-member-role.decorator'
 import { OrganizationMemberRole } from '../../organization/enums/organization-member-role.enum'
 import { RequiredOrganizationResourcePermissions } from '../../organization/decorators/required-organization-resource-permissions.decorator'
+import { RequiredAnyOrganizationResourcePermissions } from '../../organization/decorators/required-any-organization-resource-permissions.decorator'
 import { OrganizationResourcePermission } from '../../organization/enums/organization-resource-permission.enum'
 
 const GUARDS_METADATA_KEY = '__guards__'
@@ -210,6 +211,40 @@ export function getRequiredOrganizationResourcePermissions(
   }
 
   return Reflect.getMetadata(RequiredOrganizationResourcePermissions.KEY, controller) as
+    | OrganizationResourcePermission[]
+    | undefined
+}
+
+/**
+ * Gets the required any-of organization resource permissions for a controller method or class.
+ *
+ * Checks method-level metadata first, then falls back to class-level.
+ */
+export function getRequiredAnyOrganizationResourcePermissions(
+  controller: ControllerType,
+): OrganizationResourcePermission[] | undefined
+export function getRequiredAnyOrganizationResourcePermissions<T extends object>(
+  controller: Type<T>,
+  methodName: keyof T & string,
+): OrganizationResourcePermission[] | undefined
+export function getRequiredAnyOrganizationResourcePermissions(
+  controller: ControllerType,
+  methodName?: string,
+): OrganizationResourcePermission[] | undefined {
+  if (methodName) {
+    assertMethodExists(controller, methodName)
+    const method = (controller.prototype as Record<string, unknown>)[methodName]
+    if (typeof method === 'function') {
+      const methodPermissions = Reflect.getMetadata(RequiredAnyOrganizationResourcePermissions.KEY, method) as
+        | OrganizationResourcePermission[]
+        | undefined
+      if (methodPermissions !== undefined) {
+        return methodPermissions
+      }
+    }
+  }
+
+  return Reflect.getMetadata(RequiredAnyOrganizationResourcePermissions.KEY, controller) as
     | OrganizationResourcePermission[]
     | undefined
 }


### PR DESCRIPTION
## Description

Adds a `@RequiredAnyOrganizationResourcePermissions` decorator (any-of semantics, evaluated by `OrganizationAuthContextGuard` alongside the existing all-of decorator) and applies it to the two temporary push access endpoints:

- `GET /object-storage/push-access`
- `GET /docker-registry/registry-push-access`

Callers must now hold either `write:snapshots` or `write:sandboxes`. Either permission is accepted because both the snapshot push flow and the declarative sandbox build flow (`Daytona.create()` with a local image context) use these endpoints.

No new permission enum value is introduced — the existing `write:snapshots` / `write:sandboxes` permissions are reused, so API key and role definitions are unaffected.

## Breaking change

API keys or roles that call these endpoints without holding `write:snapshots` or `write:sandboxes` will now receive a 403. Migration: grant one of the two permissions to affected keys. Flagged in the commit footer so it can be bundled with the next breaking release.

## Testing

- Guard unit tests cover the any-of branch: passes with either permission, denied with neither, composes with the all-of decorator, owner bypass preserved
- Controller auth specs assert the permission metadata on both endpoints
- Full `api` test suite passes (556 tests), typecheck and prettier clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens access control for temporary push access: callers must now hold either write:snapshots or write:sandboxes to use GET /object-storage/push-access and GET /docker-registry/registry-push-access.

- **New Features**
  - Added `@RequiredAnyOrganizationResourcePermissions` with any-of semantics, enforced by `OrganizationAuthContextGuard`.
  - Reused existing permission enums; no new values or role changes.
  - Added unit tests for the guard and controller metadata.

- **Migration**
  - Grant write:snapshots or write:sandboxes to API keys/roles that call these endpoints; otherwise they will receive 403.

<sup>Written for commit 0e2e906655636f4ec75855db9b5a24ac754170e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

