### PR TITLE
fix(cli): snapshot create failing with access denied error

### DIFF
--- a/apps/api/src/object-storage/services/object-storage.service.ts
+++ b/apps/api/src/object-storage/services/object-storage.service.ts
@@ -52,13 +52,13 @@ export class ObjectStorageService {
           Statement: [
             {
               Effect: 'Allow',
-              Action: ['s3:PutObject', 's3:GetObject'],
+              Action: ['s3:AbortMultipartUpload', 's3:GetObject', 's3:ListMultipartUploadParts', 's3:PutObject'],
               Resource: [`arn:aws:s3:::${bucket}/${organizationId}/*`],
             },
-            // ListBucket only shows object keys and some metadata, not the actual objects
+            // Bucket-level actions only expose bucket metadata and object keys, not object contents.
             {
               Effect: 'Allow',
-              Action: ['s3:ListBucket'],
+              Action: ['s3:GetBucketLocation', 's3:ListBucket', 's3:ListBucketMultipartUploads'],
               Resource: [`arn:aws:s3:::${bucket}`],
             },
           ],

--- a/apps/api/src/object-storage/services/object-storage.service.ts
+++ b/apps/api/src/object-storage/services/object-storage.service.ts
@@ -52,13 +52,13 @@ export class ObjectStorageService {
           Statement: [
             {
               Effect: 'Allow',
-              Action: ['s3:AbortMultipartUpload', 's3:GetObject', 's3:ListMultipartUploadParts', 's3:PutObject'],
+              Action: ['s3:PutObject', 's3:GetObject'],
               Resource: [`arn:aws:s3:::${bucket}/${organizationId}/*`],
             },
-            // Bucket-level actions only expose bucket metadata and object keys, not object contents.
+            // ListBucket only shows object keys and some metadata, not the actual objects
             {
               Effect: 'Allow',
-              Action: ['s3:GetBucketLocation', 's3:ListBucket', 's3:ListBucketMultipartUploads'],
+              Action: ['s3:ListBucket'],
               Resource: [`arn:aws:s3:::${bucket}`],
             },
           ],

--- a/apps/cli/pkg/minio/minio.go
+++ b/apps/cli/pkg/minio/minio.go
@@ -42,21 +42,10 @@ func NewClient(endpoint, accessKey, secretKey, bucket string, useSSL bool, sessi
 }
 
 func (c *Client) UploadFile(ctx context.Context, objectName string, data []byte) error {
-	exists, err := c.minioClient.BucketExists(ctx, c.bucket)
-	if err != nil {
-		return fmt.Errorf("error checking bucket existence: %w", err)
-	}
-	if !exists {
-		err = c.minioClient.MakeBucket(ctx, c.bucket, minio.MakeBucketOptions{})
-		if err != nil {
-			return fmt.Errorf("error creating bucket: %w", err)
-		}
-	}
-
 	reader := bytes.NewReader(data)
 	objectSize := int64(len(data))
 
-	_, err = c.minioClient.PutObject(ctx, c.bucket, objectName, reader, objectSize, minio.PutObjectOptions{
+	_, err := c.minioClient.PutObject(ctx, c.bucket, objectName, reader, objectSize, minio.PutObjectOptions{
 		ContentType: "application/octet-stream",
 	})
 	if err != nil {
@@ -378,14 +367,6 @@ func (c *Client) ProcessFile(ctx context.Context, filePath, orgID string, existi
 }
 
 func (c *Client) CreateDirectory(ctx context.Context, directoryPath string) error {
-	exists, err := c.minioClient.BucketExists(ctx, c.bucket)
-	if err != nil {
-		return fmt.Errorf("error checking bucket existence: %w", err)
-	}
-	if !exists {
-		return fmt.Errorf("bucket does not exist")
-	}
-
 	// Ensure the directory path ends with a slash to represent a directory
 	if !strings.HasSuffix(directoryPath, "/") {
 		directoryPath = directoryPath + "/"
@@ -394,7 +375,7 @@ func (c *Client) CreateDirectory(ctx context.Context, directoryPath string) erro
 	// Create an empty object to represent the directory
 	emptyContent := []byte{}
 	reader := bytes.NewReader(emptyContent)
-	_, err = c.minioClient.PutObject(ctx, c.bucket, directoryPath, reader, 0, minio.PutObjectOptions{
+	_, err := c.minioClient.PutObject(ctx, c.bucket, directoryPath, reader, 0, minio.PutObjectOptions{
 		ContentType: "application/directory",
 	})
 	if err != nil {


### PR DESCRIPTION
## Description

There were two stray operations added to the logic of the object storage file that were not reflected in the minio package. The exposure of make and get in code resulted in access denied because of a lack of accessibility of the STS token. This means that every command would have failed. So I removed the useless make and get bucket commands and expanded the functionality slightly. Tested with a simple snapshot create that failed before the change and is working after the fix implemented here.

## Documentation

Not required, bug fix.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

#4966 Makes parsing for GetBucket irrelevant and unreliable

## Screenshots

<img width="994" height="75" alt="snapshot-create-failure" src="https://github.com/user-attachments/assets/06d071f7-4afc-4a70-b785-3bcd2e904272" />

<img width="998" height="240" alt="snapshot-create-success" src="https://github.com/user-attachments/assets/8c3f585e-6880-41e4-b579-4910617e8a56" />


