### PR TITLE
fix(dashboard): signin redirect in effect and update auth tokens

### DIFF
--- a/apps/dashboard/src/api/apiClient.ts
+++ b/apps/dashboard/src/api/apiClient.ts
@@ -29,8 +29,12 @@ import {
 import axios, { AxiosError } from 'axios'
 import { DaytonaError } from './errors'
 
+type ExternalServiceConfiguration = BillingConfiguration | AnalyticsConfiguration
+
 export class ApiClient {
   private config: Configuration
+  private billingConfig: BillingConfiguration
+  private analyticsConfig: AnalyticsConfiguration | null
   private _snapshotApi: SnapshotsApi
   private _sandboxApi: SandboxApi
   private _userApi: UsersApi
@@ -78,7 +82,7 @@ export class ApiClient {
     this._apiKeyApi = new ApiKeysApi(this.config, undefined, axiosInstance)
     this._dockerRegistryApi = new DockerRegistryApi(this.config, undefined, axiosInstance)
     this._organizationsApi = new OrganizationsApi(this.config, undefined, axiosInstance)
-    const billingConfig = new BillingConfiguration({
+    this.billingConfig = new BillingConfiguration({
       basePath: config.billingApiUrl || window.location.origin,
       accessToken: accessToken,
       baseOptions: {
@@ -87,7 +91,7 @@ export class ApiClient {
         },
       },
     })
-    this._billingApi = new BillingApiClient(billingConfig, axiosInstance)
+    this._billingApi = new BillingApiClient(this.billingConfig, axiosInstance)
     this._volumeApi = new VolumesApi(this.config, undefined, axiosInstance)
     this._toolboxApi = new ToolboxApi(this.config, undefined, axiosInstance)
     this._auditApi = new AuditApi(this.config, undefined, axiosInstance)
@@ -96,7 +100,7 @@ export class ApiClient {
     this._webhooksApi = new WebhooksApi(this.config, undefined, axiosInstance)
 
     if (config.analyticsApiUrl) {
-      const analyticsConfig = new AnalyticsConfiguration({
+      this.analyticsConfig = new AnalyticsConfiguration({
         basePath: config.analyticsApiUrl,
         accessToken: accessToken,
         baseOptions: {
@@ -105,9 +109,10 @@ export class ApiClient {
           },
         },
       })
-      this._analyticsUsageApi = new AnalyticsUsageApi(analyticsConfig, undefined, axiosInstance)
-      this._analyticsTelemetryApi = new AnalyticsTelemetryApi(analyticsConfig, undefined, axiosInstance)
+      this._analyticsUsageApi = new AnalyticsUsageApi(this.analyticsConfig, undefined, axiosInstance)
+      this._analyticsTelemetryApi = new AnalyticsTelemetryApi(this.analyticsConfig, undefined, axiosInstance)
     } else {
+      this.analyticsConfig = null
       this._analyticsUsageApi = null
       this._analyticsTelemetryApi = null
     }
@@ -115,6 +120,22 @@ export class ApiClient {
 
   public setAccessToken(accessToken: string) {
     this.config.accessToken = accessToken
+    this.setExternalServiceAccessToken(this.billingConfig, accessToken)
+
+    if (this.analyticsConfig) {
+      this.setExternalServiceAccessToken(this.analyticsConfig, accessToken)
+    }
+  }
+
+  private setExternalServiceAccessToken(configuration: ExternalServiceConfiguration, accessToken: string) {
+    configuration.accessToken = accessToken
+    configuration.baseOptions = {
+      ...configuration.baseOptions,
+      headers: {
+        ...configuration.baseOptions?.headers,
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
   }
 
   public get snapshotApi() {


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the dashboard auth flow by moving sign-in redirects into effects and ensuring refreshed access tokens propagate to billing and analytics clients. Prevents redirect loops and keeps external requests authenticated.

- **Bug Fixes**
  - LandingPage and ApiProvider: trigger `signinRedirect` in an effect only when not authenticated, not loading, not already navigating, and not in a callback; guard with a one-time ref to avoid multiple redirects.
  - Add `LoadingFallback` with simple source tags for clearer telemetry during auth transitions.
  - ApiClient: persist `billingConfig` and `analyticsConfig` as class members and update both via a shared helper in `setAccessToken`, refreshing `Authorization` headers for external services.
  - ConfigProvider: increase `staleStateAgeInSeconds` to 5 minutes for `react-oidc-context` to reduce stale-state errors on longer redirects.

<sup>Written for commit 34e30a9f9609fae73bd3d2f3e581eb7b1b0159be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



