### PR TITLE
fix(api): redirect root requests to /dashboard

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -36,7 +36,7 @@ ENV NX_DAEMON=false
 
 RUN yarn nx build api --configuration=production --nxBail=true
 
-RUN VITE_API_URL=%DAYTONA_BASE_API_URL%/api yarn nx build dashboard --configuration=production --nxBail=true --output-style=stream
+RUN VITE_BASE_PATH=/dashboard/ VITE_API_URL=%DAYTONA_BASE_API_URL%/api yarn nx build dashboard --configuration=production --nxBail=true --output-style=stream
 
 # ── runtime ──────────────────────────────────────────────────────────────
 FROM node:24-slim AS daytona

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -123,6 +123,7 @@ import { SandboxTelemetryModule } from './sandbox-telemetry/sandbox-telemetry.mo
         return [
           {
             rootPath: join(__dirname, '..', 'dashboard'),
+            serveRoot: '/dashboard',
             exclude: ['/api/{*path}'],
             renderPath: '/',
             serveStaticOptions: {

--- a/apps/api/src/filters/all-exceptions.filter.ts
+++ b/apps/api/src/filters/all-exceptions.filter.ts
@@ -34,10 +34,15 @@ export class AllExceptionsFilter implements ExceptionFilter {
     let error: string
     let message: string
 
-    // If the exception is a NotFoundException and the request path is not an API request, serve the dashboard index.html file
+    // If the exception is a NotFoundException and the request path is not an API request,
+    // serve the dashboard index.html file for dashboard routes and redirect everything else to the dashboard
     if (exception instanceof NotFoundException && !request.path.startsWith('/api/')) {
       const response = ctx.getResponse()
-      response.sendFile(join(__dirname, '..', 'dashboard', 'index.html'))
+      if (request.path === '/dashboard' || request.path.startsWith('/dashboard/')) {
+        response.sendFile(join(__dirname, '..', 'dashboard', 'index.html'))
+      } else {
+        response.redirect(`/dashboard${request.url}`)
+      }
       return
     }
 

--- a/apps/api/src/filters/all-exceptions.filter.ts
+++ b/apps/api/src/filters/all-exceptions.filter.ts
@@ -35,13 +35,13 @@ export class AllExceptionsFilter implements ExceptionFilter {
     let message: string
 
     // If the exception is a NotFoundException and the request path is not an API request,
-    // serve the dashboard index.html file for dashboard routes and redirect everything else to the dashboard
+    // redirect root requests to the dashboard and serve the dashboard index.html file for everything else
     if (exception instanceof NotFoundException && !request.path.startsWith('/api/')) {
       const response = ctx.getResponse()
-      if (request.path === '/dashboard' || request.path.startsWith('/dashboard/')) {
-        response.sendFile(join(__dirname, '..', 'dashboard', 'index.html'))
-      } else {
+      if (request.path === '/') {
         response.redirect(`/dashboard${request.url}`)
+      } else {
+        response.sendFile(join(__dirname, '..', 'dashboard', 'index.html'))
       }
       return
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Serve the dashboard SPA under `/dashboard` and redirect only `/` to it. Non-API 404s now render the SPA so deep links like `/logout`, `/docs`, and `/slack` work, fixing refresh 404s while keeping root hits on the dashboard.

- **Bug Fixes**
  - Serve the dashboard under `/dashboard` using `serveRoot` and build with `VITE_BASE_PATH=/dashboard/` so asset URLs resolve under the new base.
  - Update `AllExceptionsFilter` to redirect only `/` to `/dashboard` and serve `index.html` for other non-API paths to preserve root-level SPA routes.

<sup>Written for commit 28a3b1a38e434bb1d477e49d3e713d9ba2524d0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

