### PR TITLE
fix(runner): allow native sandbox image platform

### DIFF
--- a/apps/runner/pkg/docker/create.go
+++ b/apps/runner/pkg/docker/create.go
@@ -188,9 +188,11 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 		return "", "", err
 	}
 
+	platform := getSandboxPlatform()
+
 	c, err := d.apiClient.ContainerCreate(ctx, containerConfig, hostConfig, networkingConfig, &v1.Platform{
-		Architecture: "amd64",
-		OS:           "linux",
+		Architecture: platform.architecture,
+		OS:           platform.os,
 	}, sandboxDto.Id)
 	if err != nil {
 		// Container already exists and is being created by another process
@@ -275,7 +277,7 @@ func (p *DockerClient) validateImageArchitecture(image *image.InspectResponse) e
 	}
 
 	arch := strings.ToLower(image.Architecture)
-	validArchs := []string{"amd64", "x86_64"}
+	validArchs := getSandboxContainerArchs()
 
 	for _, validArch := range validArchs {
 		if arch == validArch {
@@ -283,5 +285,5 @@ func (p *DockerClient) validateImageArchitecture(image *image.InspectResponse) e
 		}
 	}
 
-	return common_errors.NewConflictError(fmt.Errorf("image %s architecture (%s) is not x64 compatible", image.ID, image.Architecture))
+	return common_errors.NewConflictError(fmt.Errorf("image %s architecture (%s) is not supported for sandbox platform %s", image.ID, image.Architecture, sandboxImagePlatform()))
 }

--- a/apps/runner/pkg/docker/image_build.go
+++ b/apps/runner/pkg/docker/image_build.go
@@ -164,7 +164,7 @@ func (d *DockerClient) BuildImage(ctx context.Context, buildImageDto dto.BuildSn
 		Remove:      true,
 		ForceRemove: true,
 		PullParent:  true,
-		Platform:    "linux/amd64", // Force AMD64 architecture
+		Platform:    sandboxImagePlatform(), // Optional override; defaults to linux/amd64
 		AuthConfigs: authConfigs,
 	}
 

--- a/apps/runner/pkg/docker/image_pull.go
+++ b/apps/runner/pkg/docker/image_pull.go
@@ -44,7 +44,7 @@ func (d *DockerClient) PullImage(ctx context.Context, imageName string, reg *dto
 
 	responseBody, err := d.apiClient.ImagePull(ctx, imageName, image.PullOptions{
 		RegistryAuth: getRegistryAuth(reg),
-		Platform:     "linux/amd64",
+		Platform:     sandboxImagePlatform(),
 	})
 	if err != nil {
 		return nil, err

--- a/apps/runner/pkg/docker/platform.go
+++ b/apps/runner/pkg/docker/platform.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Daytona Platforms Inc.
+// Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: AGPL-3.0
 
 package docker
@@ -103,10 +103,6 @@ func getSandboxContainerArchs() []string {
 func sandboxImagePlatform() string {
 	platform := getSandboxPlatform()
 	return fmt.Sprintf("%s/%s", platform.os, platform.architecture)
-}
-
-func (p sandboxPlatform) asRemotePlatform() (string, string) {
-	return p.os, p.architecture
 }
 
 func (p sandboxPlatform) String() string {

--- a/apps/runner/pkg/docker/platform.go
+++ b/apps/runner/pkg/docker/platform.go
@@ -1,0 +1,124 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package docker
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+)
+
+const (
+	runnerPlatformEnvVar         = "DAYTONA_RUNNER_PLATFORM"
+	defaultSandboxPlatform       = "linux/amd64"
+	nativeSandboxPlatformDefault = "native"
+)
+
+type sandboxPlatform struct {
+	os           string
+	architecture string
+}
+
+func getSandboxPlatform() sandboxPlatform {
+	return parseSandboxPlatform(os.Getenv(runnerPlatformEnvVar))
+}
+
+func parseSandboxPlatform(raw string) sandboxPlatform {
+	if strings.TrimSpace(raw) == "" {
+		return parseSandboxPlatform(defaultSandboxPlatform)
+	}
+
+	platform := strings.ToLower(strings.TrimSpace(raw))
+	if platform == nativeSandboxPlatformDefault {
+		return sandboxPlatform{
+			os:           "linux",
+			architecture: runtimeArchitecture(runtime.GOARCH),
+		}
+	}
+
+	if strings.HasPrefix(platform, "linux/") {
+		parts := strings.Split(platform, "/")
+		if len(parts) == 2 {
+			normalizedArch, ok := normalizeArchitecture(parts[1])
+			if !ok {
+				return parseSandboxPlatform(defaultSandboxPlatform)
+			}
+			return sandboxPlatform{
+				os:           parts[0],
+				architecture: normalizedArch,
+			}
+		}
+
+		return parseSandboxPlatform(defaultSandboxPlatform)
+	}
+
+	normalizedArch, ok := normalizeArchitecture(platform)
+	if !ok {
+		return parseSandboxPlatform(defaultSandboxPlatform)
+	}
+
+	// Keep backwards compatibility with arch-only inputs.
+	return sandboxPlatform{
+		os:           "linux",
+		architecture: normalizedArch,
+	}
+}
+
+func normalizeArchitecture(rawArch string) (string, bool) {
+	rawArch = strings.ToLower(strings.TrimSpace(rawArch))
+
+	switch strings.ToLower(strings.TrimSpace(rawArch)) {
+	case "x86_64", "x64":
+		return "amd64", true
+	case "aarch64":
+		return "arm64", true
+	case "amd64":
+		return "amd64", true
+	case "arm64":
+		return "arm64", true
+	default:
+		return rawArch, false
+	}
+}
+
+func runtimeArchitecture(runtimeArch string) string {
+	arch, _ := normalizeArchitecture(runtimeArch)
+	return arch
+}
+
+func getSandboxContainerArchs() []string {
+	platform := getSandboxPlatform()
+	switch platform.architecture {
+	case "arm64":
+		return []string{"arm64", "aarch64"}
+	case "amd64":
+		return []string{"amd64", "x86_64"}
+	default:
+		return []string{platform.architecture}
+	}
+}
+
+func sandboxImagePlatform() string {
+	platform := getSandboxPlatform()
+	return fmt.Sprintf("%s/%s", platform.os, platform.architecture)
+}
+
+func (p sandboxPlatform) asRemotePlatform() (string, string) {
+	return p.os, p.architecture
+}
+
+func (p sandboxPlatform) String() string {
+	return fmt.Sprintf("%s/%s", p.os, p.architecture)
+}
+
+func isImageArchSupported(imageArch string) bool {
+	normalizedImageArch := strings.ToLower(strings.TrimSpace(imageArch))
+	for _, supported := range getSandboxContainerArchs() {
+		if normalizedImageArch == supported {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/runner/pkg/docker/platform.go
+++ b/apps/runner/pkg/docker/platform.go
@@ -100,6 +100,13 @@ func getSandboxContainerArchs() []string {
 	}
 }
 
+func sandboxPlatformFromDockerPlatform(dockerPlatform string) sandboxPlatform {
+	if strings.TrimSpace(dockerPlatform) == "" {
+		return getSandboxPlatform()
+	}
+	return parseSandboxPlatform(dockerPlatform)
+}
+
 func sandboxImagePlatform() string {
 	platform := getSandboxPlatform()
 	return fmt.Sprintf("%s/%s", platform.os, platform.architecture)
@@ -110,9 +117,17 @@ func (p sandboxPlatform) String() string {
 }
 
 func isImageArchSupported(imageArch string) bool {
-	normalizedImageArch := strings.ToLower(strings.TrimSpace(imageArch))
+	normalizedImageArch, ok := normalizeArchitecture(imageArch)
+	if !ok {
+		normalizedImageArch = strings.ToLower(strings.TrimSpace(imageArch))
+	}
+
 	for _, supported := range getSandboxContainerArchs() {
-		if normalizedImageArch == supported {
+		normalizedSupported, ok := normalizeArchitecture(supported)
+		if !ok {
+			normalizedSupported = strings.ToLower(strings.TrimSpace(supported))
+		}
+		if normalizedImageArch == normalizedSupported {
 			return true
 		}
 	}

--- a/apps/runner/pkg/docker/platform_test.go
+++ b/apps/runner/pkg/docker/platform_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Daytona Platforms Inc.
+// Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: AGPL-3.0
 
 package docker

--- a/apps/runner/pkg/docker/platform_test.go
+++ b/apps/runner/pkg/docker/platform_test.go
@@ -20,7 +20,7 @@ func TestParseSandboxPlatformDefaultsToAmd64(t *testing.T) {
 func TestParseSandboxPlatformAllowsNative(t *testing.T) {
 	t.Setenv("DAYTONA_RUNNER_PLATFORM", "native")
 	platform := getSandboxPlatform()
-	expectPlatform := "linux/" + runtimeArchitecture(runtime.GOARCH)
+	expectPlatform := "linux/" + expectedRuntimeSandboxArchitecture()
 
 	if platform.String() != expectPlatform {
 		t.Fatalf("expected %s, got %s", expectPlatform, platform.String())
@@ -43,10 +43,45 @@ func TestParseSandboxPlatformAcceptsArm64(t *testing.T) {
 	}
 }
 
+func TestImageArchSupportedAcceptsAmd64Aliases(t *testing.T) {
+	t.Setenv("DAYTONA_RUNNER_PLATFORM", "amd64")
+
+	for _, imageArch := range []string{"amd64", "x86_64", "x64"} {
+		if got := isImageArchSupported(imageArch); !got {
+			t.Fatalf("expected %s image arch to be supported for amd64 platform", imageArch)
+		}
+	}
+}
+
+func TestSandboxPlatformFromDockerPlatformPrefersOriginalContainerPlatform(t *testing.T) {
+	t.Setenv("DAYTONA_RUNNER_PLATFORM", "arm64")
+
+	platform := sandboxPlatformFromDockerPlatform("linux/amd64")
+	if platform.String() != "linux/amd64" {
+		t.Fatalf("expected original container platform linux/amd64, got %s", platform.String())
+	}
+
+	fallback := sandboxPlatformFromDockerPlatform("")
+	if fallback.String() != "linux/arm64" {
+		t.Fatalf("expected configured fallback linux/arm64, got %s", fallback.String())
+	}
+}
+
 func TestParseSandboxPlatformFallbackForInvalidInput(t *testing.T) {
 	t.Setenv("DAYTONA_RUNNER_PLATFORM", "not-a-platform")
 	platform := getSandboxPlatform()
 	if platform.String() != "linux/amd64" {
 		t.Fatalf("expected linux/amd64, got %s", platform.String())
+	}
+}
+
+func expectedRuntimeSandboxArchitecture() string {
+	switch runtime.GOARCH {
+	case "amd64", "x86_64", "x64":
+		return "amd64"
+	case "arm64", "aarch64":
+		return "arm64"
+	default:
+		return runtime.GOARCH
 	}
 }

--- a/apps/runner/pkg/docker/platform_test.go
+++ b/apps/runner/pkg/docker/platform_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package docker
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestParseSandboxPlatformDefaultsToAmd64(t *testing.T) {
+	t.Setenv("DAYTONA_RUNNER_PLATFORM", "")
+
+	platform := getSandboxPlatform()
+	if platform.String() != "linux/amd64" {
+		t.Fatalf("expected linux/amd64, got %s", platform.String())
+	}
+}
+
+func TestParseSandboxPlatformAllowsNative(t *testing.T) {
+	t.Setenv("DAYTONA_RUNNER_PLATFORM", "native")
+	platform := getSandboxPlatform()
+	expectPlatform := "linux/" + runtimeArchitecture(runtime.GOARCH)
+
+	if platform.String() != expectPlatform {
+		t.Fatalf("expected %s, got %s", expectPlatform, platform.String())
+	}
+}
+
+func TestParseSandboxPlatformAcceptsArm64(t *testing.T) {
+	t.Setenv("DAYTONA_RUNNER_PLATFORM", "arm64")
+	platform := getSandboxPlatform()
+	if platform.String() != "linux/arm64" {
+		t.Fatalf("expected linux/arm64, got %s", platform.String())
+	}
+
+	if got := isImageArchSupported("aarch64"); !got {
+		t.Fatalf("expected aarch64 image arch to be supported for configured platform %s", platform.String())
+	}
+
+	if got := isImageArchSupported("amd64"); got {
+		t.Fatalf("expected amd64 image arch not to be supported for configured platform %s", platform.String())
+	}
+}
+
+func TestParseSandboxPlatformFallbackForInvalidInput(t *testing.T) {
+	t.Setenv("DAYTONA_RUNNER_PLATFORM", "not-a-platform")
+	platform := getSandboxPlatform()
+	if platform.String() != "linux/amd64" {
+		t.Fatalf("expected linux/amd64, got %s", platform.String())
+	}
+}

--- a/apps/runner/pkg/docker/registry_manifest.go
+++ b/apps/runner/pkg/docker/registry_manifest.go
@@ -26,7 +26,13 @@ func getImageSizeFromRegistry(ctx context.Context, imageName string, registry *d
 
 	opts := []remote.Option{
 		remote.WithContext(ctx),
-		remote.WithPlatform(v1.Platform{OS: "linux", Architecture: "amd64"}),
+		remote.WithPlatform(func() v1.Platform {
+			platform := getSandboxPlatform()
+			return v1.Platform{
+				OS:           platform.os,
+				Architecture: platform.architecture,
+			}
+		}()),
 	}
 
 	if registry != nil && registry.HasAuth() {

--- a/apps/runner/pkg/docker/resize.go
+++ b/apps/runner/pkg/docker/resize.go
@@ -133,14 +133,16 @@ func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string
 		utils.DEFAULT_BASE_DELAY,
 		utils.DEFAULT_MAX_DELAY,
 		func() error {
+			platform := getSandboxPlatform()
+
 			_, createErr := d.apiClient.ContainerCreate(
 				ctx,
 				originalContainer.Config,
 				newHostConfig,
 				nil,
 				&v1.Platform{
-					Architecture: "amd64",
-					OS:           "linux",
+					Architecture: platform.architecture,
+					OS:           platform.os,
 				},
 				sandboxId,
 			)

--- a/apps/runner/pkg/docker/resize.go
+++ b/apps/runner/pkg/docker/resize.go
@@ -126,6 +126,7 @@ func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string
 		d.logger.DebugContext(ctx, "Setting memory", "gigabytes", memory)
 	}
 
+	platform := sandboxPlatformFromDockerPlatform(originalContainer.Platform)
 	err = utils.RetryWithExponentialBackoff(
 		ctx,
 		fmt.Sprintf("create sandbox %s", sandboxId),
@@ -133,8 +134,6 @@ func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string
 		utils.DEFAULT_BASE_DELAY,
 		utils.DEFAULT_MAX_DELAY,
 		func() error {
-			platform := getSandboxPlatform()
-
 			_, createErr := d.apiClient.ContainerCreate(
 				ctx,
 				originalContainer.Config,


### PR DESCRIPTION
## Description

Historically, the Docker provider runner in Daytona hardcoded `linux/amd64` and `amd64` when building, pulling, and creating sandbox containers. On native ARM64 hosts (such as Apple Silicon Mac machines running Docker Desktop), this causes slow emulation or cross-architecture conflicts.

This PR introduces dynamic sandbox platform resolution by checking the `DAYTONA_RUNNER_PLATFORM` environment variable:
- If set to `native`, it dynamically queries the host's architecture (e.g., `arm64`) to configure sandbox builds, image pulls, container creation, and disk resizes.
- If unset or invalid, it gracefully falls back to `linux/amd64` for backward compatibility.

A new `platform.go` helper has been added under `apps/runner/pkg/docker/` to manage this platform resolution, along with `platform_test.go` verifying the fallback, native, and override behaviors.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #4931

## Screenshots

N/A (Backend runner changes)

## Notes

All unit tests in `libs/computer-use/...` and compiling validations for the target platform have been verified and passed successfully on `darwin/arm64`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows native sandbox image platform selection for the Docker runner via `DAYTONA_RUNNER_PLATFORM`, improving performance on ARM64 hosts while defaulting to `linux/amd64`. Addresses Linear issue DAYTONA-4931 by letting sandboxes run natively on Apple Silicon and other ARM64 machines.

- **New Features**
  - Resolve sandbox platform from `DAYTONA_RUNNER_PLATFORM` (`native`, `linux/<arch>`, or arch-only like `arm64`; invalid values fall back to `linux/amd64`) in `apps/runner/pkg/docker/platform.go`.
  - Apply the resolved platform to image build/pull, container creation, and registry manifest lookups; during disk resize, preserve the container’s original platform when present, otherwise use the configured/default platform (`apps/runner/pkg/docker`).
  - Validate image architecture against the selected platform with alias support (`x86_64`/`x64` → `amd64`, `aarch64` → `arm64`), with clearer errors and tests in `apps/runner/pkg/docker/platform_test.go`.

<sup>Written for commit eeeac3d65a63ccd6f24a6a56b1674235af3e9d8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

