### PR TITLE
feat(cli): make the CLI agent-friendly for automation

### DIFF
--- a/apps/cli/apiclient/api_client.go
+++ b/apps/cli/apiclient/api_client.go
@@ -39,9 +39,10 @@ const DaytonaSourceHeader = "X-Daytona-Source"
 const API_VERSION_HEADER = "X-Daytona-Api-Version"
 
 func checkVersionsMismatch(res *http.Response) {
-	// If the CLI is running in a structured output mode (e.g. json/yaml),
-	// avoid printing human-readable warnings that could break consumers.
-	if internal.SuppressVersionMismatchWarning {
+	// If the CLI is running in a structured output mode (e.g. json/yaml) or
+	// with prompting disabled (--no-input), avoid printing human-readable
+	// warnings that could break consumers.
+	if internal.SuppressVersionMismatchWarning || internal.NoInput {
 		return
 	}
 

--- a/apps/cli/apiclient/error_handler.go
+++ b/apps/cli/apiclient/error_handler.go
@@ -5,10 +5,11 @@ package apiclient
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 )
 
 type ApiErrorResponse struct {
@@ -18,7 +19,10 @@ type ApiErrorResponse struct {
 
 func HandleErrorResponse(res *http.Response, requestErr error) error {
 	if res == nil {
-		return requestErr
+		if requestErr == nil {
+			return nil
+		}
+		return clierr.New(clierr.CategoryNetwork, requestErr.Error())
 	}
 
 	defer res.Body.Close()
@@ -58,13 +62,7 @@ func HandleErrorResponse(res *http.Response, requestErr error) error {
 		}
 	}
 
-	if res.StatusCode == http.StatusUnauthorized {
-		errMessage += " - run 'daytona login' to reauthenticate"
-	}
-
-	if res.StatusCode == http.StatusForbidden {
-		errMessage += " - check that your API key has sufficient permissions for this action"
-	}
-
-	return errors.New(errMessage)
+	// FromHTTPStatus attaches the 401/403 remediation hints; Error()
+	// re-appends them so the rendered text matches the previous output.
+	return clierr.FromHTTPStatus(res.StatusCode, errMessage)
 }

--- a/apps/cli/apiclient/error_handler_test.go
+++ b/apps/cli/apiclient/error_handler_test.go
@@ -4,12 +4,14 @@
 package apiclient_test
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/daytonaio/daytona/cli/apiclient"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 )
 
 func response(statusCode int, body string) *http.Response {
@@ -115,10 +117,17 @@ func TestHandleErrorResponse_UnchangedBehavior(t *testing.T) {
 		}
 	})
 
-	t.Run("nil response returns the original request error", func(t *testing.T) {
+	t.Run("nil response returns a network clierr preserving the request error message", func(t *testing.T) {
 		err := apiclient.HandleErrorResponse(nil, io.ErrUnexpectedEOF)
-		if err != io.ErrUnexpectedEOF {
-			t.Errorf("expected original error, got: %v", err)
+		var cliErr *clierr.Error
+		if !errors.As(err, &cliErr) {
+			t.Fatalf("expected *clierr.Error, got %T: %v", err, err)
+		}
+		if cliErr.Category != clierr.CategoryNetwork {
+			t.Errorf("expected category %q, got %q", clierr.CategoryNetwork, cliErr.Category)
+		}
+		if cliErr.Message != io.ErrUnexpectedEOF.Error() {
+			t.Errorf("expected message %q, got %q", io.ErrUnexpectedEOF.Error(), cliErr.Message)
 		}
 	})
 

--- a/apps/cli/cmd/api/api.go
+++ b/apps/cli/cmd/api/api.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
+	"github.com/daytonaio/daytona/cli/auth"
 	"github.com/daytonaio/daytona/cli/config"
 	"github.com/daytonaio/daytona/cli/internal/clierr"
 	"github.com/spf13/cobra"
@@ -48,10 +49,13 @@ PATH is resolved against the active profile's API URL and the request is authent
 			return err
 		}
 
-		// GetApiClient validates the profile and refreshes the OAuth token
-		// when needed; the raw request below is then built from the
-		// (possibly refreshed) active profile.
-		if _, err := apiclient_cli.GetApiClient(nil, nil); err != nil {
+		// Refresh the OAuth token up front: GetApiClient only triggers a
+		// refresh once a client instance is already cached, so a fresh
+		// process would build the raw request below with an expired token.
+		// GetApiClient is dropped entirely — its only other effect here was
+		// profile validation, which GetConfig/GetActiveProfile below already
+		// perform (and RefreshTokenIfNeeded re-checks the credentials).
+		if err := auth.RefreshTokenIfNeeded(cmd.Context()); err != nil {
 			return err
 		}
 

--- a/apps/cli/cmd/api/api.go
+++ b/apps/cli/cmd/api/api.go
@@ -37,7 +37,15 @@ PATH is resolved against the active profile's API URL and the request is authent
   daytona api /sandbox/my-sandbox -X DELETE
   daytona api /snapshots -X POST --input snapshot.json
   cat body.json | daytona api /sandbox -X POST --input -`,
-	Args: cobra.ExactArgs(1),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return clierr.New(clierr.CategoryUsage, "missing required argument: PATH")
+		}
+		if len(args) > 1 {
+			return clierr.Newf(clierr.CategoryUsage, "accepts 1 argument, received %d", len(args))
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		method, err := normalizeMethod(apiMethodFlag)
 		if err != nil {

--- a/apps/cli/cmd/api/api.go
+++ b/apps/cli/cmd/api/api.go
@@ -1,0 +1,196 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+// Package api implements 'daytona api', an escape hatch for making raw
+// authenticated requests to the Daytona API. It is its own package because
+// package cmd cannot import config (config imports cmd for autocompletion
+// setup, which would create an import cycle).
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
+	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+	"github.com/spf13/cobra"
+)
+
+var (
+	apiMethodFlag string
+	apiInputFlag  string
+)
+
+var ApiCmd = &cobra.Command{
+	Use:   "api PATH",
+	Short: "Make an authenticated request to the Daytona API",
+	Long: `Make an authenticated HTTP request to the Daytona API and print the raw response body to stdout.
+
+PATH is resolved against the active profile's API URL and the request is authenticated with the active profile's credentials. Responses with status 400 or above still print the body, then exit non-zero.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		method, err := normalizeMethod(apiMethodFlag)
+		if err != nil {
+			return err
+		}
+
+		body, hasBody, err := resolveBody(method, apiInputFlag, os.Stdin)
+		if err != nil {
+			return err
+		}
+
+		// GetApiClient validates the profile and refreshes the OAuth token
+		// when needed; the raw request below is then built from the
+		// (possibly refreshed) active profile.
+		if _, err := apiclient_cli.GetApiClient(nil, nil); err != nil {
+			return err
+		}
+
+		c, err := config.GetConfig()
+		if err != nil {
+			return err
+		}
+
+		activeProfile, err := c.GetActiveProfile()
+		if err != nil {
+			return err
+		}
+
+		var bodyReader io.Reader
+		if hasBody {
+			bodyReader = bytes.NewReader(body)
+		}
+
+		req, err := http.NewRequestWithContext(cmd.Context(), method, joinURL(activeProfile.Api.Url, args[0]), bodyReader)
+		if err != nil {
+			return clierr.New(clierr.CategoryUsage, err.Error())
+		}
+
+		if activeProfile.Api.Key != nil {
+			req.Header.Set("Authorization", "Bearer "+*activeProfile.Api.Key)
+		} else if activeProfile.Api.Token != nil {
+			req.Header.Set("Authorization", "Bearer "+activeProfile.Api.Token.AccessToken)
+			if activeProfile.ActiveOrganizationId != nil {
+				req.Header.Set("X-Daytona-Organization-ID", *activeProfile.ActiveOrganizationId)
+			}
+		}
+		req.Header.Set(apiclient_cli.DaytonaSourceHeader, "cli")
+		req.Header.Set("Accept", "application/json")
+		if hasBody {
+			req.Header.Set("Content-Type", "application/json")
+		}
+
+		resp, err := (&http.Client{}).Do(req)
+		if err != nil {
+			return clierr.New(clierr.CategoryNetwork, err.Error())
+		}
+		defer resp.Body.Close()
+
+		out := &trailingNewlineWriter{w: os.Stdout}
+		if _, err := io.Copy(out, resp.Body); err != nil {
+			return clierr.New(clierr.CategoryNetwork, err.Error())
+		}
+		if err := out.finish(); err != nil {
+			return err
+		}
+
+		if resp.StatusCode >= 400 {
+			return clierr.FromHTTPStatus(resp.StatusCode, fmt.Sprintf("HTTP %d %s", resp.StatusCode, http.StatusText(resp.StatusCode)))
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	ApiCmd.Flags().StringVarP(&apiMethodFlag, "method", "X", http.MethodGet, "HTTP method (GET, POST, PUT, PATCH, DELETE, HEAD)")
+	ApiCmd.Flags().StringVar(&apiInputFlag, "input", "", "Request body source: a file path or '-' for stdin (POST, PUT, and PATCH only)")
+}
+
+// joinURL resolves an API path against the profile base URL, tolerating a
+// trailing slash on the base and a leading slash on the path.
+func joinURL(base, path string) string {
+	return strings.TrimSuffix(base, "/") + "/" + strings.TrimPrefix(path, "/")
+}
+
+var apiAllowedMethods = []string{
+	http.MethodGet,
+	http.MethodPost,
+	http.MethodPut,
+	http.MethodPatch,
+	http.MethodDelete,
+	http.MethodHead,
+}
+
+// normalizeMethod uppercases the --method value and validates it against the
+// supported set.
+func normalizeMethod(method string) (string, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(method))
+	for _, m := range apiAllowedMethods {
+		if normalized == m {
+			return normalized, nil
+		}
+	}
+	return "", clierr.Newf(clierr.CategoryUsage, "invalid --method value %q: must be one of GET, POST, PUT, PATCH, DELETE, HEAD", method)
+}
+
+// resolveBody resolves the --input flag into the request body bytes. input is
+// a file path or "-" for stdin and is only valid for methods that carry a
+// body (POST, PUT, PATCH).
+func resolveBody(method, input string, stdin io.Reader) (body []byte, hasBody bool, err error) {
+	if input == "" {
+		return nil, false, nil
+	}
+
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch:
+	default:
+		return nil, false, clierr.Newf(clierr.CategoryUsage, "--input cannot be used with %s: only POST, PUT, and PATCH requests carry a body", method)
+	}
+
+	if input == "-" {
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return nil, false, clierr.Newf(clierr.CategoryUsage, "failed to read request body from stdin: %s", err)
+		}
+		return data, true, nil
+	}
+
+	data, err := os.ReadFile(input)
+	if err != nil {
+		return nil, false, clierr.Newf(clierr.CategoryUsage, "failed to read request body from %s: %s", input, err)
+	}
+	return data, true, nil
+}
+
+// trailingNewlineWriter passes bytes through to w, tracking whether any
+// output was produced and whether it ended with a newline so finish can
+// terminate a partial last line.
+type trailingNewlineWriter struct {
+	w     io.Writer
+	wrote bool
+	last  byte
+}
+
+func (t *trailingNewlineWriter) Write(p []byte) (int, error) {
+	n, err := t.w.Write(p)
+	if n > 0 {
+		t.wrote = true
+		t.last = p[n-1]
+	}
+	return n, err
+}
+
+// finish writes a trailing newline when output was produced without one.
+func (t *trailingNewlineWriter) finish() error {
+	if !t.wrote || t.last == '\n' {
+		return nil
+	}
+	_, err := t.w.Write([]byte{'\n'})
+	return err
+}

--- a/apps/cli/cmd/api/api.go
+++ b/apps/cli/cmd/api/api.go
@@ -32,6 +32,10 @@ var ApiCmd = &cobra.Command{
 	Long: `Make an authenticated HTTP request to the Daytona API and print the raw response body to stdout.
 
 PATH is resolved against the active profile's API URL and the request is authenticated with the active profile's credentials. Responses with status 400 or above still print the body, then exit non-zero.`,
+	Example: `  daytona api /sandbox
+  daytona api /sandbox/my-sandbox -X DELETE
+  daytona api /snapshots -X POST --input snapshot.json
+  cat body.json | daytona api /sandbox -X POST --input -`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		method, err := normalizeMethod(apiMethodFlag)

--- a/apps/cli/cmd/api/api_test.go
+++ b/apps/cli/cmd/api/api_test.go
@@ -5,8 +5,11 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -165,5 +168,131 @@ func TestTrailingNewlineWriter(t *testing.T) {
 				t.Errorf("output = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// apiTestEnv points the CLI at the given test server using API-key auth and
+// a sandboxed config dir. SHELL is cleared so the first GetConfig call does
+// not try to install shell autocompletion into the real home directory.
+func apiTestEnv(t *testing.T, serverURL string) {
+	t.Helper()
+	t.Setenv("DAYTONA_CONFIG_DIR", t.TempDir())
+	t.Setenv("DAYTONA_API_KEY", "test-api-key")
+	t.Setenv("DAYTONA_API_URL", serverURL)
+	t.Setenv("SHELL", "")
+}
+
+// runApiCmd invokes ApiCmd's RunE with the given flag values and path,
+// returning everything the command wrote to stdout alongside its error.
+func runApiCmd(t *testing.T, method, input, path string) (string, error) {
+	t.Helper()
+
+	prevMethod, prevInput := apiMethodFlag, apiInputFlag
+	t.Cleanup(func() { apiMethodFlag, apiInputFlag = prevMethod, prevInput })
+	apiMethodFlag, apiInputFlag = method, input
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	prevStdout := os.Stdout
+	os.Stdout = w
+	ApiCmd.SetContext(context.Background())
+	runErr := ApiCmd.RunE(ApiCmd, []string{path})
+	os.Stdout = prevStdout
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(out), runErr
+}
+
+func TestApiCmdKeyAuthRequestAndBodyRelay(t *testing.T) {
+	var gotAuth, gotOrg, gotSource, gotAccept string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sandbox", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotOrg = r.Header.Get("X-Daytona-Organization-ID")
+		gotSource = r.Header.Get("X-Daytona-Source")
+		gotAccept = r.Header.Get("Accept")
+		// Deliberately no trailing newline: the command must append one.
+		if _, err := w.Write([]byte(`{"items":[]}`)); err != nil {
+			t.Error(err)
+		}
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	apiTestEnv(t, server.URL)
+
+	out, err := runApiCmd(t, http.MethodGet, "", "/sandbox")
+	if err != nil {
+		t.Fatalf("RunE returned unexpected error: %v", err)
+	}
+
+	if gotAuth != "Bearer test-api-key" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer test-api-key")
+	}
+	if gotOrg != "" {
+		t.Errorf("X-Daytona-Organization-ID = %q, want absent for key auth", gotOrg)
+	}
+	if gotSource != "cli" {
+		t.Errorf("X-Daytona-Source = %q, want %q", gotSource, "cli")
+	}
+	if gotAccept != "application/json" {
+		t.Errorf("Accept = %q, want %q", gotAccept, "application/json")
+	}
+	if out != "{\"items\":[]}\n" {
+		t.Errorf("stdout = %q, want body relayed with trailing newline", out)
+	}
+}
+
+func TestApiCmdNotFoundPrintsBodyAndFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sandbox/missing", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		if _, err := w.Write([]byte(`{"message":"sandbox not found"}`)); err != nil {
+			t.Error(err)
+		}
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	apiTestEnv(t, server.URL)
+
+	out, err := runApiCmd(t, http.MethodGet, "", "/sandbox/missing")
+
+	if out != "{\"message\":\"sandbox not found\"}\n" {
+		t.Errorf("stdout = %q, want error body relayed with trailing newline", out)
+	}
+	var cliErr *clierr.Error
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *clierr.Error, got %T: %v", err, err)
+	}
+	if cliErr.Category != clierr.CategoryNotFound {
+		t.Errorf("category = %q, want %q", cliErr.Category, clierr.CategoryNotFound)
+	}
+	if !strings.Contains(cliErr.Message, "HTTP 404") {
+		t.Errorf("message = %q, want it to mention HTTP 404", cliErr.Message)
+	}
+}
+
+func TestApiCmdInputWithGetRejected(t *testing.T) {
+	// Must fail during flag validation, before any request is made.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("unexpected request to API server")
+	}))
+	t.Cleanup(server.Close)
+	apiTestEnv(t, server.URL)
+
+	out, err := runApiCmd(t, http.MethodGet, "-", "/sandbox")
+	assertUsageError(t, err)
+	if out != "" {
+		t.Errorf("stdout = %q, want empty", out)
 	}
 }

--- a/apps/cli/cmd/api/api_test.go
+++ b/apps/cli/cmd/api/api_test.go
@@ -1,0 +1,169 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package api
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+)
+
+func assertUsageError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var cliErr *clierr.Error
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *clierr.Error, got %T: %v", err, err)
+	}
+	if cliErr.Category != clierr.CategoryUsage {
+		t.Errorf("expected category %q, got %q", clierr.CategoryUsage, cliErr.Category)
+	}
+}
+
+func TestJoinURL(t *testing.T) {
+	tests := []struct {
+		name string
+		base string
+		path string
+		want string
+	}{
+		{name: "no slashes", base: "https://api.daytona.io", path: "sandbox", want: "https://api.daytona.io/sandbox"},
+		{name: "trailing slash on base", base: "https://api.daytona.io/", path: "sandbox", want: "https://api.daytona.io/sandbox"},
+		{name: "leading slash on path", base: "https://api.daytona.io", path: "/sandbox", want: "https://api.daytona.io/sandbox"},
+		{name: "both slashes", base: "https://api.daytona.io/", path: "/sandbox", want: "https://api.daytona.io/sandbox"},
+		{name: "base with path segment", base: "https://app.daytona.io/api", path: "/sandbox/abc", want: "https://app.daytona.io/api/sandbox/abc"},
+		{name: "path with query string", base: "https://api.daytona.io", path: "/sandbox?verbose=true", want: "https://api.daytona.io/sandbox?verbose=true"},
+		{name: "empty path", base: "https://api.daytona.io", path: "", want: "https://api.daytona.io/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := joinURL(tt.base, tt.path); got != tt.want {
+				t.Errorf("joinURL(%q, %q) = %q, want %q", tt.base, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeMethod(t *testing.T) {
+	tests := []struct {
+		name    string
+		method  string
+		want    string
+		wantErr bool
+	}{
+		{name: "uppercase passthrough", method: "GET", want: "GET"},
+		{name: "lowercase normalized", method: "post", want: "POST"},
+		{name: "mixed case normalized", method: "DeLeTe", want: "DELETE"},
+		{name: "surrounding whitespace trimmed", method: " put ", want: "PUT"},
+		{name: "patch allowed", method: "patch", want: "PATCH"},
+		{name: "head allowed", method: "HEAD", want: "HEAD"},
+		{name: "unsupported method rejected", method: "OPTIONS", wantErr: true},
+		{name: "garbage rejected", method: "FOO", wantErr: true},
+		{name: "empty rejected", method: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeMethod(tt.method)
+			if tt.wantErr {
+				assertUsageError(t, err)
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeMethod(%q) unexpected error: %v", tt.method, err)
+			}
+			if got != tt.want {
+				t.Errorf("normalizeMethod(%q) = %q, want %q", tt.method, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveBody(t *testing.T) {
+	bodyFile := filepath.Join(t.TempDir(), "body.json")
+	if err := os.WriteFile(bodyFile, []byte(`{"name":"my-sandbox"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		method   string
+		input    string
+		stdin    string
+		want     string
+		wantBody bool
+		wantErr  bool
+	}{
+		{name: "no input means no body", method: http.MethodGet, input: ""},
+		{name: "no input with POST means no body", method: http.MethodPost, input: ""},
+		{name: "stdin body for POST", method: http.MethodPost, input: "-", stdin: `{"a":1}`, want: `{"a":1}`, wantBody: true},
+		{name: "file body for PUT", method: http.MethodPut, input: bodyFile, want: `{"name":"my-sandbox"}`, wantBody: true},
+		{name: "file body for PATCH", method: http.MethodPatch, input: bodyFile, want: `{"name":"my-sandbox"}`, wantBody: true},
+		{name: "empty stdin body still counts as body", method: http.MethodPost, input: "-", stdin: "", want: "", wantBody: true},
+		{name: "input with GET rejected", method: http.MethodGet, input: bodyFile, wantErr: true},
+		{name: "stdin input with GET rejected", method: http.MethodGet, input: "-", wantErr: true},
+		{name: "input with HEAD rejected", method: http.MethodHead, input: bodyFile, wantErr: true},
+		{name: "input with DELETE rejected", method: http.MethodDelete, input: "-", wantErr: true},
+		{name: "missing file errors", method: http.MethodPost, input: filepath.Join(t.TempDir(), "missing.json"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, hasBody, err := resolveBody(tt.method, tt.input, strings.NewReader(tt.stdin))
+			if tt.wantErr {
+				assertUsageError(t, err)
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveBody(%q, %q) unexpected error: %v", tt.method, tt.input, err)
+			}
+			if hasBody != tt.wantBody {
+				t.Errorf("resolveBody(%q, %q) hasBody = %v, want %v", tt.method, tt.input, hasBody, tt.wantBody)
+			}
+			if string(body) != tt.want {
+				t.Errorf("resolveBody(%q, %q) body = %q, want %q", tt.method, tt.input, body, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrailingNewlineWriter(t *testing.T) {
+	tests := []struct {
+		name   string
+		writes []string
+		want   string
+	}{
+		{name: "no output stays empty", writes: nil, want: ""},
+		{name: "missing newline appended", writes: []string{`{"ok":true}`}, want: "{\"ok\":true}\n"},
+		{name: "existing newline kept", writes: []string{"line\n"}, want: "line\n"},
+		{name: "tracks last chunk", writes: []string{"a\n", "b"}, want: "a\nb\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := &trailingNewlineWriter{w: &buf}
+			for _, chunk := range tt.writes {
+				if _, err := w.Write([]byte(chunk)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := w.finish(); err != nil {
+				t.Fatal(err)
+			}
+			if got := buf.String(); got != tt.want {
+				t.Errorf("output = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/cli/cmd/auth/login.go
+++ b/apps/cli/cmd/auth/login.go
@@ -23,8 +23,11 @@ import (
 )
 
 var LoginCmd = &cobra.Command{
-	Use:     "login",
-	Short:   "Log in to Daytona",
+	Use:   "login",
+	Short: "Log in to Daytona",
+	Example: `  daytona login
+  daytona login --api-key $DAYTONA_API_KEY
+  daytona login --api-key-stdin < ~/.daytona-api-key`,
 	Args:    cobra.NoArgs,
 	GroupID: internal.USER_GROUP,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/auth/login.go
+++ b/apps/cli/cmd/auth/login.go
@@ -6,12 +6,16 @@ package auth
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/daytonaio/daytona/cli/auth"
 	"github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/config"
 	"github.com/daytonaio/daytona/cli/internal"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	view_common "github.com/daytonaio/daytona/cli/views/common"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -28,6 +32,35 @@ var LoginCmd = &cobra.Command{
 
 		if apiKeyFlag != "" {
 			return updateProfileWithLogin(nil, &apiKeyFlag)
+		}
+
+		if loginApiKeyStdinFlag {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("error reading API key from stdin: %w", err)
+			}
+			key := strings.TrimSpace(string(data))
+			if key == "" {
+				return clierr.New(clierr.CategoryUsage, "empty API key on stdin")
+			}
+			return updateProfileWithLogin(nil, &key)
+		}
+
+		if loginApiKeyFileFlag != "" {
+			data, err := os.ReadFile(loginApiKeyFileFlag)
+			if err != nil {
+				return fmt.Errorf("error reading API key file: %w", err)
+			}
+			key := strings.TrimSpace(string(data))
+			if key == "" {
+				return clierr.Newf(clierr.CategoryUsage, "empty API key in file %s", loginApiKeyFileFlag)
+			}
+			return updateProfileWithLogin(nil, &key)
+		}
+
+		if !internal.Interactive() {
+			return clierr.New(clierr.CategoryUsage, "cannot prompt for login method in non-interactive mode").
+				WithHint("provide --api-key, --api-key-stdin, or --api-key-file (or set DAYTONA_API_KEY and DAYTONA_API_URL)")
 		}
 
 		items := []view_common.SelectItem{
@@ -72,11 +105,16 @@ var LoginCmd = &cobra.Command{
 }
 
 var (
-	apiKeyFlag string
+	apiKeyFlag           string
+	loginApiKeyStdinFlag bool
+	loginApiKeyFileFlag  string
 )
 
 func init() {
 	LoginCmd.Flags().StringVar(&apiKeyFlag, "api-key", "", "API key to use for authentication")
+	LoginCmd.Flags().BoolVar(&loginApiKeyStdinFlag, "api-key-stdin", false, "Read the API key from stdin")
+	LoginCmd.Flags().StringVar(&loginApiKeyFileFlag, "api-key-file", "", "Read the API key from a file")
+	LoginCmd.MarkFlagsMutuallyExclusive("api-key", "api-key-stdin", "api-key-file")
 }
 
 func updateProfileWithLogin(tokenConfig *config.Token, apiKey *string) error {

--- a/apps/cli/cmd/auth/login.go
+++ b/apps/cli/cmd/auth/login.go
@@ -33,31 +33,11 @@ var LoginCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
-		if apiKeyFlag != "" {
-			return updateProfileWithLogin(nil, &apiKeyFlag)
+		key, err := resolveAPIKey(apiKeyFlag, loginApiKeyStdinFlag, loginApiKeyFileFlag, os.Stdin)
+		if err != nil {
+			return err
 		}
-
-		if loginApiKeyStdinFlag {
-			data, err := io.ReadAll(os.Stdin)
-			if err != nil {
-				return fmt.Errorf("error reading API key from stdin: %w", err)
-			}
-			key := strings.TrimSpace(string(data))
-			if key == "" {
-				return clierr.New(clierr.CategoryUsage, "empty API key on stdin")
-			}
-			return updateProfileWithLogin(nil, &key)
-		}
-
-		if loginApiKeyFileFlag != "" {
-			data, err := os.ReadFile(loginApiKeyFileFlag)
-			if err != nil {
-				return fmt.Errorf("error reading API key file: %w", err)
-			}
-			key := strings.TrimSpace(string(data))
-			if key == "" {
-				return clierr.Newf(clierr.CategoryUsage, "empty API key in file %s", loginApiKeyFileFlag)
-			}
+		if key != "" {
 			return updateProfileWithLogin(nil, &key)
 		}
 
@@ -118,6 +98,42 @@ func init() {
 	LoginCmd.Flags().BoolVar(&loginApiKeyStdinFlag, "api-key-stdin", false, "Read the API key from stdin")
 	LoginCmd.Flags().StringVar(&loginApiKeyFileFlag, "api-key-file", "", "Read the API key from a file")
 	LoginCmd.MarkFlagsMutuallyExclusive("api-key", "api-key-stdin", "api-key-file")
+}
+
+// resolveAPIKey resolves the API key from the non-interactive sources, in
+// precedence order: --api-key value, stdin (--api-key-stdin), then a file
+// (--api-key-file). It returns "" with a nil error when no source was given,
+// in which case the caller falls back to the interactive flow.
+func resolveAPIKey(flagVal string, stdinFlag bool, fileFlag string, stdin io.Reader) (string, error) {
+	if flagVal != "" {
+		return flagVal, nil
+	}
+
+	if stdinFlag {
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return "", fmt.Errorf("error reading API key from stdin: %w", err)
+		}
+		key := strings.TrimSpace(string(data))
+		if key == "" {
+			return "", clierr.New(clierr.CategoryUsage, "empty API key on stdin")
+		}
+		return key, nil
+	}
+
+	if fileFlag != "" {
+		data, err := os.ReadFile(fileFlag)
+		if err != nil {
+			return "", fmt.Errorf("error reading API key file: %w", err)
+		}
+		key := strings.TrimSpace(string(data))
+		if key == "" {
+			return "", clierr.Newf(clierr.CategoryUsage, "empty API key in file %s", fileFlag)
+		}
+		return key, nil
+	}
+
+	return "", nil
 }
 
 func updateProfileWithLogin(tokenConfig *config.Token, apiKey *string) error {

--- a/apps/cli/cmd/auth/login_test.go
+++ b/apps/cli/cmd/auth/login_test.go
@@ -1,0 +1,68 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package auth
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+)
+
+func TestResolveAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "key")
+	if err := os.WriteFile(keyFile, []byte("  file-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	emptyFile := filepath.Join(dir, "empty")
+	if err := os.WriteFile(emptyFile, []byte(" \n\t"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name         string
+		flagVal      string
+		stdinFlag    bool
+		fileFlag     string
+		stdin        string
+		want         string
+		wantErr      bool
+		wantUsageErr bool
+	}{
+		{name: "flag wins over stdin and file", flagVal: "flag-key", stdinFlag: true, fileFlag: keyFile, stdin: "stdin-key", want: "flag-key"},
+		{name: "stdin key trimmed", stdinFlag: true, stdin: "  stdin-key \n", want: "stdin-key"},
+		{name: "file key trimmed", fileFlag: keyFile, want: "file-key"},
+		{name: "empty stdin is usage error", stdinFlag: true, stdin: " \n", wantErr: true, wantUsageErr: true},
+		{name: "empty file is usage error", fileFlag: emptyFile, wantErr: true, wantUsageErr: true},
+		{name: "missing file errors", fileFlag: filepath.Join(dir, "missing"), wantErr: true},
+		{name: "no source resolves to empty key", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveAPIKey(tt.flagVal, tt.stdinFlag, tt.fileFlag, strings.NewReader(tt.stdin))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				var cliErr *clierr.Error
+				isUsage := errors.As(err, &cliErr) && cliErr.Category == clierr.CategoryUsage
+				if isUsage != tt.wantUsageErr {
+					t.Errorf("usage-category clierr = %v, want %v (err: %v)", isUsage, tt.wantUsageErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveAPIKey = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/cli/cmd/common/followlogs.go
+++ b/apps/cli/cmd/common/followlogs.go
@@ -1,0 +1,75 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common
+
+import (
+	"context"
+	"time"
+)
+
+// FollowBuildLogs streams build logs to stdout until pollState reports that
+// the resource reached a terminal state. pollState returns done=true once the
+// resource is terminal; an error returned alongside done=true is the terminal
+// failure surfaced to the caller after the stream is drained, while an error
+// with done=false aborts immediately (the state poll itself failed).
+//
+// When the resource is already terminal before streaming begins, a follow
+// stream would race against the cancellation grace period and could truncate
+// long output. In that case the complete log history is fetched with a single
+// plain (non-follow) request and the terminal-state error semantics still
+// apply.
+func FollowBuildLogs(ctx context.Context, params ReadLogParams, pollState func(context.Context) (done bool, failed error)) error {
+	done, failErr := pollState(ctx)
+	if !done && failErr != nil {
+		return failErr
+	}
+	if done {
+		follow := false
+		params.Follow = &follow
+		err := ReadBuildLogs(ctx, params)
+		if failErr != nil {
+			return failErr
+		}
+		return err
+	}
+
+	follow := true
+	params.Follow = &follow
+
+	logsCtx, stopLogs := context.WithCancel(ctx)
+	defer stopLogs()
+
+	streamDone := make(chan error, 1)
+	go func() {
+		streamDone <- ReadBuildLogs(logsCtx, params)
+	}()
+
+	for {
+		select {
+		case err := <-streamDone:
+			// A nil channel blocks forever, so after the stream ends the loop
+			// keeps polling the resource state until it turns terminal.
+			streamDone = nil
+			if err != nil {
+				return err
+			}
+		case <-time.After(time.Second):
+		}
+
+		done, failErr := pollState(ctx)
+		if !done && failErr != nil {
+			return failErr
+		}
+		if done {
+			// Grace period so trailing log output is flushed before the
+			// stream is canceled.
+			time.Sleep(250 * time.Millisecond)
+			stopLogs()
+			if streamDone != nil {
+				<-streamDone
+			}
+			return failErr
+		}
+	}
+}

--- a/apps/cli/cmd/common/followlogs_test.go
+++ b/apps/cli/cmd/common/followlogs_test.go
@@ -1,0 +1,207 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+)
+
+// followLogsRecorder tracks the build-logs requests served by the test server.
+type followLogsRecorder struct {
+	mu      sync.Mutex
+	hits    int
+	follows []bool
+}
+
+func (r *followLogsRecorder) record(req *http.Request) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.hits++
+	r.follows = append(r.follows, req.URL.Query().Get("follow") == "true")
+}
+
+func (r *followLogsRecorder) snapshot() (int, []bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.hits, append([]bool(nil), r.follows...)
+}
+
+func followLogsTestServer(t *testing.T, body string, rec *followLogsRecorder) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/sandbox/sbx-1/build-logs" {
+			http.NotFound(w, r)
+			return
+		}
+		rec.record(r)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func followLogsTestParams(serverURL string) common.ReadLogParams {
+	key := "test-api-key"
+	follow := true
+	return common.ReadLogParams{
+		Id:           "sbx-1",
+		ServerUrl:    serverURL,
+		ServerApi:    config.ServerApi{Url: serverURL, Key: &key},
+		Follow:       &follow,
+		ResourceType: common.ResourceTypeSandbox,
+	}
+}
+
+// followLogsCaptureStdout redirects os.Stdout for the duration of fn and
+// returns everything written to it.
+func followLogsCaptureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	collected := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(r)
+		collected <- string(data)
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing stdout pipe: %v", err)
+	}
+	os.Stdout = orig
+	return <-collected
+}
+
+// TestFollowBuildLogsAlreadyTerminal is the regression test for follow mode
+// truncating output when the resource is already terminal at entry: the
+// complete log history must arrive via exactly one plain (non-follow) fetch,
+// and the terminal-state error semantics must still apply.
+func TestFollowBuildLogsAlreadyTerminal(t *testing.T) {
+	body := strings.Repeat("a long line of build output that must not be truncated\n", 200)
+
+	tests := []struct {
+		name        string
+		failErr     error
+		wantInError string
+	}{
+		{name: "terminal success", failErr: nil},
+		{name: "terminal failure", failErr: clierr.New(clierr.CategoryServer, "sandbox processing failed: boom"), wantInError: "boom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &followLogsRecorder{}
+			server := followLogsTestServer(t, body, rec)
+
+			polls := 0
+			var err error
+			out := followLogsCaptureStdout(t, func() {
+				err = common.FollowBuildLogs(context.Background(), followLogsTestParams(server.URL), func(context.Context) (bool, error) {
+					polls++
+					return true, tt.failErr
+				})
+			})
+
+			if tt.failErr == nil {
+				if err != nil {
+					t.Fatalf("FollowBuildLogs() error: %v", err)
+				}
+			} else {
+				if !clierr.HasCategory(err, clierr.CategoryServer) {
+					t.Fatalf("FollowBuildLogs() error = %v, want server-category clierr", err)
+				}
+				if !strings.Contains(err.Error(), tt.wantInError) {
+					t.Errorf("FollowBuildLogs() error = %q, want it to mention %q", err.Error(), tt.wantInError)
+				}
+			}
+			if out != body {
+				t.Errorf("streamed %d bytes, want the complete %d-byte log output", len(out), len(body))
+			}
+			hits, follows := rec.snapshot()
+			if hits != 1 {
+				t.Errorf("build-logs requests = %d, want exactly 1", hits)
+			}
+			if len(follows) > 0 && follows[0] {
+				t.Error("already-terminal fetch used follow=true, want a plain fetch")
+			}
+			if polls != 1 {
+				t.Errorf("pollState calls = %d, want 1", polls)
+			}
+		})
+	}
+}
+
+func TestFollowBuildLogsPollErrorAborts(t *testing.T) {
+	rec := &followLogsRecorder{}
+	server := followLogsTestServer(t, "unused", rec)
+
+	pollErr := errors.New("poll failed")
+	var err error
+	out := followLogsCaptureStdout(t, func() {
+		err = common.FollowBuildLogs(context.Background(), followLogsTestParams(server.URL), func(context.Context) (bool, error) {
+			return false, pollErr
+		})
+	})
+
+	if !errors.Is(err, pollErr) {
+		t.Fatalf("FollowBuildLogs() error = %v, want %v", err, pollErr)
+	}
+	if out != "" {
+		t.Errorf("streamed output %q, want none", out)
+	}
+	if hits, _ := rec.snapshot(); hits != 0 {
+		t.Errorf("build-logs requests = %d, want 0", hits)
+	}
+}
+
+func TestFollowBuildLogsStreamsUntilTerminal(t *testing.T) {
+	body := "streaming build output\n"
+	rec := &followLogsRecorder{}
+	server := followLogsTestServer(t, body, rec)
+
+	polls := 0
+	var err error
+	out := followLogsCaptureStdout(t, func() {
+		err = common.FollowBuildLogs(context.Background(), followLogsTestParams(server.URL), func(context.Context) (bool, error) {
+			polls++
+			return polls > 1, nil
+		})
+	})
+
+	if err != nil {
+		t.Fatalf("FollowBuildLogs() error: %v", err)
+	}
+	if out != body {
+		t.Errorf("streamed output %q, want %q", out, body)
+	}
+	hits, follows := rec.snapshot()
+	if hits != 1 {
+		t.Fatalf("build-logs requests = %d, want 1", hits)
+	}
+	if !follows[0] {
+		t.Error("streaming request missing follow=true query")
+	}
+	if polls < 2 {
+		t.Errorf("pollState calls = %d, want at least 2", polls)
+	}
+}

--- a/apps/cli/cmd/common/format.go
+++ b/apps/cli/cmd/common/format.go
@@ -75,6 +75,10 @@ func (f YAMLFormatter) Format(data interface{}) (string, error) {
 }
 
 func (f *outputFormatter) Print() {
+	// No --format means no formatter; printing structured output is a no-op.
+	if f.formatter == nil {
+		return
+	}
 
 	formattedOutput, err := f.formatter.Format(f.data)
 	if err != nil {
@@ -105,14 +109,30 @@ func UnblockStdOut() {
 
 func RegisterFormatFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&FormatFlag, formatFlagName, formatFlagShortHand, FormatFlag, formatFlagDescription)
-	cmd.PreRunE = formatFlagPreRunE
+	chainFormatPreRunE(cmd)
 }
 
 // RegisterFormatFlagNoShorthand registers --format without the -f shorthand,
 // for commands where -f is already taken (e.g. --force, --dockerfile).
 func RegisterFormatFlagNoShorthand(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&FormatFlag, formatFlagName, FormatFlag, formatFlagDescription)
-	cmd.PreRunE = formatFlagPreRunE
+	chainFormatPreRunE(cmd)
+}
+
+// chainFormatPreRunE installs the --format validation as the command's
+// PreRunE, calling any pre-existing PreRunE after validation succeeds instead
+// of clobbering it.
+func chainFormatPreRunE(cmd *cobra.Command) {
+	original := cmd.PreRunE
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := formatFlagPreRunE(cmd, args); err != nil {
+			return err
+		}
+		if original != nil {
+			return original(cmd, args)
+		}
+		return nil
+	}
 }
 
 func formatFlagPreRunE(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/common/format.go
+++ b/apps/cli/cmd/common/format.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/daytonaio/daytona/cli/internal"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
@@ -77,7 +78,9 @@ func (f *outputFormatter) Print() {
 
 	formattedOutput, err := f.formatter.Format(f.data)
 	if err != nil {
-		fmt.Printf("Error formatting output: %v\n", err)
+		// Stdout is blocked while a structured format is active, so report
+		// the formatting failure on stderr.
+		fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -102,15 +105,28 @@ func UnblockStdOut() {
 
 func RegisterFormatFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&FormatFlag, formatFlagName, formatFlagShortHand, FormatFlag, formatFlagDescription)
-	cmd.PreRun = func(cmd *cobra.Command, args []string) {
-		if FormatFlag != "" {
-			BlockStdOut()
-			// When a structured output format is requested, suppress
-			// noisy warnings such as version mismatch so scripts
-			// consuming json/yaml aren't broken.
-			internal.SuppressVersionMismatchWarning = true
-		} else {
-			internal.SuppressVersionMismatchWarning = false
-		}
+	cmd.PreRunE = formatFlagPreRunE
+}
+
+// RegisterFormatFlagNoShorthand registers --format without the -f shorthand,
+// for commands where -f is already taken (e.g. --force, --dockerfile).
+func RegisterFormatFlagNoShorthand(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&FormatFlag, formatFlagName, FormatFlag, formatFlagDescription)
+	cmd.PreRunE = formatFlagPreRunE
+}
+
+func formatFlagPreRunE(cmd *cobra.Command, args []string) error {
+	switch FormatFlag {
+	case "":
+		internal.SuppressVersionMismatchWarning = false
+	case "json", "yaml":
+		BlockStdOut()
+		// When a structured output format is requested, suppress
+		// noisy warnings such as version mismatch so scripts
+		// consuming json/yaml aren't broken.
+		internal.SuppressVersionMismatchWarning = true
+	default:
+		return clierr.Newf(clierr.CategoryUsage, "invalid --format value %q: must be one of json, yaml", FormatFlag)
 	}
+	return nil
 }

--- a/apps/cli/cmd/common/format_test.go
+++ b/apps/cli/cmd/common/format_test.go
@@ -1,0 +1,93 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+	"github.com/spf13/cobra"
+)
+
+func TestFormatFlagPreRunEValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "empty value is accepted", value: "", wantErr: false},
+		{name: "json is accepted", value: "json", wantErr: false},
+		{name: "yaml is accepted", value: "yaml", wantErr: false},
+		{name: "xml is rejected", value: "xml", wantErr: true},
+		{name: "uppercase JSON is rejected", value: "JSON", wantErr: true},
+		{name: "whitespace value is rejected", value: " json", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prevFormat := common.FormatFlag
+			t.Cleanup(func() {
+				common.UnblockStdOut()
+				common.FormatFlag = prevFormat
+				internal.SuppressVersionMismatchWarning = false
+			})
+
+			cmd := &cobra.Command{Use: "test"}
+			common.RegisterFormatFlag(cmd)
+			if cmd.PreRunE == nil {
+				t.Fatal("RegisterFormatFlag did not set PreRunE")
+			}
+
+			common.FormatFlag = tt.value
+			err := cmd.PreRunE(cmd, nil)
+
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("PreRunE with format %q returned unexpected error: %v", tt.value, err)
+				}
+				return
+			}
+
+			var cliErr *clierr.Error
+			if !errors.As(err, &cliErr) {
+				t.Fatalf("PreRunE with format %q expected *clierr.Error, got %T: %v", tt.value, err, err)
+			}
+			if cliErr.Category != clierr.CategoryUsage {
+				t.Errorf("PreRunE with format %q category = %q, want %q", tt.value, cliErr.Category, clierr.CategoryUsage)
+			}
+		})
+	}
+}
+
+func TestRegisterFormatFlagShorthands(t *testing.T) {
+	tests := []struct {
+		name          string
+		register      func(*cobra.Command)
+		wantShorthand string
+	}{
+		{name: "RegisterFormatFlag keeps -f shorthand", register: common.RegisterFormatFlag, wantShorthand: "f"},
+		{name: "RegisterFormatFlagNoShorthand has no shorthand", register: common.RegisterFormatFlagNoShorthand, wantShorthand: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test"}
+			tt.register(cmd)
+
+			flag := cmd.Flags().Lookup("format")
+			if flag == nil {
+				t.Fatal("--format flag not registered")
+			}
+			if flag.Shorthand != tt.wantShorthand {
+				t.Errorf("--format shorthand = %q, want %q", flag.Shorthand, tt.wantShorthand)
+			}
+			if cmd.PreRunE == nil {
+				t.Error("PreRunE not set")
+			}
+		})
+	}
+}

--- a/apps/cli/cmd/common/format_test.go
+++ b/apps/cli/cmd/common/format_test.go
@@ -91,3 +91,77 @@ func TestRegisterFormatFlagShorthands(t *testing.T) {
 		})
 	}
 }
+
+func TestRegisterFormatFlagChainsPreRunE(t *testing.T) {
+	tests := []struct {
+		name            string
+		value           string
+		wantErr         bool
+		wantOriginalRun bool
+	}{
+		{name: "valid format runs original PreRunE after validation", value: "json", wantOriginalRun: true},
+		{name: "empty format runs original PreRunE", value: "", wantOriginalRun: true},
+		{name: "invalid format short-circuits original PreRunE", value: "xml", wantErr: true, wantOriginalRun: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prevFormat := common.FormatFlag
+			t.Cleanup(func() {
+				common.UnblockStdOut()
+				common.FormatFlag = prevFormat
+				internal.SuppressVersionMismatchWarning = false
+			})
+
+			originalRun := false
+			cmd := &cobra.Command{Use: "test"}
+			cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+				originalRun = true
+				return nil
+			}
+			common.RegisterFormatFlag(cmd)
+
+			common.FormatFlag = tt.value
+			err := cmd.PreRunE(cmd, nil)
+
+			if tt.wantErr && err == nil {
+				t.Error("PreRunE expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("PreRunE unexpected error: %v", err)
+			}
+			if originalRun != tt.wantOriginalRun {
+				t.Errorf("original PreRunE run = %v, want %v", originalRun, tt.wantOriginalRun)
+			}
+		})
+	}
+}
+
+func TestRegisterFormatFlagChainPropagatesOriginalError(t *testing.T) {
+	prevFormat := common.FormatFlag
+	t.Cleanup(func() {
+		common.UnblockStdOut()
+		common.FormatFlag = prevFormat
+		internal.SuppressVersionMismatchWarning = false
+	})
+
+	wantErr := errors.New("original failed")
+	cmd := &cobra.Command{Use: "test"}
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error { return wantErr }
+	common.RegisterFormatFlagNoShorthand(cmd)
+
+	common.FormatFlag = "json"
+	if err := cmd.PreRunE(cmd, nil); !errors.Is(err, wantErr) {
+		t.Errorf("PreRunE error = %v, want original error %v", err, wantErr)
+	}
+}
+
+func TestPrintWithoutFormatIsNoOp(t *testing.T) {
+	prevFormat := common.FormatFlag
+	t.Cleanup(func() { common.FormatFlag = prevFormat })
+
+	// With no --format value the formatter is nil; Print must return
+	// without panicking (and without touching stdout blocking state).
+	common.FormatFlag = ""
+	common.NewFormatter(struct{ Name string }{Name: "x"}).Print()
+}

--- a/apps/cli/cmd/common/logs.go
+++ b/apps/cli/cmd/common/logs.go
@@ -8,12 +8,14 @@ package common
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
 
 	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -33,7 +35,10 @@ const (
 	ResourceTypeSnapshot ResourceType = "snapshots"
 )
 
-func ReadBuildLogs(ctx context.Context, params ReadLogParams) {
+// ReadBuildLogs streams build logs to stdout until the stream ends or ctx is
+// canceled. Cancellation is the caller's signal to stop and returns nil; in
+// follow mode an EOF keeps polling for more output until then.
+func ReadBuildLogs(ctx context.Context, params ReadLogParams) error {
 	url := fmt.Sprintf("%s/%s/%s/build-logs", params.ServerUrl, params.ResourceType, params.Id)
 	if params.Follow != nil && *params.Follow {
 		url = fmt.Sprintf("%s?follow=true", url)
@@ -41,8 +46,7 @@ func ReadBuildLogs(ctx context.Context, params ReadLogParams) {
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
-		log.Errorf("Failed to create request: %v", err)
-		return
+		return clierr.Newf(clierr.CategoryNetwork, "failed to create request: %v", err)
 	}
 
 	if params.ServerApi.Key != nil {
@@ -60,14 +64,15 @@ func ReadBuildLogs(ctx context.Context, params ReadLogParams) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Errorf("Failed to connect to server: %v", err)
-		return
+		if ctx.Err() != nil {
+			return nil
+		}
+		return clierr.Newf(clierr.CategoryNetwork, "failed to connect to server: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Errorf("Server returned a non-OK status while retrieving logs: %d", resp.StatusCode)
-		return
+		return clierr.FromHTTPStatus(resp.StatusCode, fmt.Sprintf("server returned a non-OK status while retrieving logs: %d", resp.StatusCode))
 	}
 
 	reader := bufio.NewReader(resp.Body)
@@ -76,7 +81,7 @@ func ReadBuildLogs(ctx context.Context, params ReadLogParams) {
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		default:
 			n, err := reader.Read(buffer)
 			if n > 0 {
@@ -84,24 +89,23 @@ func ReadBuildLogs(ctx context.Context, params ReadLogParams) {
 			}
 
 			if err != nil {
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					if params.Follow != nil && *params.Follow {
 						time.Sleep(500 * time.Millisecond)
 						continue
 					}
-					return
+					return nil
 				}
-				if err == context.Canceled {
-					return
+				if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+					return nil
 				}
 				// In follow mode the upstream proxy can reset long-lived streams; the
 				// build itself is unaffected and the caller still polls for completion.
 				if params.Follow != nil && *params.Follow {
 					log.Warnf("Build log stream interrupted (%v); the build is still running, waiting for it to complete...", err)
-					return
+					return nil
 				}
-				log.Errorf("Error reading from stream: %v", err)
-				return
+				return clierr.Newf(clierr.CategoryNetwork, "error reading from stream: %v", err)
 			}
 		}
 	}

--- a/apps/cli/cmd/common/parse.go
+++ b/apps/cli/cmd/common/parse.go
@@ -26,14 +26,14 @@ func ParseKeyValuePairs(entries []string, flag string) (map[string]string, error
 	return pairs, nil
 }
 
-// ParseVolumeSpecs parses VOLUME_ID:MOUNT_PATH entries. Both the volume ID
-// and the mount path must be non-empty.
+// ParseVolumeSpecs parses VOLUME:MOUNT_PATH entries, where VOLUME is a
+// volume ID or name. Both the volume and the mount path must be non-empty.
 func ParseVolumeSpecs(entries []string) ([]apiclient.SandboxVolume, error) {
 	volumes := make([]apiclient.SandboxVolume, 0, len(entries))
 	for _, entry := range entries {
 		volumeId, mountPath, found := strings.Cut(entry, ":")
 		if !found || volumeId == "" || mountPath == "" {
-			return nil, clierr.Newf(clierr.CategoryUsage, "invalid --volume value %q: expected VOLUME_ID:MOUNT_PATH", entry)
+			return nil, clierr.Newf(clierr.CategoryUsage, "invalid --volume value %q: expected VOLUME:MOUNT_PATH", entry)
 		}
 		volumes = append(volumes, apiclient.SandboxVolume{
 			VolumeId:  volumeId,

--- a/apps/cli/cmd/common/parse.go
+++ b/apps/cli/cmd/common/parse.go
@@ -1,0 +1,74 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+	"github.com/joho/godotenv"
+)
+
+// ParseKeyValuePairs parses KEY=VALUE entries collected from the given flag.
+// Every entry must contain '=' and a non-empty key.
+func ParseKeyValuePairs(entries []string, flag string) (map[string]string, error) {
+	pairs := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		key, value, found := strings.Cut(entry, "=")
+		if !found || key == "" {
+			return nil, clierr.Newf(clierr.CategoryUsage, "invalid --%s value %q: expected KEY=VALUE", flag, entry)
+		}
+		pairs[key] = value
+	}
+	return pairs, nil
+}
+
+// ParseVolumeSpecs parses VOLUME_ID:MOUNT_PATH entries. Both the volume ID
+// and the mount path must be non-empty.
+func ParseVolumeSpecs(entries []string) ([]apiclient.SandboxVolume, error) {
+	volumes := make([]apiclient.SandboxVolume, 0, len(entries))
+	for _, entry := range entries {
+		volumeId, mountPath, found := strings.Cut(entry, ":")
+		if !found || volumeId == "" || mountPath == "" {
+			return nil, clierr.Newf(clierr.CategoryUsage, "invalid --volume value %q: expected VOLUME_ID:MOUNT_PATH", entry)
+		}
+		volumes = append(volumes, apiclient.SandboxVolume{
+			VolumeId:  volumeId,
+			MountPath: mountPath,
+		})
+	}
+	return volumes, nil
+}
+
+// ReadKeyValueFile reads KEY=VALUE pairs from a dotenv-style file.
+func ReadKeyValueFile(path string) (map[string]string, error) {
+	values, err := godotenv.Read(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	return values, nil
+}
+
+// ResolveKeyValuePairs merges KEY=VALUE pairs from an optional file with
+// entries given on the command line; CLI entries override file values per key.
+func ResolveKeyValuePairs(entries []string, filePath, flag string) (map[string]string, error) {
+	result := map[string]string{}
+	if filePath != "" {
+		fileValues, err := ReadKeyValueFile(filePath)
+		if err != nil {
+			return nil, err
+		}
+		result = fileValues
+	}
+	cliValues, err := ParseKeyValuePairs(entries, flag)
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range cliValues {
+		result[key] = value
+	}
+	return result, nil
+}

--- a/apps/cli/cmd/common/parse_test.go
+++ b/apps/cli/cmd/common/parse_test.go
@@ -1,0 +1,159 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common
+
+import (
+	"errors"
+	"maps"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+)
+
+func TestParseKeyValuePairs(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []string
+		want    map[string]string
+		wantErr bool
+	}{
+		{name: "empty input", entries: nil, want: map[string]string{}},
+		{name: "single pair", entries: []string{"FOO=bar"}, want: map[string]string{"FOO": "bar"}},
+		{name: "multiple pairs", entries: []string{"A=1", "B=2"}, want: map[string]string{"A": "1", "B": "2"}},
+		{name: "value contains equals", entries: []string{"URL=http://x?a=b"}, want: map[string]string{"URL": "http://x?a=b"}},
+		{name: "empty value allowed", entries: []string{"FOO="}, want: map[string]string{"FOO": ""}},
+		{name: "last entry wins for duplicate key", entries: []string{"A=1", "A=2"}, want: map[string]string{"A": "2"}},
+		{name: "missing separator", entries: []string{"FOO"}, wantErr: true},
+		{name: "empty key", entries: []string{"=bar"}, wantErr: true},
+		{name: "empty entry", entries: []string{""}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseKeyValuePairs(tt.entries, "env")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseKeyValuePairs(%v) expected error, got nil", tt.entries)
+				}
+				var cliErr *clierr.Error
+				if !errors.As(err, &cliErr) || cliErr.Category != clierr.CategoryUsage {
+					t.Errorf("ParseKeyValuePairs(%v) error = %v, want usage-category clierr", tt.entries, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseKeyValuePairs(%v) unexpected error: %v", tt.entries, err)
+			}
+			if !maps.Equal(got, tt.want) {
+				t.Errorf("ParseKeyValuePairs(%v) = %v, want %v", tt.entries, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseVolumeSpecs(t *testing.T) {
+	tests := []struct {
+		name      string
+		entries   []string
+		wantId    string
+		wantMount string
+		wantErr   bool
+	}{
+		{name: "valid spec", entries: []string{"vol-123:/data"}, wantId: "vol-123", wantMount: "/data"},
+		{name: "mount path contains colon", entries: []string{"vol-123:/a:b"}, wantId: "vol-123", wantMount: "/a:b"},
+		{name: "missing separator", entries: []string{"vol-123"}, wantErr: true},
+		{name: "empty volume id", entries: []string{":/data"}, wantErr: true},
+		{name: "empty mount path", entries: []string{"vol-123:"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseVolumeSpecs(tt.entries)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseVolumeSpecs(%v) expected error, got nil", tt.entries)
+				}
+				var cliErr *clierr.Error
+				if !errors.As(err, &cliErr) || cliErr.Category != clierr.CategoryUsage {
+					t.Errorf("ParseVolumeSpecs(%v) error = %v, want usage-category clierr", tt.entries, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseVolumeSpecs(%v) unexpected error: %v", tt.entries, err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("ParseVolumeSpecs(%v) returned %d volumes, want 1", tt.entries, len(got))
+			}
+			if got[0].VolumeId != tt.wantId || got[0].MountPath != tt.wantMount {
+				t.Errorf("ParseVolumeSpecs(%v) = %s:%s, want %s:%s", tt.entries, got[0].VolumeId, got[0].MountPath, tt.wantId, tt.wantMount)
+			}
+		})
+	}
+}
+
+func TestReadKeyValueFile(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		if _, err := ReadKeyValueFile(filepath.Join(t.TempDir(), "nope.env")); err == nil {
+			t.Fatal("ReadKeyValueFile expected error for missing file, got nil")
+		}
+	})
+
+	t.Run("valid file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "test.env")
+		if err := os.WriteFile(path, []byte("FOO=bar\nBAZ=qux\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := ReadKeyValueFile(path)
+		if err != nil {
+			t.Fatalf("ReadKeyValueFile unexpected error: %v", err)
+		}
+		want := map[string]string{"FOO": "bar", "BAZ": "qux"}
+		if !maps.Equal(got, want) {
+			t.Errorf("ReadKeyValueFile = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestResolveKeyValuePairs(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "values.env")
+	if err := os.WriteFile(filePath, []byte("A=file\nB=file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		entries  []string
+		filePath string
+		want     map[string]string
+		wantErr  bool
+	}{
+		{name: "cli only", entries: []string{"A=cli"}, want: map[string]string{"A": "cli"}},
+		{name: "file only", filePath: filePath, want: map[string]string{"A": "file", "B": "file"}},
+		{name: "cli overrides file per key", entries: []string{"B=cli", "C=cli"}, filePath: filePath, want: map[string]string{"A": "file", "B": "cli", "C": "cli"}},
+		{name: "missing file", entries: []string{"A=cli"}, filePath: filepath.Join(dir, "nope.env"), wantErr: true},
+		{name: "invalid cli entry", entries: []string{"broken"}, filePath: filePath, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveKeyValuePairs(tt.entries, tt.filePath, "env")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ResolveKeyValuePairs(%v, %q) expected error, got nil", tt.entries, tt.filePath)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveKeyValuePairs(%v, %q) unexpected error: %v", tt.entries, tt.filePath, err)
+			}
+			if !maps.Equal(got, tt.want) {
+				t.Errorf("ResolveKeyValuePairs(%v, %q) = %v, want %v", tt.entries, tt.filePath, got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/cli/cmd/common/parse_test.go
+++ b/apps/cli/cmd/common/parse_test.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/daytonaio/daytona/cli/internal/clierr"
@@ -79,6 +80,9 @@ func TestParseVolumeSpecs(t *testing.T) {
 				var cliErr *clierr.Error
 				if !errors.As(err, &cliErr) || cliErr.Category != clierr.CategoryUsage {
 					t.Errorf("ParseVolumeSpecs(%v) error = %v, want usage-category clierr", tt.entries, err)
+				}
+				if !strings.Contains(err.Error(), "expected VOLUME:MOUNT_PATH") {
+					t.Errorf("ParseVolumeSpecs(%v) error = %q, want it to mention expected VOLUME:MOUNT_PATH", tt.entries, err)
 				}
 				return
 			}

--- a/apps/cli/cmd/common/shell.go
+++ b/apps/cli/cmd/common/shell.go
@@ -1,0 +1,51 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common
+
+import "strings"
+
+// ShellJoinArgs joins command arguments into a single shell command line.
+// A single argument is returned verbatim so already-quoted commands
+// (e.g. `daytona exec my-sandbox "echo hi | wc -l"`) keep working. With
+// multiple arguments each one is quoted when needed so the remote shell
+// sees the same argument vector the user typed locally.
+func ShellJoinArgs(args []string) string {
+	if len(args) == 1 {
+		return args[0]
+	}
+
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		quoted[i] = shellQuoteArg(arg)
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellQuoteArg(arg string) string {
+	if arg == "" {
+		return "''"
+	}
+	if !shellArgNeedsQuoting(arg) {
+		return arg
+	}
+	return "'" + strings.ReplaceAll(arg, "'", `'\''`) + "'"
+}
+
+// shellArgNeedsQuoting reports whether arg contains any byte outside the
+// POSIX-safe set [A-Za-z0-9_./:=@%^,+-].
+func shellArgNeedsQuoting(arg string) bool {
+	for i := 0; i < len(arg); i++ {
+		c := arg[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '_' || c == '.' || c == '/' || c == ':' || c == '=' ||
+			c == '@' || c == '%' || c == '^' || c == ',' || c == '+' || c == '-':
+		default:
+			return true
+		}
+	}
+	return false
+}

--- a/apps/cli/cmd/common/shell_test.go
+++ b/apps/cli/cmd/common/shell_test.go
@@ -1,0 +1,77 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common_test
+
+import (
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/cmd/common"
+)
+
+func TestShellJoinArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "single argument is returned verbatim",
+			args: []string{"echo hi | wc -l"},
+			want: "echo hi | wc -l",
+		},
+		{
+			name: "single argument with quotes is returned verbatim",
+			args: []string{`echo "hello world" && ls`},
+			want: `echo "hello world" && ls`,
+		},
+		{
+			name: "safe arguments stay unquoted",
+			args: []string{"ls", "-la", "/tmp/dir", "--format=long", "user@host:path", "a,b+c%d^e"},
+			want: "ls -la /tmp/dir --format=long user@host:path a,b+c%d^e",
+		},
+		{
+			name: "argument with spaces is quoted",
+			args: []string{"echo", "hello world"},
+			want: "echo 'hello world'",
+		},
+		{
+			name: "single quote is escaped",
+			args: []string{"echo", "it's"},
+			want: `echo 'it'\''s'`,
+		},
+		{
+			name: "double quotes are wrapped in single quotes",
+			args: []string{"echo", `say "hi"`},
+			want: `echo 'say "hi"'`,
+		},
+		{
+			name: "dollar variable is quoted",
+			args: []string{"echo", "$HOME"},
+			want: "echo '$HOME'",
+		},
+		{
+			name: "glob is quoted",
+			args: []string{"ls", "*.go"},
+			want: "ls '*.go'",
+		},
+		{
+			name: "empty argument becomes empty quotes",
+			args: []string{"printf", ""},
+			want: "printf ''",
+		},
+		{
+			name: "no arguments yields empty string",
+			args: nil,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := common.ShellJoinArgs(tt.args); got != tt.want {
+				t.Errorf("ShellJoinArgs(%q) = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/cli/cmd/common/state.go
+++ b/apps/cli/cmd/common/state.go
@@ -6,13 +6,25 @@ package common
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 )
 
-func AwaitSnapshotState(ctx context.Context, apiClient *apiclient.APIClient, name string, states ...apiclient.SnapshotState) error {
+// AwaitSnapshotState polls the snapshot until it reaches one of the given
+// states. A timeout <= 0 waits indefinitely; on expiry a timeout-category
+// error is returned.
+func AwaitSnapshotState(ctx context.Context, apiClient *apiclient.APIClient, name string, timeout time.Duration, states ...apiclient.SnapshotState) error {
+	var expired <-chan time.Time
+	if timeout > 0 {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		expired = timer.C
+	}
+
 	for {
 		snapshot, res, err := apiClient.SnapshotsAPI.GetSnapshot(ctx, name).Execute()
 		if err != nil {
@@ -33,11 +45,27 @@ func AwaitSnapshotState(ctx context.Context, apiClient *apiclient.APIClient, nam
 			return fmt.Errorf("snapshot processing failed: %s", *snapshot.ErrorReason.Get())
 		}
 
-		time.Sleep(time.Second)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-expired:
+			return clierr.Newf(clierr.CategoryTimeout, "timed out after %s waiting for snapshot %q to reach state %s", timeout, name, awaitStateNames(states))
+		case <-time.After(time.Second):
+		}
 	}
 }
 
-func AwaitSandboxState(ctx context.Context, apiClient *apiclient.APIClient, targetSandbox string, states ...apiclient.SandboxState) error {
+// AwaitSandboxState polls the sandbox until it reaches one of the given
+// states. A timeout <= 0 waits indefinitely; on expiry a timeout-category
+// error is returned.
+func AwaitSandboxState(ctx context.Context, apiClient *apiclient.APIClient, targetSandbox string, timeout time.Duration, states ...apiclient.SandboxState) error {
+	var expired <-chan time.Time
+	if timeout > 0 {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		expired = timer.C
+	}
+
 	for {
 		sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, targetSandbox).Execute()
 		if err != nil {
@@ -58,6 +86,21 @@ func AwaitSandboxState(ctx context.Context, apiClient *apiclient.APIClient, targ
 			}
 		}
 
-		time.Sleep(time.Second)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-expired:
+			return clierr.Newf(clierr.CategoryTimeout, "timed out after %s waiting for sandbox %q to reach state %s", timeout, targetSandbox, awaitStateNames(states))
+		case <-time.After(time.Second):
+		}
 	}
+}
+
+// awaitStateNames renders a list of awaited states for timeout messages.
+func awaitStateNames[T ~string](states []T) string {
+	names := make([]string, len(states))
+	for i, s := range states {
+		names[i] = string(s)
+	}
+	return strings.Join(names, ", ")
 }

--- a/apps/cli/cmd/common/state_test.go
+++ b/apps/cli/cmd/common/state_test.go
@@ -1,0 +1,114 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+)
+
+// stateTestSandboxJSON renders a minimal Sandbox payload containing every
+// property the generated client requires plus the given state.
+func stateTestSandboxJSON(state string) string {
+	return fmt.Sprintf(`{
+		"id": "sbx-1",
+		"organizationId": "org-1",
+		"name": "my-sandbox",
+		"user": "daytona",
+		"env": {},
+		"labels": {},
+		"public": false,
+		"networkBlockAll": false,
+		"target": "us",
+		"cpu": 1,
+		"gpu": 0,
+		"memory": 1,
+		"disk": 1,
+		"toolboxProxyUrl": "",
+		"state": %q
+	}`, state)
+}
+
+func stateTestApiClient(serverURL string) *apiclient.APIClient {
+	clientConfig := apiclient.NewConfiguration()
+	clientConfig.Servers = apiclient.ServerConfigurations{{URL: serverURL}}
+	return apiclient.NewAPIClient(clientConfig)
+}
+
+func stateTestServer(t *testing.T, state string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, stateTestSandboxJSON(state))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestAwaitSandboxStateTimeout(t *testing.T) {
+	server := stateTestServer(t, "starting")
+	apiClient := stateTestApiClient(server.URL)
+
+	start := time.Now()
+	err := common.AwaitSandboxState(context.Background(), apiClient, "sbx-1", 50*time.Millisecond, apiclient.SANDBOXSTATE_STARTED)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	var cliErr *clierr.Error
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *clierr.Error, got %T: %v", err, err)
+	}
+	if cliErr.Category != clierr.CategoryTimeout {
+		t.Errorf("category = %q, want %q", cliErr.Category, clierr.CategoryTimeout)
+	}
+	if elapsed >= time.Second {
+		t.Errorf("timeout took %s, expected to expire well before the next 1s poll", elapsed)
+	}
+}
+
+func TestAwaitSandboxStateSuccess(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{name: "bounded wait reaches target state", timeout: 5 * time.Second},
+		{name: "unbounded wait reaches target state", timeout: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := stateTestServer(t, "started")
+			apiClient := stateTestApiClient(server.URL)
+
+			err := common.AwaitSandboxState(context.Background(), apiClient, "sbx-1", tt.timeout, apiclient.SANDBOXSTATE_STARTED)
+			if err != nil {
+				t.Fatalf("AwaitSandboxState() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestAwaitSandboxStateContextCanceled(t *testing.T) {
+	server := stateTestServer(t, "starting")
+	apiClient := stateTestApiClient(server.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := common.AwaitSandboxState(ctx, apiClient, "sbx-1", 0, apiclient.SANDBOXSTATE_STARTED)
+	if err == nil {
+		t.Fatal("expected error for canceled context, got nil")
+	}
+}

--- a/apps/cli/cmd/common/state_test.go
+++ b/apps/cli/cmd/common/state_test.go
@@ -112,3 +112,47 @@ func TestAwaitSandboxStateContextCanceled(t *testing.T) {
 		t.Fatal("expected error for canceled context, got nil")
 	}
 }
+
+// stateTestSnapshotJSON renders a minimal SnapshotDto payload containing
+// every property the generated client requires plus the given state.
+func stateTestSnapshotJSON(state string) string {
+	return fmt.Sprintf(`{
+		"id": "snap-1",
+		"general": false,
+		"name": "my-snapshot",
+		"state": %q,
+		"size": null,
+		"entrypoint": [],
+		"cpu": 1,
+		"gpu": 0,
+		"mem": 1,
+		"disk": 3,
+		"errorReason": null,
+		"createdAt": "2024-01-01T00:00:00Z",
+		"updatedAt": "2024-01-01T00:00:00Z",
+		"lastUsedAt": null
+	}`, state)
+}
+
+func TestAwaitSnapshotStateTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, stateTestSnapshotJSON("pending"))
+	}))
+	t.Cleanup(server.Close)
+	apiClient := stateTestApiClient(server.URL)
+
+	start := time.Now()
+	err := common.AwaitSnapshotState(context.Background(), apiClient, "my-snapshot", 50*time.Millisecond, apiclient.SNAPSHOTSTATE_ACTIVE)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !clierr.HasCategory(err, clierr.CategoryTimeout) {
+		t.Errorf("HasCategory(err, timeout) = false, err = %v", err)
+	}
+	if elapsed >= time.Second {
+		t.Errorf("timeout took %s, expected to expire well before the next 1s poll", elapsed)
+	}
+}

--- a/apps/cli/cmd/mcp/config.go
+++ b/apps/cli/cmd/mcp/config.go
@@ -13,7 +13,7 @@ import (
 )
 
 var ConfigCmd = &cobra.Command{
-	Use:   "config [AGENT_NAME]",
+	Use:   "config",
 	Short: "Outputs JSON configuration for Daytona MCP Server",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/mcp/config.go
+++ b/apps/cli/cmd/mcp/config.go
@@ -15,7 +15,9 @@ import (
 var ConfigCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Outputs JSON configuration for Daytona MCP Server",
-	Args:  cobra.NoArgs,
+	Example: `  daytona mcp config
+  daytona mcp config > daytona-mcp.json`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {

--- a/apps/cli/cmd/mcp/config_test.go
+++ b/apps/cli/cmd/mcp/config_test.go
@@ -1,0 +1,12 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package mcp
+
+import "testing"
+
+func TestConfigCmdUse(t *testing.T) {
+	if ConfigCmd.Use != "config" {
+		t.Errorf("ConfigCmd.Use = %q, want %q", ConfigCmd.Use, "config")
+	}
+}

--- a/apps/cli/cmd/mcp/init.go
+++ b/apps/cli/cmd/mcp/init.go
@@ -15,7 +15,9 @@ import (
 var InitCmd = &cobra.Command{
 	Use:   "init [AGENT_NAME]",
 	Short: "Initialize Daytona MCP Server with an agent (currently supported: claude, windsurf, cursor)",
-	Args:  cobra.MaximumNArgs(1),
+	Example: `  daytona mcp init claude
+  daytona mcp init cursor`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return fmt.Errorf("agent name is required")

--- a/apps/cli/cmd/mcp/start.go
+++ b/apps/cli/cmd/mcp/start.go
@@ -14,7 +14,9 @@ import (
 var StartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start Daytona MCP Server",
-	Args:  cobra.NoArgs,
+	Example: `  # Typically launched by an MCP client (see 'daytona mcp init')
+  daytona mcp start`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		server := mcp.NewDaytonaMCPServer()
 

--- a/apps/cli/cmd/organization/create.go
+++ b/apps/cli/cmd/organization/create.go
@@ -23,7 +23,9 @@ var regionFlag string
 var CreateCmd = &cobra.Command{
 	Use:   "create [ORGANIZATION_NAME]",
 	Short: "Create a new organization and set it as active",
-	Args:  cobra.ExactArgs(1),
+	Example: `  daytona organization create my-org
+  daytona organization create my-org --region us`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 

--- a/apps/cli/cmd/organization/create.go
+++ b/apps/cli/cmd/organization/create.go
@@ -10,6 +10,8 @@ import (
 	"github.com/charmbracelet/huh"
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	"github.com/daytonaio/daytona/cli/views/common"
 	"github.com/daytonaio/daytona/cli/views/organization"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
@@ -47,6 +49,9 @@ var CreateCmd = &cobra.Command{
 		case len(regions) == 1:
 			chosenRegion = &regions[0]
 		default:
+			if !internal.Interactive() {
+				return clierr.New(clierr.CategoryUsage, "cannot prompt for input in non-interactive mode").WithHint("pass --region")
+			}
 			var chosenRegionId string
 			var regionOptions []huh.Option[string]
 

--- a/apps/cli/cmd/organization/delete.go
+++ b/apps/cli/cmd/organization/delete.go
@@ -20,8 +20,11 @@ import (
 )
 
 var DeleteCmd = &cobra.Command{
-	Use:     "delete [ORGANIZATION]",
-	Short:   "Delete an organization",
+	Use:   "delete [ORGANIZATION]",
+	Short: "Delete an organization",
+	Example: `  daytona organization delete my-org
+  # With no argument, pick from a list interactively
+  daytona organization delete`,
 	Args:    cobra.MaximumNArgs(1),
 	Aliases: common.GetAliases("delete"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/organization/delete.go
+++ b/apps/cli/cmd/organization/delete.go
@@ -10,6 +10,8 @@ import (
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	view_common "github.com/daytonaio/daytona/cli/views/common"
 	"github.com/daytonaio/daytona/cli/views/organization"
 	"github.com/daytonaio/daytona/cli/views/util"
@@ -42,6 +44,9 @@ var DeleteCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
+			if !internal.Interactive() {
+				return clierr.New(clierr.CategoryUsage, "organization ID or name required in non-interactive mode").WithHint("pass the organization as an argument")
+			}
 			chosenOrganization, err = organization.GetOrganizationIdFromPrompt(orgList)
 			if err != nil {
 				return err

--- a/apps/cli/cmd/organization/list.go
+++ b/apps/cli/cmd/organization/list.go
@@ -14,8 +14,10 @@ import (
 )
 
 var ListCmd = &cobra.Command{
-	Use:     "list",
-	Short:   "List all organizations",
+	Use:   "list",
+	Short: "List all organizations",
+	Example: `  daytona organization list
+  daytona organization list --format json`,
 	Args:    cobra.NoArgs,
 	Aliases: common.GetAliases("list"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/organization/use.go
+++ b/apps/cli/cmd/organization/use.go
@@ -21,7 +21,10 @@ import (
 var UseCmd = &cobra.Command{
 	Use:   "use [ORGANIZATION]",
 	Short: "Set active organization",
-	Args:  cobra.MaximumNArgs(1),
+	Example: `  daytona organization use my-org
+  # With no argument, pick from a list interactively
+  daytona organization use`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var chosenOrganization *apiclient.Organization
 		ctx := context.Background()

--- a/apps/cli/cmd/organization/use.go
+++ b/apps/cli/cmd/organization/use.go
@@ -9,6 +9,8 @@ import (
 
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	"github.com/daytonaio/daytona/cli/views/common"
 	"github.com/daytonaio/daytona/cli/views/organization"
 	"github.com/daytonaio/daytona/cli/views/util"
@@ -40,6 +42,9 @@ var UseCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
+			if !internal.Interactive() {
+				return clierr.New(clierr.CategoryUsage, "organization ID or name required in non-interactive mode").WithHint("pass the organization as an argument")
+			}
 			chosenOrganization, err = organization.GetOrganizationIdFromPrompt(orgList)
 			if err != nil {
 				return err

--- a/apps/cli/cmd/sandbox/archive.go
+++ b/apps/cli/cmd/sandbox/archive.go
@@ -6,20 +6,28 @@ package sandbox
 import (
 	"context"
 	"fmt"
+	"time"
 
-	"github.com/daytonaio/daytona/cli/apiclient"
+	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
+	"github.com/daytonaio/daytona/cli/cmd/common"
 	view_common "github.com/daytonaio/daytona/cli/views/common"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/spf13/cobra"
 )
 
+var (
+	archiveWaitFlag    bool
+	archiveTimeoutFlag time.Duration
+)
+
 var ArchiveCmd = &cobra.Command{
-	Use:   "archive [SANDBOX_ID] | [SANDBOX_NAME]",
+	Use:   "archive [SANDBOX_ID | SANDBOX_NAME]",
 	Short: "Archive a sandbox",
-	Args:  cobra.MaximumNArgs(1),
+	Args:  requireSandboxArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
-		apiClient, err := apiclient.GetApiClient(nil, nil)
+		apiClient, err := apiclient_cli.GetApiClient(nil, nil)
 		if err != nil {
 			return err
 		}
@@ -28,7 +36,23 @@ var ArchiveCmd = &cobra.Command{
 
 		_, res, err := apiClient.SandboxAPI.ArchiveSandbox(ctx, sandboxIdOrNameArg).Execute()
 		if err != nil {
-			return apiclient.HandleErrorResponse(res, err)
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
+
+		if archiveWaitFlag {
+			err = common.AwaitSandboxState(ctx, apiClient, sandboxIdOrNameArg, archiveTimeoutFlag, apiclient.SANDBOXSTATE_ARCHIVED)
+			if err != nil {
+				return err
+			}
+		}
+
+		if common.FormatFlag != "" {
+			sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, sandboxIdOrNameArg).Execute()
+			if err != nil {
+				return apiclient_cli.HandleErrorResponse(res, err)
+			}
+			common.NewFormatter(sandbox).Print()
+			return nil
 		}
 
 		view_common.RenderInfoMessageBold(fmt.Sprintf("Sandbox %s marked for archival", sandboxIdOrNameArg))
@@ -37,4 +61,7 @@ var ArchiveCmd = &cobra.Command{
 }
 
 func init() {
+	ArchiveCmd.Flags().BoolVar(&archiveWaitFlag, "wait", false, "Wait until the sandbox is archived")
+	ArchiveCmd.Flags().DurationVar(&archiveTimeoutFlag, "timeout", 5*time.Minute, "Maximum time to wait with --wait (0 waits indefinitely)")
+	common.RegisterFormatFlag(ArchiveCmd)
 }

--- a/apps/cli/cmd/sandbox/archive.go
+++ b/apps/cli/cmd/sandbox/archive.go
@@ -23,7 +23,10 @@ var (
 var ArchiveCmd = &cobra.Command{
 	Use:   "archive [SANDBOX_ID | SANDBOX_NAME]",
 	Short: "Archive a sandbox",
-	Args:  requireSandboxArg,
+	Example: `  daytona archive my-sandbox
+  daytona archive my-sandbox --wait --timeout 10m
+  daytona archive my-sandbox --wait --format json`,
+	Args: requireSandboxArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 

--- a/apps/cli/cmd/sandbox/archive.go
+++ b/apps/cli/cmd/sandbox/archive.go
@@ -10,7 +10,6 @@ import (
 
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
-	view_common "github.com/daytonaio/daytona/cli/views/common"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/spf13/cobra"
 )
@@ -42,24 +41,7 @@ var ArchiveCmd = &cobra.Command{
 			return apiclient_cli.HandleErrorResponse(res, err)
 		}
 
-		if archiveWaitFlag {
-			err = common.AwaitSandboxState(ctx, apiClient, sandboxIdOrNameArg, archiveTimeoutFlag, apiclient.SANDBOXSTATE_ARCHIVED)
-			if err != nil {
-				return err
-			}
-		}
-
-		if common.FormatFlag != "" {
-			sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, sandboxIdOrNameArg).Execute()
-			if err != nil {
-				return apiclient_cli.HandleErrorResponse(res, err)
-			}
-			common.NewFormatter(sandbox).Print()
-			return nil
-		}
-
-		view_common.RenderInfoMessageBold(fmt.Sprintf("Sandbox %s marked for archival", sandboxIdOrNameArg))
-		return nil
+		return finishLifecycleAction(ctx, apiClient, sandboxIdOrNameArg, archiveWaitFlag, archiveTimeoutFlag, apiclient.SANDBOXSTATE_ARCHIVED, fmt.Sprintf("Sandbox %s marked for archival", sandboxIdOrNameArg))
 	},
 }
 

--- a/apps/cli/cmd/sandbox/cp.go
+++ b/apps/cli/cmd/sandbox/cp.go
@@ -42,7 +42,7 @@ basename inside it, and missing parent directories are created.`,
 	Example: `  daytona cp ./config.yaml my-sandbox:/workspace/config.yaml
   daytona cp my-sandbox:/workspace/output ./output
   daytona cp ./src my-sandbox:/workspace/src --format json`,
-	Args: cobra.ExactArgs(2),
+	Args: cpRequireSourceAndDestination,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		req, err := parseCpArgs(args[0], args[1])
 		if err != nil {
@@ -99,6 +99,19 @@ type cpRequest struct {
 	remotePath string
 	localPath  string
 	upload     bool
+}
+
+// cpRequireSourceAndDestination validates that exactly the SOURCE and
+// DESTINATION arguments are provided, returning a usage-category error
+// otherwise (same style as requireSandboxArg).
+func cpRequireSourceAndDestination(cmd *cobra.Command, args []string) error {
+	if len(args) < 2 {
+		return clierr.New(clierr.CategoryUsage, "missing required arguments: SOURCE and DESTINATION")
+	}
+	if len(args) > 2 {
+		return clierr.Newf(clierr.CategoryUsage, "expected exactly 2 arguments (SOURCE and DESTINATION), received %d", len(args))
+	}
+	return nil
 }
 
 // parseCpEndpoint splits a cp argument into its sandbox and path parts. An
@@ -295,14 +308,19 @@ func cpDownloadFile(ctx context.Context, apiClient *apiclient.APIClient, sandbox
 }
 
 // cpWriteLocalFile copies the downloaded temp file to localPath, creating
-// parent directories as needed, then closes and removes the temp file.
+// parent directories as needed, then closes and removes the temp file. A nil
+// tmp means the remote file was empty (the generated client skips creating a
+// temp file for empty response bodies); the local file is still created, and
+// truncated if it already exists.
 func cpWriteLocalFile(tmp *os.File, localPath string) (err error) {
-	defer func() { _ = os.Remove(tmp.Name()) }()
-	defer func() {
-		if closeErr := tmp.Close(); closeErr != nil && err == nil {
-			err = closeErr
-		}
-	}()
+	if tmp != nil {
+		defer func() { _ = os.Remove(tmp.Name()) }()
+		defer func() {
+			if closeErr := tmp.Close(); closeErr != nil && err == nil {
+				err = closeErr
+			}
+		}()
+	}
 
 	if dir := filepath.Dir(localPath); dir != "" {
 		if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
@@ -314,9 +332,11 @@ func cpWriteLocalFile(tmp *os.File, localPath string) (err error) {
 	if err != nil {
 		return err
 	}
-	if _, copyErr := io.Copy(dst, tmp); copyErr != nil {
-		_ = dst.Close()
-		return copyErr
+	if tmp != nil {
+		if _, copyErr := io.Copy(dst, tmp); copyErr != nil {
+			_ = dst.Close()
+			return copyErr
+		}
 	}
 	return dst.Close()
 }

--- a/apps/cli/cmd/sandbox/cp.go
+++ b/apps/cli/cmd/sandbox/cp.go
@@ -39,6 +39,9 @@ Exactly one of SOURCE or DESTINATION must reference a sandbox path using the
 <sandbox>:<path> form, where <sandbox> is a sandbox ID or name. Directories
 are copied recursively. Copying into an existing directory places the source
 basename inside it, and missing parent directories are created.`,
+	Example: `  daytona cp ./config.yaml my-sandbox:/workspace/config.yaml
+  daytona cp my-sandbox:/workspace/output ./output
+  daytona cp ./src my-sandbox:/workspace/src --format json`,
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		req, err := parseCpArgs(args[0], args[1])

--- a/apps/cli/cmd/sandbox/cp.go
+++ b/apps/cli/cmd/sandbox/cp.go
@@ -1,0 +1,332 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
+	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+	view_common "github.com/daytonaio/daytona/cli/views/common"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+	"github.com/spf13/cobra"
+)
+
+// cpResult is the structured output of `daytona cp` in --format mode.
+type cpResult struct {
+	Source           string `json:"source" yaml:"source"`
+	Destination      string `json:"destination" yaml:"destination"`
+	Direction        string `json:"direction" yaml:"direction"`
+	FilesTransferred int    `json:"filesTransferred" yaml:"filesTransferred"`
+}
+
+var CpCmd = &cobra.Command{
+	Use:   "cp SOURCE DESTINATION",
+	Short: "Copy files between the local machine and a sandbox",
+	Long: `Copy files or directories between the local filesystem and a sandbox.
+
+Exactly one of SOURCE or DESTINATION must reference a sandbox path using the
+<sandbox>:<path> form, where <sandbox> is a sandbox ID or name. Directories
+are copied recursively. Copying into an existing directory places the source
+basename inside it, and missing parent directories are created.`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		req, err := parseCpArgs(args[0], args[1])
+		if err != nil {
+			return err
+		}
+
+		ctx := context.Background()
+
+		apiClient, err := apiclient_cli.GetApiClient(nil, nil)
+		if err != nil {
+			return err
+		}
+
+		sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, req.sandboxRef).Execute()
+		if err != nil {
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
+
+		if err := common.RequireStartedState(sandbox); err != nil {
+			return err
+		}
+
+		var transferred int
+		direction := "download"
+		if req.upload {
+			direction = "upload"
+			transferred, err = cpUpload(ctx, apiClient, sandbox.Id, req.sandboxRef, req.localPath, req.remotePath)
+		} else {
+			transferred, err = cpDownload(ctx, apiClient, sandbox.Id, req.sandboxRef, req.remotePath, req.localPath)
+		}
+		if err != nil {
+			return err
+		}
+
+		if common.FormatFlag != "" {
+			common.NewFormatter(cpResult{
+				Source:           args[0],
+				Destination:      args[1],
+				Direction:        direction,
+				FilesTransferred: transferred,
+			}).Print()
+			return nil
+		}
+
+		view_common.RenderInfoMessageBold(fmt.Sprintf("Copied %d file(s)", transferred))
+		return nil
+	},
+}
+
+// cpRequest describes a validated cp invocation: which sandbox is involved,
+// the remote and local paths, and the transfer direction.
+type cpRequest struct {
+	sandboxRef string
+	remotePath string
+	localPath  string
+	upload     bool
+}
+
+// parseCpEndpoint splits a cp argument into its sandbox and path parts. An
+// argument is remote iff it contains a ":" whose prefix is longer than one
+// character (so Windows drive letters like C:\foo stay local) and is not a
+// relative-directory marker ("." or ".."). The path is everything after the
+// first ":", so remote paths may themselves contain colons.
+func parseCpEndpoint(s string) (sandbox, filePath string, remote bool) {
+	idx := strings.Index(s, ":")
+	if idx < 0 {
+		return "", s, false
+	}
+	prefix := s[:idx]
+	if len(prefix) <= 1 || prefix == ".." {
+		return "", s, false
+	}
+	return prefix, s[idx+1:], true
+}
+
+// parseCpArgs validates that exactly one side of the copy references a
+// sandbox and resolves the transfer direction. An empty remote path defaults
+// to the sandbox working directory (".").
+func parseCpArgs(source, destination string) (*cpRequest, error) {
+	srcSandbox, srcPath, srcRemote := parseCpEndpoint(source)
+	dstSandbox, dstPath, dstRemote := parseCpEndpoint(destination)
+
+	var req *cpRequest
+	switch {
+	case srcRemote && dstRemote:
+		return nil, clierr.New(clierr.CategoryUsage, "copying between two sandboxes is not supported").
+			WithHint("exactly one of SOURCE and DESTINATION may use the <sandbox>:<path> form")
+	case !srcRemote && !dstRemote:
+		return nil, clierr.New(clierr.CategoryUsage, "neither SOURCE nor DESTINATION references a sandbox").
+			WithHint("use <sandbox>:<path> for the remote side, e.g. 'daytona cp ./file.txt my-sandbox:/tmp/file.txt'")
+	case dstRemote:
+		req = &cpRequest{sandboxRef: dstSandbox, remotePath: dstPath, localPath: srcPath, upload: true}
+	default:
+		req = &cpRequest{sandboxRef: srcSandbox, remotePath: srcPath, localPath: dstPath, upload: false}
+	}
+
+	if req.remotePath == "" {
+		req.remotePath = "."
+	}
+	return req, nil
+}
+
+// cpUpload copies a local file or directory tree into the sandbox and returns
+// the number of files transferred.
+func cpUpload(ctx context.Context, apiClient *apiclient.APIClient, sandboxId, sandboxRef, localSrc, remoteDst string) (int, error) {
+	srcInfo, err := os.Stat(localSrc)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, clierr.Newf(clierr.CategoryUsage, "local source %q does not exist", localSrc)
+		}
+		return 0, err
+	}
+
+	// Mirror cp semantics: copying into an existing remote directory places
+	// the source basename inside it. The info call is best-effort — an error
+	// just means the destination does not exist yet.
+	if remoteInfo, _, infoErr := apiClient.ToolboxAPI.GetFileInfoDeprecated(ctx, sandboxId).Path(remoteDst).Execute(); infoErr == nil && remoteInfo != nil && remoteInfo.IsDir {
+		remoteDst = path.Join(remoteDst, filepath.Base(localSrc))
+	}
+
+	if !srcInfo.IsDir() {
+		if err := cpUploadFile(ctx, apiClient, sandboxId, localSrc, remoteDst); err != nil {
+			return 0, err
+		}
+		cpReportTransfer("Uploaded", localSrc, sandboxRef+":"+remoteDst)
+		return 1, nil
+	}
+
+	count := 0
+	err = filepath.WalkDir(localSrc, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		rel, relErr := filepath.Rel(localSrc, p)
+		if relErr != nil {
+			return relErr
+		}
+		remotePath := remoteDst
+		if rel != "." {
+			remotePath = path.Join(remoteDst, filepath.ToSlash(rel))
+		}
+
+		if d.IsDir() {
+			// Best-effort mirror of the directory itself so empty directories
+			// are preserved; per-file uploads create missing parents anyway.
+			_, _ = apiClient.ToolboxAPI.CreateFolderDeprecated(ctx, sandboxId).Path(remotePath).Mode("0755").Execute()
+			return nil
+		}
+
+		if err := cpUploadFile(ctx, apiClient, sandboxId, p, remotePath); err != nil {
+			return err
+		}
+		count++
+		cpReportTransfer("Uploaded", p, sandboxRef+":"+remotePath)
+		return nil
+	})
+	return count, err
+}
+
+// cpUploadFile uploads a single local file to remotePath in the sandbox,
+// creating the remote parent directory best-effort first.
+func cpUploadFile(ctx context.Context, apiClient *apiclient.APIClient, sandboxId, localPath, remotePath string) error {
+	file, err := os.Open(localPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+
+	if parent := path.Dir(remotePath); parent != "" && parent != "." && parent != "/" {
+		// Best-effort: if creation fails the upload reports the real error.
+		_, _ = apiClient.ToolboxAPI.CreateFolderDeprecated(ctx, sandboxId).Path(parent).Mode("0755").Execute()
+	}
+
+	res, err := apiClient.ToolboxAPI.UploadFileDeprecated(ctx, sandboxId).Path(remotePath).File(file).Execute()
+	if err != nil {
+		return apiclient_cli.HandleErrorResponse(res, err)
+	}
+	return nil
+}
+
+// cpDownload copies a sandbox file or directory tree to the local filesystem
+// and returns the number of files transferred.
+func cpDownload(ctx context.Context, apiClient *apiclient.APIClient, sandboxId, sandboxRef, remoteSrc, localDst string) (int, error) {
+	info, res, err := apiClient.ToolboxAPI.GetFileInfoDeprecated(ctx, sandboxId).Path(remoteSrc).Execute()
+	if err != nil {
+		return 0, apiclient_cli.HandleErrorResponse(res, err)
+	}
+
+	// Mirror cp semantics: copying into an existing local directory places
+	// the source basename inside it.
+	if dstInfo, statErr := os.Stat(localDst); statErr == nil && dstInfo.IsDir() {
+		localDst = filepath.Join(localDst, path.Base(remoteSrc))
+	}
+
+	if info.IsDir {
+		return cpDownloadDir(ctx, apiClient, sandboxId, sandboxRef, remoteSrc, localDst)
+	}
+
+	if err := cpDownloadFile(ctx, apiClient, sandboxId, remoteSrc, localDst); err != nil {
+		return 0, err
+	}
+	cpReportTransfer("Downloaded", sandboxRef+":"+remoteSrc, localDst)
+	return 1, nil
+}
+
+// cpDownloadDir recursively downloads a sandbox directory into localDir.
+// FileInfo.Name returned by the toolbox is a basename, so child remote paths
+// are built with the POSIX path package against the parent directory.
+func cpDownloadDir(ctx context.Context, apiClient *apiclient.APIClient, sandboxId, sandboxRef, remoteDir, localDir string) (int, error) {
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		return 0, err
+	}
+
+	entries, res, err := apiClient.ToolboxAPI.ListFilesDeprecated(ctx, sandboxId).Path(remoteDir).Execute()
+	if err != nil {
+		return 0, apiclient_cli.HandleErrorResponse(res, err)
+	}
+
+	count := 0
+	for _, entry := range entries {
+		remotePath := path.Join(remoteDir, entry.Name)
+		localPath := filepath.Join(localDir, entry.Name)
+
+		if entry.IsDir {
+			n, err := cpDownloadDir(ctx, apiClient, sandboxId, sandboxRef, remotePath, localPath)
+			count += n
+			if err != nil {
+				return count, err
+			}
+			continue
+		}
+
+		if err := cpDownloadFile(ctx, apiClient, sandboxId, remotePath, localPath); err != nil {
+			return count, err
+		}
+		count++
+		cpReportTransfer("Downloaded", sandboxRef+":"+remotePath, localPath)
+	}
+	return count, nil
+}
+
+// cpDownloadFile downloads a single sandbox file to localPath.
+func cpDownloadFile(ctx context.Context, apiClient *apiclient.APIClient, sandboxId, remotePath, localPath string) error {
+	tmpFile, res, err := apiClient.ToolboxAPI.DownloadFileDeprecated(ctx, sandboxId).Path(remotePath).Execute()
+	if err != nil {
+		return apiclient_cli.HandleErrorResponse(res, err)
+	}
+	return cpWriteLocalFile(tmpFile, localPath)
+}
+
+// cpWriteLocalFile copies the downloaded temp file to localPath, creating
+// parent directories as needed, then closes and removes the temp file.
+func cpWriteLocalFile(tmp *os.File, localPath string) (err error) {
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	defer func() {
+		if closeErr := tmp.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	if dir := filepath.Dir(localPath); dir != "" {
+		if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
+			return mkErr
+		}
+	}
+
+	dst, err := os.Create(localPath)
+	if err != nil {
+		return err
+	}
+	if _, copyErr := io.Copy(dst, tmp); copyErr != nil {
+		_ = dst.Close()
+		return copyErr
+	}
+	return dst.Close()
+}
+
+// cpReportTransfer prints the per-file human progress line; suppressed in
+// --format mode where only the structured summary is emitted.
+func cpReportTransfer(verb, source, destination string) {
+	if common.FormatFlag != "" {
+		return
+	}
+	view_common.RenderInfoMessage(fmt.Sprintf("%s %s -> %s", verb, source, destination))
+}
+
+func init() {
+	common.RegisterFormatFlag(CpCmd)
+}

--- a/apps/cli/cmd/sandbox/cp_test.go
+++ b/apps/cli/cmd/sandbox/cp_test.go
@@ -4,10 +4,20 @@
 package sandbox
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/daytonaio/daytona/cli/internal/clierr"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 )
 
 func TestParseCpEndpoint(t *testing.T) {
@@ -130,5 +140,245 @@ func TestParseCpArgs(t *testing.T) {
 				t.Errorf("parseCpArgs(%q, %q) localPath = %q, want %q", tt.source, tt.destination, req.localPath, tt.wantLocalPath)
 			}
 		})
+	}
+}
+
+func TestCpRequireSourceAndDestination(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "no args", args: nil, wantErr: "missing required arguments: SOURCE and DESTINATION"},
+		{name: "one arg", args: []string{"a.txt"}, wantErr: "missing required arguments: SOURCE and DESTINATION"},
+		{name: "two args", args: []string{"a.txt", "box:/tmp/a.txt"}},
+		{name: "three args", args: []string{"a", "b", "c"}, wantErr: "expected exactly 2 arguments (SOURCE and DESTINATION), received 3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := cpRequireSourceAndDestination(nil, tt.args)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("cpRequireSourceAndDestination(%v) unexpected error: %v", tt.args, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("cpRequireSourceAndDestination(%v) expected error, got nil", tt.args)
+			}
+			if !clierr.HasCategory(err, clierr.CategoryUsage) {
+				t.Errorf("cpRequireSourceAndDestination(%v) error %v is not usage-category", tt.args, err)
+			}
+			if err.Error() != tt.wantErr {
+				t.Errorf("cpRequireSourceAndDestination(%v) error = %q, want %q", tt.args, err.Error(), tt.wantErr)
+			}
+			if code := clierr.ExitCode(err); code != 2 {
+				t.Errorf("cpRequireSourceAndDestination(%v) exit code = %d, want 2", tt.args, code)
+			}
+		})
+	}
+}
+
+const cpTestAuthHeader = "Bearer cp-test-key"
+
+// cpTestApiClient starts an httptest server around mux and returns a
+// generated API client pointed at it, with a static Authorization header so
+// handlers can assert auth propagation.
+func cpTestApiClient(t *testing.T, mux *http.ServeMux) *apiclient.APIClient {
+	t.Helper()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	clientConfig := apiclient.NewConfiguration()
+	clientConfig.Servers = apiclient.ServerConfigurations{{URL: server.URL}}
+	clientConfig.AddDefaultHeader("Authorization", cpTestAuthHeader)
+	return apiclient.NewAPIClient(clientConfig)
+}
+
+// cpTestFileInfoJSON renders a FileInfo payload with every property the
+// generated client requires.
+func cpTestFileInfoJSON(name string, isDir bool, size int) string {
+	return fmt.Sprintf(`{
+		"name": %q,
+		"isDir": %t,
+		"size": %d,
+		"modTime": "2026-01-01T00:00:00Z",
+		"mode": "-rw-r--r--",
+		"permissions": "644",
+		"owner": "daytona",
+		"group": "daytona"
+	}`, name, isDir, size)
+}
+
+func TestCpUploadFileSuccess(t *testing.T) {
+	const content = "hello from local"
+	localPath := filepath.Join(t.TempDir(), "hello.txt")
+	if err := os.WriteFile(localPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var uploadHits int
+	var uploadAuth, uploadPath, uploadBody string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/toolbox/sbx-1/toolbox/files/info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"error":"file not found"}`)
+	})
+	mux.HandleFunc("/toolbox/sbx-1/toolbox/files/folder", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/toolbox/sbx-1/toolbox/files/upload", func(w http.ResponseWriter, r *http.Request) {
+		uploadHits++
+		uploadAuth = r.Header.Get("Authorization")
+		uploadPath = r.URL.Query().Get("path")
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			t.Errorf("upload request has no multipart %q field: %v", "file", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		defer func() { _ = file.Close() }()
+		body, err := io.ReadAll(file)
+		if err != nil {
+			t.Errorf("reading multipart file: %v", err)
+		}
+		uploadBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	apiClient := cpTestApiClient(t, mux)
+
+	n, err := cpUpload(context.Background(), apiClient, "sbx-1", "box", localPath, "/workspace/hello.txt")
+	if err != nil {
+		t.Fatalf("cpUpload() unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("cpUpload() transferred = %d, want 1", n)
+	}
+	if uploadHits != 1 {
+		t.Fatalf("upload endpoint hit %d times, want 1", uploadHits)
+	}
+	if uploadAuth != cpTestAuthHeader {
+		t.Errorf("upload Authorization header = %q, want %q", uploadAuth, cpTestAuthHeader)
+	}
+	if uploadPath != "/workspace/hello.txt" {
+		t.Errorf("upload path query = %q, want %q", uploadPath, "/workspace/hello.txt")
+	}
+	if uploadBody != content {
+		t.Errorf("uploaded body = %q, want %q", uploadBody, content)
+	}
+}
+
+func TestCpDownloadFileSuccess(t *testing.T) {
+	const content = "hello from sandbox"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/toolbox/sbx-1/toolbox/files/info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, cpTestFileInfoJSON("out.txt", false, len(content)))
+	})
+	mux.HandleFunc("/toolbox/sbx-1/toolbox/files/download", func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != cpTestAuthHeader {
+			t.Errorf("download Authorization header = %q, want %q", auth, cpTestAuthHeader)
+		}
+		_, _ = fmt.Fprint(w, content)
+	})
+
+	apiClient := cpTestApiClient(t, mux)
+
+	localDst := filepath.Join(t.TempDir(), "nested", "out.txt")
+	n, err := cpDownload(context.Background(), apiClient, "sbx-1", "box", "/workspace/out.txt", localDst)
+	if err != nil {
+		t.Fatalf("cpDownload() unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("cpDownload() transferred = %d, want 1", n)
+	}
+	got, err := os.ReadFile(localDst)
+	if err != nil {
+		t.Fatalf("reading downloaded file: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("downloaded content = %q, want %q", got, content)
+	}
+}
+
+// Regression test: the generated client returns a nil *os.File for empty
+// response bodies (decode short-circuits on len(b)==0), so an empty remote
+// file must still produce an empty local file.
+func TestCpDownloadEmptyFile(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/toolbox/sbx-1/toolbox/files/info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, cpTestFileInfoJSON("empty.txt", false, 0))
+	})
+	mux.HandleFunc("/toolbox/sbx-1/toolbox/files/download", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	apiClient := cpTestApiClient(t, mux)
+
+	t.Run("creates missing file and parent directories", func(t *testing.T) {
+		localDst := filepath.Join(t.TempDir(), "nested", "empty.txt")
+		n, err := cpDownload(context.Background(), apiClient, "sbx-1", "box", "/workspace/empty.txt", localDst)
+		if err != nil {
+			t.Fatalf("cpDownload() unexpected error: %v", err)
+		}
+		if n != 1 {
+			t.Errorf("cpDownload() transferred = %d, want 1", n)
+		}
+		info, err := os.Stat(localDst)
+		if err != nil {
+			t.Fatalf("empty local file was not created: %v", err)
+		}
+		if info.Size() != 0 {
+			t.Errorf("local file size = %d, want 0", info.Size())
+		}
+	})
+
+	t.Run("truncates existing file", func(t *testing.T) {
+		localDst := filepath.Join(t.TempDir(), "stale.txt")
+		if err := os.WriteFile(localDst, []byte("stale content"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := cpDownload(context.Background(), apiClient, "sbx-1", "box", "/workspace/empty.txt", localDst); err != nil {
+			t.Fatalf("cpDownload() unexpected error: %v", err)
+		}
+		info, err := os.Stat(localDst)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Size() != 0 {
+			t.Errorf("local file size after empty download = %d, want 0 (truncated)", info.Size())
+		}
+	})
+}
+
+func TestCpDownloadRemoteNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/toolbox/sbx-1/toolbox/files/info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"error":"file not found"}`)
+	})
+
+	apiClient := cpTestApiClient(t, mux)
+
+	localDst := filepath.Join(t.TempDir(), "out.txt")
+	_, err := cpDownload(context.Background(), apiClient, "sbx-1", "box", "/workspace/missing.txt", localDst)
+	if err == nil {
+		t.Fatal("cpDownload() expected error for missing remote file, got nil")
+	}
+	if !clierr.HasCategory(err, clierr.CategoryNotFound) {
+		t.Errorf("cpDownload() error %v is not not_found-category", err)
+	}
+	if !strings.Contains(err.Error(), "file not found") {
+		t.Errorf("cpDownload() error = %q, want it to preserve the server message", err.Error())
+	}
+	if _, statErr := os.Stat(localDst); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Errorf("local destination %q should not exist after failed download, stat err = %v", localDst, statErr)
 	}
 }

--- a/apps/cli/cmd/sandbox/cp_test.go
+++ b/apps/cli/cmd/sandbox/cp_test.go
@@ -1,0 +1,134 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package sandbox
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+)
+
+func TestParseCpEndpoint(t *testing.T) {
+	tests := []struct {
+		name        string
+		arg         string
+		wantSandbox string
+		wantPath    string
+		wantRemote  bool
+	}{
+		{name: "plain local path", arg: "foo/bar.txt", wantPath: "foo/bar.txt"},
+		{name: "sandbox with absolute path", arg: "box:/tmp/a", wantSandbox: "box", wantPath: "/tmp/a", wantRemote: true},
+		{name: "sandbox with relative path", arg: "my-sandbox:data/x.csv", wantSandbox: "my-sandbox", wantPath: "data/x.csv", wantRemote: true},
+		{name: "windows drive letter absolute", arg: `C:\foo\bar`, wantPath: `C:\foo\bar`},
+		{name: "windows drive letter relative", arg: "C:foo", wantPath: "C:foo"},
+		{name: "dot relative path without colon", arg: "./x", wantPath: "./x"},
+		{name: "dot prefix with colon", arg: ".:y", wantPath: ".:y"},
+		{name: "dot-dot prefix with colon", arg: "..:y", wantPath: "..:y"},
+		{name: "empty prefix", arg: ":/tmp/a", wantPath: ":/tmp/a"},
+		{name: "colon in remote path", arg: "box:/a:b", wantSandbox: "box", wantPath: "/a:b", wantRemote: true},
+		{name: "remote with empty path", arg: "box:", wantSandbox: "box", wantPath: "", wantRemote: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sandbox, filePath, remote := parseCpEndpoint(tt.arg)
+			if remote != tt.wantRemote {
+				t.Fatalf("parseCpEndpoint(%q) remote = %v, want %v", tt.arg, remote, tt.wantRemote)
+			}
+			if sandbox != tt.wantSandbox {
+				t.Errorf("parseCpEndpoint(%q) sandbox = %q, want %q", tt.arg, sandbox, tt.wantSandbox)
+			}
+			if filePath != tt.wantPath {
+				t.Errorf("parseCpEndpoint(%q) path = %q, want %q", tt.arg, filePath, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestParseCpArgs(t *testing.T) {
+	tests := []struct {
+		name           string
+		source         string
+		destination    string
+		wantErr        bool
+		wantUpload     bool
+		wantSandboxRef string
+		wantRemotePath string
+		wantLocalPath  string
+	}{
+		{
+			name:           "upload direction",
+			source:         "./local.txt",
+			destination:    "box:/tmp/remote.txt",
+			wantUpload:     true,
+			wantSandboxRef: "box",
+			wantRemotePath: "/tmp/remote.txt",
+			wantLocalPath:  "./local.txt",
+		},
+		{
+			name:           "download direction",
+			source:         "my-sandbox:/var/log/app.log",
+			destination:    "out/app.log",
+			wantUpload:     false,
+			wantSandboxRef: "my-sandbox",
+			wantRemotePath: "/var/log/app.log",
+			wantLocalPath:  "out/app.log",
+		},
+		{
+			name:           "empty remote path defaults to working directory",
+			source:         "box:",
+			destination:    "out",
+			wantUpload:     false,
+			wantSandboxRef: "box",
+			wantRemotePath: ".",
+			wantLocalPath:  "out",
+		},
+		{
+			name:           "windows source stays local",
+			source:         `C:\data\file.bin`,
+			destination:    "box:/tmp/file.bin",
+			wantUpload:     true,
+			wantSandboxRef: "box",
+			wantRemotePath: "/tmp/file.bin",
+			wantLocalPath:  `C:\data\file.bin`,
+		},
+		{name: "both remote rejected", source: "box-a:/tmp/x", destination: "box-b:/tmp/y", wantErr: true},
+		{name: "both local rejected", source: "a.txt", destination: "b.txt", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := parseCpArgs(tt.source, tt.destination)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseCpArgs(%q, %q) expected error, got nil", tt.source, tt.destination)
+				}
+				var cliErr *clierr.Error
+				if !errors.As(err, &cliErr) {
+					t.Fatalf("parseCpArgs(%q, %q) error type = %T, want *clierr.Error", tt.source, tt.destination, err)
+				}
+				if cliErr.Category != clierr.CategoryUsage {
+					t.Errorf("parseCpArgs(%q, %q) error category = %q, want %q", tt.source, tt.destination, cliErr.Category, clierr.CategoryUsage)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseCpArgs(%q, %q) unexpected error: %v", tt.source, tt.destination, err)
+			}
+			if req.upload != tt.wantUpload {
+				t.Errorf("parseCpArgs(%q, %q) upload = %v, want %v", tt.source, tt.destination, req.upload, tt.wantUpload)
+			}
+			if req.sandboxRef != tt.wantSandboxRef {
+				t.Errorf("parseCpArgs(%q, %q) sandboxRef = %q, want %q", tt.source, tt.destination, req.sandboxRef, tt.wantSandboxRef)
+			}
+			if req.remotePath != tt.wantRemotePath {
+				t.Errorf("parseCpArgs(%q, %q) remotePath = %q, want %q", tt.source, tt.destination, req.remotePath, tt.wantRemotePath)
+			}
+			if req.localPath != tt.wantLocalPath {
+				t.Errorf("parseCpArgs(%q, %q) localPath = %q, want %q", tt.source, tt.destination, req.localPath, tt.wantLocalPath)
+			}
+		})
+	}
+}

--- a/apps/cli/cmd/sandbox/create.go
+++ b/apps/cli/cmd/sandbox/create.go
@@ -23,8 +23,11 @@ import (
 const SANDBOX_TERMINAL_PORT = 22222
 
 var CreateCmd = &cobra.Command{
-	Use:     "create [flags]",
-	Short:   "Create a new sandbox",
+	Use:   "create [flags]",
+	Short: "Create a new sandbox",
+	Example: `  daytona create --snapshot my-snapshot:1.0 --name my-sandbox
+  daytona create --name my-sandbox --env-file .env --if-exists reuse
+  daytona create --snapshot my-snapshot:1.0 --name my-sandbox --format json`,
 	Args:    cobra.NoArgs,
 	Aliases: common.GetAliases("create"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/sandbox/create.go
+++ b/apps/cli/cmd/sandbox/create.go
@@ -5,7 +5,6 @@ package sandbox
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -125,8 +124,7 @@ var CreateCmd = &cobra.Command{
 		sandbox, res, err := apiClient.SandboxAPI.CreateSandbox(ctx).CreateSandbox(*createSandbox).Execute()
 		if err != nil {
 			createErr := apiclient_cli.HandleErrorResponse(res, err)
-			var cliErr *clierr.Error
-			if createIfExistsFlag != "reuse" || !errors.As(createErr, &cliErr) || cliErr.Category != clierr.CategoryConflict {
+			if createIfExistsFlag != "reuse" || !clierr.HasCategory(createErr, clierr.CategoryConflict) {
 				return createErr
 			}
 			existing, res, err := apiClient.SandboxAPI.GetSandbox(ctx, nameFlag).Execute()

--- a/apps/cli/cmd/sandbox/create.go
+++ b/apps/cli/cmd/sandbox/create.go
@@ -5,14 +5,15 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	"github.com/daytonaio/daytona/cli/util"
 	views_common "github.com/daytonaio/daytona/cli/views/common"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
@@ -28,6 +29,15 @@ var CreateCmd = &cobra.Command{
 	Aliases: common.GetAliases("create"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
+
+		switch createIfExistsFlag {
+		case "error", "reuse":
+		default:
+			return clierr.Newf(clierr.CategoryUsage, "invalid --if-exists value %q: must be one of error, reuse", createIfExistsFlag)
+		}
+		if createIfExistsFlag == "reuse" && nameFlag == "" {
+			return clierr.New(clierr.CategoryUsage, "--if-exists reuse requires --name")
+		}
 
 		apiClient, err := apiclient_cli.GetApiClient(nil, nil)
 		if err != nil {
@@ -46,24 +56,18 @@ var CreateCmd = &cobra.Command{
 		if userFlag != "" {
 			createSandbox.SetUser(userFlag)
 		}
-		if len(envFlag) > 0 {
-			env := make(map[string]string)
-			for _, e := range envFlag {
-				parts := strings.SplitN(e, "=", 2)
-				if len(parts) == 2 {
-					env[parts[0]] = parts[1]
-				}
-			}
+		env, err := common.ResolveKeyValuePairs(envFlag, createEnvFileFlag, "env")
+		if err != nil {
+			return err
+		}
+		if len(env) > 0 {
 			createSandbox.SetEnv(env)
 		}
-		if len(labelsFlag) > 0 {
-			labels := make(map[string]string)
-			for _, l := range labelsFlag {
-				parts := strings.SplitN(l, "=", 2)
-				if len(parts) == 2 {
-					labels[parts[0]] = parts[1]
-				}
-			}
+		labels, err := common.ResolveKeyValuePairs(labelsFlag, createLabelFileFlag, "label")
+		if err != nil {
+			return err
+		}
+		if len(labels) > 0 {
 			createSandbox.SetLabels(labels)
 		}
 		if publicFlag {
@@ -106,44 +110,35 @@ var CreateCmd = &cobra.Command{
 		}
 
 		if len(volumesFlag) > 0 {
-			volumes := make([]apiclient.SandboxVolume, 0, len(volumesFlag))
-			for _, v := range volumesFlag {
-				parts := strings.SplitN(v, ":", 2)
-				if len(parts) == 2 {
-					volumeId := parts[0]
-					mountPath := parts[1]
-					volume := apiclient.SandboxVolume{
-						VolumeId:  volumeId,
-						MountPath: mountPath,
-					}
-					volumes = append(volumes, volume)
-				}
+			volumes, err := common.ParseVolumeSpecs(volumesFlag)
+			if err != nil {
+				return err
 			}
-			if len(volumes) > 0 {
-				createSandbox.SetVolumes(volumes)
-			}
+			createSandbox.SetVolumes(volumes)
 		}
 
 		var sandbox *apiclient.Sandbox
 
 		sandbox, res, err := apiClient.SandboxAPI.CreateSandbox(ctx).CreateSandbox(*createSandbox).Execute()
 		if err != nil {
-			return apiclient_cli.HandleErrorResponse(res, err)
+			createErr := apiclient_cli.HandleErrorResponse(res, err)
+			var cliErr *clierr.Error
+			if createIfExistsFlag != "reuse" || !errors.As(createErr, &cliErr) || cliErr.Category != clierr.CategoryConflict {
+				return createErr
+			}
+			existing, res, err := apiClient.SandboxAPI.GetSandbox(ctx, nameFlag).Execute()
+			if err != nil {
+				return apiclient_cli.HandleErrorResponse(res, err)
+			}
+			sandbox = existing
+			if common.FormatFlag == "" {
+				views_common.RenderInfoMessage(fmt.Sprintf("Sandbox '%s' already exists, reusing it", nameFlag))
+			}
 		}
 
 		if sandbox.State != nil && *sandbox.State == apiclient.SANDBOXSTATE_PENDING_BUILD {
-			c, err := config.GetConfig()
-			if err != nil {
-				return err
-			}
-
-			activeProfile, err := c.GetActiveProfile()
-			if err != nil {
-				return err
-			}
-
 			// Accept any post-pending state — transient states can be skipped between polls.
-			err = common.AwaitSandboxState(ctx, apiClient, sandbox.Id, 0,
+			err = common.AwaitSandboxState(ctx, apiClient, sandbox.Id, createTimeoutFlag,
 				apiclient.SANDBOXSTATE_BUILDING_SNAPSHOT,
 				apiclient.SANDBOXSTATE_PULLING_SNAPSHOT,
 				apiclient.SANDBOXSTATE_STARTING,
@@ -153,28 +148,54 @@ var CreateCmd = &cobra.Command{
 				return err
 			}
 
-			logsContext, stopLogs := context.WithCancel(context.Background())
-			defer stopLogs()
+			stopLogs := func() {}
+			if common.FormatFlag == "" {
+				c, err := config.GetConfig()
+				if err != nil {
+					return err
+				}
 
-			go func() {
-				_ = common.ReadBuildLogs(logsContext, common.ReadLogParams{
-					Id:                   sandbox.Id,
-					ServerUrl:            activeProfile.Api.Url,
-					ServerApi:            activeProfile.Api,
-					ActiveOrganizationId: activeProfile.ActiveOrganizationId,
-					Follow:               util.Pointer(true),
-					ResourceType:         common.ResourceTypeSandbox,
-				})
-			}()
+				activeProfile, err := c.GetActiveProfile()
+				if err != nil {
+					return err
+				}
 
-			err = common.AwaitSandboxState(ctx, apiClient, sandbox.Id, 0, apiclient.SANDBOXSTATE_STARTED)
+				logsContext, cancelLogs := context.WithCancel(context.Background())
+				defer cancelLogs()
+				stopLogs = cancelLogs
+
+				go func() {
+					_ = common.ReadBuildLogs(logsContext, common.ReadLogParams{
+						Id:                   sandbox.Id,
+						ServerUrl:            activeProfile.Api.Url,
+						ServerApi:            activeProfile.Api,
+						ActiveOrganizationId: activeProfile.ActiveOrganizationId,
+						Follow:               util.Pointer(true),
+						ResourceType:         common.ResourceTypeSandbox,
+					})
+				}()
+			}
+
+			err = common.AwaitSandboxState(ctx, apiClient, sandbox.Id, createTimeoutFlag, apiclient.SANDBOXSTATE_STARTED)
 			if err != nil {
 				return err
 			}
 
-			// Wait for the last logs to be read
-			time.Sleep(250 * time.Millisecond)
+			if common.FormatFlag == "" {
+				// Wait for the last logs to be read
+				time.Sleep(250 * time.Millisecond)
+			}
 			stopLogs()
+		}
+
+		if common.FormatFlag != "" {
+			freshSandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, sandbox.Id).Execute()
+			if err != nil {
+				return apiclient_cli.HandleErrorResponse(res, err)
+			}
+			formattedData := common.NewFormatter(freshSandbox)
+			formattedData.Print()
+			return nil
 		}
 
 		previewUrl, res, err := apiClient.SandboxAPI.GetPortPreviewUrl(ctx, sandbox.Id, SANDBOX_TERMINAL_PORT).Execute()
@@ -211,6 +232,10 @@ var (
 	contextFlag          []string
 	networkBlockAllFlag  bool
 	networkAllowListFlag string
+	createEnvFileFlag    string
+	createLabelFileFlag  string
+	createIfExistsFlag   string
+	createTimeoutFlag    time.Duration
 )
 
 func init() {
@@ -233,7 +258,13 @@ func init() {
 	CreateCmd.Flags().StringArrayVarP(&contextFlag, "context", "c", []string{}, "Files or directories to include in the build context (can be specified multiple times)")
 	CreateCmd.Flags().BoolVar(&networkBlockAllFlag, "network-block-all", false, "Whether to block all network access for the sandbox")
 	CreateCmd.Flags().StringVar(&networkAllowListFlag, "network-allow-list", "", "Comma-separated list of allowed CIDR network addresses for the sandbox")
+	CreateCmd.Flags().StringVar(&createEnvFileFlag, "env-file", "", "Read environment variables from a dotenv-style file (entries from --env override file values)")
+	CreateCmd.Flags().StringVar(&createLabelFileFlag, "label-file", "", "Read labels from a dotenv-style file (entries from --label override file values)")
+	CreateCmd.Flags().StringVar(&createIfExistsFlag, "if-exists", "error", "Behavior when a sandbox with the same name already exists (error, reuse; reuse requires --name)")
+	CreateCmd.Flags().DurationVar(&createTimeoutFlag, "timeout", 0, "Maximum time to wait for the sandbox to start (0 means wait indefinitely)")
 
 	CreateCmd.MarkFlagsMutuallyExclusive("snapshot", "dockerfile")
 	CreateCmd.MarkFlagsMutuallyExclusive("snapshot", "context")
+
+	common.RegisterFormatFlagNoShorthand(CreateCmd)
 }

--- a/apps/cli/cmd/sandbox/create.go
+++ b/apps/cli/cmd/sandbox/create.go
@@ -143,7 +143,7 @@ var CreateCmd = &cobra.Command{
 			}
 
 			// Accept any post-pending state — transient states can be skipped between polls.
-			err = common.AwaitSandboxState(ctx, apiClient, sandbox.Id,
+			err = common.AwaitSandboxState(ctx, apiClient, sandbox.Id, 0,
 				apiclient.SANDBOXSTATE_BUILDING_SNAPSHOT,
 				apiclient.SANDBOXSTATE_PULLING_SNAPSHOT,
 				apiclient.SANDBOXSTATE_STARTING,
@@ -156,16 +156,18 @@ var CreateCmd = &cobra.Command{
 			logsContext, stopLogs := context.WithCancel(context.Background())
 			defer stopLogs()
 
-			go common.ReadBuildLogs(logsContext, common.ReadLogParams{
-				Id:                   sandbox.Id,
-				ServerUrl:            activeProfile.Api.Url,
-				ServerApi:            activeProfile.Api,
-				ActiveOrganizationId: activeProfile.ActiveOrganizationId,
-				Follow:               util.Pointer(true),
-				ResourceType:         common.ResourceTypeSandbox,
-			})
+			go func() {
+				_ = common.ReadBuildLogs(logsContext, common.ReadLogParams{
+					Id:                   sandbox.Id,
+					ServerUrl:            activeProfile.Api.Url,
+					ServerApi:            activeProfile.Api,
+					ActiveOrganizationId: activeProfile.ActiveOrganizationId,
+					Follow:               util.Pointer(true),
+					ResourceType:         common.ResourceTypeSandbox,
+				})
+			}()
 
-			err = common.AwaitSandboxState(ctx, apiClient, sandbox.Id, apiclient.SANDBOXSTATE_STARTED)
+			err = common.AwaitSandboxState(ctx, apiClient, sandbox.Id, 0, apiclient.SANDBOXSTATE_STARTED)
 			if err != nil {
 				return err
 			}

--- a/apps/cli/cmd/sandbox/delete.go
+++ b/apps/cli/cmd/sandbox/delete.go
@@ -64,8 +64,12 @@ type deleteSingleResult struct {
 }
 
 var DeleteCmd = &cobra.Command{
-	Use:     "delete [SANDBOX_ID | SANDBOX_NAME]",
-	Short:   "Delete a sandbox",
+	Use:   "delete [SANDBOX_ID | SANDBOX_NAME]",
+	Short: "Delete a sandbox",
+	Example: `  daytona delete my-sandbox
+  daytona delete my-sandbox --wait --format json
+  daytona delete --all --dry-run
+  daytona delete --all --yes`,
 	Args:    cobra.MaximumNArgs(1),
 	Aliases: common.GetAliases("delete"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/sandbox/delete.go
+++ b/apps/cli/cmd/sandbox/delete.go
@@ -75,26 +75,21 @@ var DeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
+		if len(args) == 0 && !allFlag {
+			return clierr.New(clierr.CategoryUsage, "missing required argument: sandbox ID or name (or pass --all)")
+		}
+
 		apiClient, err := apiclient_cli.GetApiClient(nil, nil)
 		if err != nil {
 			return err
 		}
 
 		if len(args) == 0 {
-			if allFlag {
-				return deleteAllSandboxes(ctx, apiClient)
-			}
-			return cmd.Help()
+			return deleteAllSandboxes(ctx, apiClient)
 		}
 
 		return deleteSingleSandbox(ctx, apiClient, args[0])
 	},
-}
-
-// deleteIsNotFound reports whether err is a not_found CLI error.
-func deleteIsNotFound(err error) bool {
-	var cliErr *clierr.Error
-	return errors.As(err, &cliErr) && cliErr.Category == clierr.CategoryNotFound
 }
 
 // sandboxDryRunResult builds the dry-run payload for the given sandboxes.
@@ -130,7 +125,7 @@ func awaitSandboxDeleted(ctx context.Context, apiClient *apiclient.APIClient, id
 		sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, id).Execute()
 		if err != nil {
 			handled := apiclient_cli.HandleErrorResponse(res, err)
-			if deleteIsNotFound(handled) {
+			if clierr.HasCategory(handled, clierr.CategoryNotFound) {
 				return nil
 			}
 			return handled
@@ -266,7 +261,7 @@ func deleteSingleSandbox(ctx context.Context, apiClient *apiclient.APIClient, sa
 	sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, sandboxIdOrNameArg).Execute()
 	if err != nil {
 		handled := apiclient_cli.HandleErrorResponse(res, err)
-		if deleteIgnoreNotFoundFlag && deleteIsNotFound(handled) {
+		if deleteIgnoreNotFoundFlag && clierr.HasCategory(handled, clierr.CategoryNotFound) {
 			return sandboxNotFoundOutput(sandboxIdOrNameArg)
 		}
 		return handled
@@ -293,7 +288,7 @@ func deleteSingleSandbox(ctx context.Context, apiClient *apiclient.APIClient, sa
 	_, res, err = apiClient.SandboxAPI.DeleteSandbox(ctx, sandbox.Id).Execute()
 	if err != nil {
 		handled := apiclient_cli.HandleErrorResponse(res, err)
-		if deleteIgnoreNotFoundFlag && deleteIsNotFound(handled) {
+		if deleteIgnoreNotFoundFlag && clierr.HasCategory(handled, clierr.CategoryNotFound) {
 			return sandboxNotFoundOutput(sandboxIdOrNameArg)
 		}
 		return handled

--- a/apps/cli/cmd/sandbox/delete.go
+++ b/apps/cli/cmd/sandbox/delete.go
@@ -5,12 +5,14 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
+	"time"
 
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	view_common "github.com/daytonaio/daytona/cli/views/common"
 	views_util "github.com/daytonaio/daytona/cli/views/util"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
@@ -19,8 +21,50 @@ import (
 
 const spinnerThreshold = 10
 
+// deleteDryRunItem describes one sandbox that would be deleted.
+type deleteDryRunItem struct {
+	Id    string `json:"id" yaml:"id"`
+	Name  string `json:"name" yaml:"name"`
+	State string `json:"state" yaml:"state"`
+}
+
+// deleteDryRunResult is the structured output of `delete --dry-run`.
+type deleteDryRunResult struct {
+	DryRun    bool               `json:"dryRun" yaml:"dryRun"`
+	Count     int                `json:"count" yaml:"count"`
+	Sandboxes []deleteDryRunItem `json:"sandboxes" yaml:"sandboxes"`
+}
+
+type deleteBulkDeletedItem struct {
+	Id   string `json:"id" yaml:"id"`
+	Name string `json:"name" yaml:"name"`
+}
+
+type deleteBulkFailedItem struct {
+	Id    string `json:"id" yaml:"id"`
+	Error string `json:"error" yaml:"error"`
+}
+
+// deleteBulkResult is the structured output of `delete --all`. Deleted and
+// Failed are always non-nil so both keys appear in the output.
+type deleteBulkResult struct {
+	DryRun  bool                    `json:"dryRun" yaml:"dryRun"`
+	Count   int                     `json:"count" yaml:"count"`
+	Deleted []deleteBulkDeletedItem `json:"deleted" yaml:"deleted"`
+	Failed  []deleteBulkFailedItem  `json:"failed" yaml:"failed"`
+}
+
+// deleteSingleResult is the structured output of a single sandbox delete.
+// Name is a pointer so a missing sandbox renders "name": null.
+type deleteSingleResult struct {
+	Id      string  `json:"id" yaml:"id"`
+	Name    *string `json:"name" yaml:"name"`
+	Deleted bool    `json:"deleted" yaml:"deleted"`
+	Found   bool    `json:"found" yaml:"found"`
+}
+
 var DeleteCmd = &cobra.Command{
-	Use:     "delete [SANDBOX_ID] | [SANDBOX_NAME]",
+	Use:     "delete [SANDBOX_ID | SANDBOX_NAME]",
 	Short:   "Delete a sandbox",
 	Args:    cobra.MaximumNArgs(1),
 	Aliases: common.GetAliases("delete"),
@@ -32,93 +76,266 @@ var DeleteCmd = &cobra.Command{
 			return err
 		}
 
-		// Handle case when no sandbox ID is provided and allFlag is true
 		if len(args) == 0 {
 			if allFlag {
-				var cursor *string
-				limit := float32(200.0) // 200 is the maximum limit for the API
-				var allSandboxes []apiclient.SandboxListItem
-
-				for {
-					request := apiClient.SandboxAPI.ListSandboxes(ctx).Limit(limit)
-					if cursor != nil {
-						request = request.Cursor(*cursor)
-					}
-
-					sandboxBatch, res, err := request.Execute()
-					if err != nil {
-						return apiclient_cli.HandleErrorResponse(res, err)
-					}
-
-					allSandboxes = append(allSandboxes, sandboxBatch.Items...)
-
-					if !sandboxBatch.NextCursor.IsSet() || sandboxBatch.NextCursor.Get() == nil {
-						break
-					}
-					cursor = sandboxBatch.NextCursor.Get()
-				}
-
-				if len(allSandboxes) == 0 {
-					view_common.RenderInfoMessageBold("No sandboxes to delete")
-					return nil
-				}
-
-				var deletedCount int64
-
-				deleteFn := func() error {
-					var wg sync.WaitGroup
-					sem := make(chan struct{}, 10) // limit to 10 concurrent deletes
-
-					for _, sb := range allSandboxes {
-						wg.Add(1)
-						go func(sb apiclient.SandboxListItem) {
-							defer wg.Done()
-							sem <- struct{}{}
-							defer func() { <-sem }()
-
-							_, res, err := apiClient.SandboxAPI.DeleteSandbox(ctx, sb.Id).Execute()
-							if err != nil {
-								fmt.Printf("Failed to delete sandbox %s: %s\n", sb.Id, apiclient_cli.HandleErrorResponse(res, err))
-							} else {
-								atomic.AddInt64(&deletedCount, 1)
-							}
-						}(sb)
-					}
-					wg.Wait()
-					return nil
-				}
-
-				if len(allSandboxes) > spinnerThreshold {
-					err = views_util.WithInlineSpinner("Deleting all sandboxes", deleteFn)
-				} else {
-					err = deleteFn()
-				}
-				if err != nil {
-					return err
-				}
-
-				view_common.RenderInfoMessageBold(fmt.Sprintf("Deleted %d sandboxes", atomic.LoadInt64(&deletedCount)))
-				return nil
+				return deleteAllSandboxes(ctx, apiClient)
 			}
 			return cmd.Help()
 		}
 
-		// Handle case when a sandbox ID is provided
-		sandboxIdOrNameArg := args[0]
+		return deleteSingleSandbox(ctx, apiClient, args[0])
+	},
+}
 
-		_, res, err := apiClient.SandboxAPI.DeleteSandbox(ctx, sandboxIdOrNameArg).Execute()
+// deleteIsNotFound reports whether err is a not_found CLI error.
+func deleteIsNotFound(err error) bool {
+	var cliErr *clierr.Error
+	return errors.As(err, &cliErr) && cliErr.Category == clierr.CategoryNotFound
+}
+
+// sandboxDryRunResult builds the dry-run payload for the given sandboxes.
+func sandboxDryRunResult(items []apiclient.SandboxListItem) deleteDryRunResult {
+	result := deleteDryRunResult{DryRun: true, Count: len(items), Sandboxes: []deleteDryRunItem{}}
+	for _, sb := range items {
+		var state string
+		if sb.State != nil {
+			state = string(*sb.State)
+		}
+		result.Sandboxes = append(result.Sandboxes, deleteDryRunItem{Id: sb.Id, Name: sb.Name, State: state})
+	}
+	return result
+}
+
+// newDeleteBulkResult builds an empty bulk-delete payload with non-nil
+// Deleted and Failed slices.
+func newDeleteBulkResult(count int) deleteBulkResult {
+	return deleteBulkResult{Count: count, Deleted: []deleteBulkDeletedItem{}, Failed: []deleteBulkFailedItem{}}
+}
+
+// awaitSandboxDeleted polls the sandbox until the API reports it gone
+// (not found) or its state is DESTROYED. A timeout <= 0 waits indefinitely.
+func awaitSandboxDeleted(ctx context.Context, apiClient *apiclient.APIClient, id string, timeout time.Duration) error {
+	var expired <-chan time.Time
+	if timeout > 0 {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		expired = timer.C
+	}
+
+	for {
+		sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, id).Execute()
+		if err != nil {
+			handled := apiclient_cli.HandleErrorResponse(res, err)
+			if deleteIsNotFound(handled) {
+				return nil
+			}
+			return handled
+		}
+
+		if sandbox.State != nil && *sandbox.State == apiclient.SANDBOXSTATE_DESTROYED {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-expired:
+			return clierr.Newf(clierr.CategoryTimeout, "timed out after %s waiting for sandbox %q to be deleted", timeout, id)
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func deleteAllSandboxes(ctx context.Context, apiClient *apiclient.APIClient) error {
+	var cursor *string
+	limit := float32(200.0) // 200 is the maximum limit for the API
+	var allSandboxes []apiclient.SandboxListItem
+
+	for {
+		request := apiClient.SandboxAPI.ListSandboxes(ctx).Limit(limit)
+		if cursor != nil {
+			request = request.Cursor(*cursor)
+		}
+
+		sandboxBatch, res, err := request.Execute()
 		if err != nil {
 			return apiclient_cli.HandleErrorResponse(res, err)
 		}
 
-		view_common.RenderInfoMessageBold(fmt.Sprintf("Sandbox %s deleted", sandboxIdOrNameArg))
+		allSandboxes = append(allSandboxes, sandboxBatch.Items...)
 
+		if !sandboxBatch.NextCursor.IsSet() || sandboxBatch.NextCursor.Get() == nil {
+			break
+		}
+		cursor = sandboxBatch.NextCursor.Get()
+	}
+
+	if deleteDryRunFlag {
+		if common.FormatFlag != "" {
+			common.NewFormatter(sandboxDryRunResult(allSandboxes)).Print()
+			return nil
+		}
+		if len(allSandboxes) == 0 {
+			view_common.RenderInfoMessageBold("No sandboxes to delete")
+			return nil
+		}
+		for _, sb := range allSandboxes {
+			view_common.RenderInfoMessage(fmt.Sprintf("Would delete sandbox %s (%s)", sb.Name, sb.Id))
+		}
 		return nil
-	},
+	}
+
+	if len(allSandboxes) == 0 {
+		if common.FormatFlag != "" {
+			common.NewFormatter(newDeleteBulkResult(0)).Print()
+			return nil
+		}
+		view_common.RenderInfoMessageBold("No sandboxes to delete")
+		return nil
+	}
+
+	if !deleteYesFlag {
+		confirmed, err := view_common.Confirm(fmt.Sprintf("Delete %d sandboxes?", len(allSandboxes)))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return errors.New("aborted")
+		}
+	}
+
+	result := newDeleteBulkResult(len(allSandboxes))
+
+	deleteFn := func() error {
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		sem := make(chan struct{}, 10) // limit to 10 concurrent deletes
+
+		for _, sb := range allSandboxes {
+			wg.Add(1)
+			go func(sb apiclient.SandboxListItem) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+
+				_, res, err := apiClient.SandboxAPI.DeleteSandbox(ctx, sb.Id).Execute()
+				if err != nil {
+					err = apiclient_cli.HandleErrorResponse(res, err)
+				} else if deleteWaitFlag {
+					err = awaitSandboxDeleted(ctx, apiClient, sb.Id, deleteTimeoutFlag)
+				}
+
+				mu.Lock()
+				defer mu.Unlock()
+				if err != nil {
+					if common.FormatFlag == "" {
+						fmt.Printf("Failed to delete sandbox %s: %s\n", sb.Id, err)
+					}
+					result.Failed = append(result.Failed, deleteBulkFailedItem{Id: sb.Id, Error: err.Error()})
+				} else {
+					result.Deleted = append(result.Deleted, deleteBulkDeletedItem{Id: sb.Id, Name: sb.Name})
+				}
+			}(sb)
+		}
+		wg.Wait()
+		return nil
+	}
+
+	if common.FormatFlag == "" && len(allSandboxes) > spinnerThreshold {
+		if err := views_util.WithInlineSpinner("Deleting all sandboxes", deleteFn); err != nil {
+			return err
+		}
+	} else if err := deleteFn(); err != nil {
+		return err
+	}
+
+	if common.FormatFlag != "" {
+		common.NewFormatter(result).Print()
+		return nil
+	}
+
+	view_common.RenderInfoMessageBold(fmt.Sprintf("Deleted %d sandboxes", len(result.Deleted)))
+	return nil
 }
 
-var allFlag bool
+func deleteSingleSandbox(ctx context.Context, apiClient *apiclient.APIClient, sandboxIdOrNameArg string) error {
+	sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, sandboxIdOrNameArg).Execute()
+	if err != nil {
+		handled := apiclient_cli.HandleErrorResponse(res, err)
+		if deleteIgnoreNotFoundFlag && deleteIsNotFound(handled) {
+			return sandboxNotFoundOutput(sandboxIdOrNameArg)
+		}
+		return handled
+	}
+
+	if deleteDryRunFlag {
+		if common.FormatFlag != "" {
+			var state string
+			if sandbox.State != nil {
+				state = string(*sandbox.State)
+			}
+			result := deleteDryRunResult{
+				DryRun:    true,
+				Count:     1,
+				Sandboxes: []deleteDryRunItem{{Id: sandbox.Id, Name: sandbox.Name, State: state}},
+			}
+			common.NewFormatter(result).Print()
+			return nil
+		}
+		view_common.RenderInfoMessage(fmt.Sprintf("Would delete sandbox %s (%s)", sandbox.Name, sandbox.Id))
+		return nil
+	}
+
+	_, res, err = apiClient.SandboxAPI.DeleteSandbox(ctx, sandbox.Id).Execute()
+	if err != nil {
+		handled := apiclient_cli.HandleErrorResponse(res, err)
+		if deleteIgnoreNotFoundFlag && deleteIsNotFound(handled) {
+			return sandboxNotFoundOutput(sandboxIdOrNameArg)
+		}
+		return handled
+	}
+
+	if deleteWaitFlag {
+		if err := awaitSandboxDeleted(ctx, apiClient, sandbox.Id, deleteTimeoutFlag); err != nil {
+			return err
+		}
+	}
+
+	if common.FormatFlag != "" {
+		name := sandbox.Name
+		common.NewFormatter(deleteSingleResult{Id: sandbox.Id, Name: &name, Deleted: true, Found: true}).Print()
+		return nil
+	}
+
+	view_common.RenderInfoMessageBold(fmt.Sprintf("Sandbox %s deleted", sandboxIdOrNameArg))
+	return nil
+}
+
+// sandboxNotFoundOutput reports a missing sandbox as success (--ignore-not-found).
+func sandboxNotFoundOutput(arg string) error {
+	if common.FormatFlag != "" {
+		common.NewFormatter(deleteSingleResult{Id: arg, Name: nil, Deleted: false, Found: false}).Print()
+		return nil
+	}
+	view_common.RenderInfoMessageBold(fmt.Sprintf("Sandbox %s not found, nothing to delete", arg))
+	return nil
+}
+
+var (
+	allFlag                  bool
+	deleteYesFlag            bool
+	deleteDryRunFlag         bool
+	deleteIgnoreNotFoundFlag bool
+	deleteWaitFlag           bool
+	deleteTimeoutFlag        time.Duration
+)
 
 func init() {
 	DeleteCmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Delete all sandboxes")
+	DeleteCmd.Flags().BoolVarP(&deleteYesFlag, "yes", "y", false, "Skip the confirmation prompt for bulk deletes")
+	DeleteCmd.Flags().BoolVar(&deleteDryRunFlag, "dry-run", false, "Show what would be deleted without deleting anything")
+	DeleteCmd.Flags().BoolVar(&deleteIgnoreNotFoundFlag, "ignore-not-found", false, "Treat a missing sandbox as a successful delete")
+	DeleteCmd.Flags().BoolVar(&deleteWaitFlag, "wait", false, "Wait until the sandbox is fully deleted")
+	DeleteCmd.Flags().DurationVar(&deleteTimeoutFlag, "timeout", 5*time.Minute, "Maximum time to wait with --wait (0 waits indefinitely)")
+	common.RegisterFormatFlag(DeleteCmd)
 }

--- a/apps/cli/cmd/sandbox/delete_test.go
+++ b/apps/cli/cmd/sandbox/delete_test.go
@@ -1,0 +1,119 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package sandbox
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+)
+
+func TestDeleteIsNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "plain error", err: errors.New("boom"), want: false},
+		{name: "not found clierr", err: clierr.New(clierr.CategoryNotFound, "sandbox not found"), want: true},
+		{name: "other category clierr", err: clierr.New(clierr.CategoryServer, "internal error"), want: false},
+		{name: "wrapped not found", err: fmt.Errorf("context: %w", clierr.New(clierr.CategoryNotFound, "gone")), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deleteIsNotFound(tt.err); got != tt.want {
+				t.Errorf("deleteIsNotFound(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSandboxDryRunResult(t *testing.T) {
+	state := apiclient.SANDBOXSTATE_STARTED
+	items := []apiclient.SandboxListItem{
+		{Id: "id-1", Name: "one", State: &state},
+		{Id: "id-2", Name: "two"},
+	}
+
+	result := sandboxDryRunResult(items)
+
+	if !result.DryRun {
+		t.Error("DryRun = false, want true")
+	}
+	if result.Count != 2 {
+		t.Errorf("Count = %d, want 2", result.Count)
+	}
+	if len(result.Sandboxes) != 2 {
+		t.Fatalf("len(Sandboxes) = %d, want 2", len(result.Sandboxes))
+	}
+	if result.Sandboxes[0].Id != "id-1" || result.Sandboxes[0].Name != "one" || result.Sandboxes[0].State != "started" {
+		t.Errorf("Sandboxes[0] = %+v, want {id-1 one started}", result.Sandboxes[0])
+	}
+	if result.Sandboxes[1].State != "" {
+		t.Errorf("Sandboxes[1].State = %q, want empty for nil state", result.Sandboxes[1].State)
+	}
+}
+
+func TestSandboxDryRunResultEmptyMarshalsArray(t *testing.T) {
+	data, err := json.Marshal(sandboxDryRunResult(nil))
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"sandboxes":[]`) {
+		t.Errorf("marshaled dry-run result %s missing empty sandboxes array", data)
+	}
+}
+
+func TestNewDeleteBulkResultJSONShape(t *testing.T) {
+	data, err := json.Marshal(newDeleteBulkResult(0))
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	for _, want := range []string{`"dryRun":false`, `"count":0`, `"deleted":[]`, `"failed":[]`} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("marshaled bulk result %s missing %s", data, want)
+		}
+	}
+}
+
+func TestDeleteSingleResultJSONShape(t *testing.T) {
+	name := "my-sandbox"
+	tests := []struct {
+		name   string
+		result deleteSingleResult
+		want   []string
+	}{
+		{
+			name:   "deleted sandbox",
+			result: deleteSingleResult{Id: "id-1", Name: &name, Deleted: true, Found: true},
+			want:   []string{`"id":"id-1"`, `"name":"my-sandbox"`, `"deleted":true`, `"found":true`},
+		},
+		{
+			name:   "not found sandbox",
+			result: deleteSingleResult{Id: "missing", Name: nil, Deleted: false, Found: false},
+			want:   []string{`"id":"missing"`, `"name":null`, `"deleted":false`, `"found":false`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.result)
+			if err != nil {
+				t.Fatalf("json.Marshal: %v", err)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(string(data), want) {
+					t.Errorf("marshaled result %s missing %s", data, want)
+				}
+			}
+		})
+	}
+}

--- a/apps/cli/cmd/sandbox/delete_test.go
+++ b/apps/cli/cmd/sandbox/delete_test.go
@@ -4,10 +4,16 @@
 package sandbox
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 )
 
@@ -91,4 +97,50 @@ func TestDeleteSingleResultJSONShape(t *testing.T) {
 			}
 		})
 	}
+}
+
+func awaitTestClient(serverURL string) *apiclient.APIClient {
+	clientConfig := apiclient.NewConfiguration()
+	clientConfig.Servers = apiclient.ServerConfigurations{{URL: serverURL}}
+	return apiclient.NewAPIClient(clientConfig)
+}
+
+func TestAwaitSandboxDeleted(t *testing.T) {
+	t.Run("not found means deleted", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprint(w, `{"error":"Not Found","message":"sandbox gone"}`)
+		}))
+		defer server.Close()
+
+		if err := awaitSandboxDeleted(context.Background(), awaitTestClient(server.URL), "sbx-1", time.Second); err != nil {
+			t.Fatalf("awaitSandboxDeleted() = %v, want nil", err)
+		}
+	})
+
+	t.Run("destroyed state means deleted", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, testSandboxJSON("destroyed"))
+		}))
+		defer server.Close()
+
+		if err := awaitSandboxDeleted(context.Background(), awaitTestClient(server.URL), "sbx-1", time.Second); err != nil {
+			t.Fatalf("awaitSandboxDeleted() = %v, want nil", err)
+		}
+	})
+
+	t.Run("timeout while sandbox persists", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, testSandboxJSON("started"))
+		}))
+		defer server.Close()
+
+		err := awaitSandboxDeleted(context.Background(), awaitTestClient(server.URL), "sbx-1", 50*time.Millisecond)
+		if !clierr.HasCategory(err, clierr.CategoryTimeout) {
+			t.Fatalf("awaitSandboxDeleted() = %v, want timeout-category error", err)
+		}
+	})
 }

--- a/apps/cli/cmd/sandbox/delete_test.go
+++ b/apps/cli/cmd/sandbox/delete_test.go
@@ -5,36 +5,11 @@ package sandbox
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/daytonaio/daytona/cli/internal/clierr"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 )
-
-func TestDeleteIsNotFound(t *testing.T) {
-	tests := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{name: "nil error", err: nil, want: false},
-		{name: "plain error", err: errors.New("boom"), want: false},
-		{name: "not found clierr", err: clierr.New(clierr.CategoryNotFound, "sandbox not found"), want: true},
-		{name: "other category clierr", err: clierr.New(clierr.CategoryServer, "internal error"), want: false},
-		{name: "wrapped not found", err: fmt.Errorf("context: %w", clierr.New(clierr.CategoryNotFound, "gone")), want: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := deleteIsNotFound(tt.err); got != tt.want {
-				t.Errorf("deleteIsNotFound(%v) = %v, want %v", tt.err, got, tt.want)
-			}
-		})
-	}
-}
 
 func TestSandboxDryRunResult(t *testing.T) {
 	state := apiclient.SANDBOXSTATE_STARTED

--- a/apps/cli/cmd/sandbox/exec.go
+++ b/apps/cli/cmd/sandbox/exec.go
@@ -31,7 +31,12 @@ Exits with the remote command's exit code; exit code 255 indicates a CLI-side fa
 	Example: `  daytona exec my-sandbox -- ls -la /workspace
   daytona exec my-sandbox -- python -c "print('hi')"
   daytona exec my-sandbox --cwd /workspace --format json -- npm test`,
-	Args: cobra.MinimumNArgs(2),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 2 {
+			return clierr.New(clierr.CategoryUsage, "missing required arguments: sandbox and command")
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 

--- a/apps/cli/cmd/sandbox/exec.go
+++ b/apps/cli/cmd/sandbox/exec.go
@@ -5,50 +5,56 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	"github.com/daytonaio/daytona/cli/toolbox"
 	"github.com/spf13/cobra"
 )
 
+// execResult is the structured output of `daytona exec` in --format mode.
+type execResult struct {
+	Result   string `json:"result" yaml:"result"`
+	ExitCode int    `json:"exitCode" yaml:"exitCode"`
+}
+
 var ExecCmd = &cobra.Command{
 	Use:   "exec [SANDBOX_ID | SANDBOX_NAME] -- [COMMAND] [ARGS...]",
 	Short: "Execute a command in a sandbox",
-	Long:  "Execute a command in a running sandbox",
-	Args:  cobra.MinimumNArgs(2),
+	Long: `Execute a command in a running sandbox.
+
+Exits with the remote command's exit code; exit code 255 indicates a CLI-side failure (for example the sandbox was not found or is not running).`,
+	Args: cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
 		apiClient, err := apiclient.GetApiClient(nil, nil)
 		if err != nil {
-			return err
+			return execFailure(err)
 		}
 
 		sandboxIdOrName := args[0]
 
-		// Find the command args after "--"
+		// The command and its arguments follow the sandbox reference (after "--").
 		commandArgs := args[1:]
-		if len(commandArgs) == 0 {
-			return fmt.Errorf("no command specified")
-		}
 
 		// First, get the sandbox to get its ID and region (in case name was provided)
 		sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, sandboxIdOrName).Execute()
 		if err != nil {
-			return apiclient.HandleErrorResponse(res, err)
+			return execFailure(apiclient.HandleErrorResponse(res, err))
 		}
 
 		if err := common.RequireStartedState(sandbox); err != nil {
-			return err
+			return execFailure(err)
 		}
 
 		toolboxClient := toolbox.NewClient(apiClient)
 
-		command := strings.Join(commandArgs, " ")
+		command := common.ShellJoinArgs(commandArgs)
 
 		executeRequest := toolbox.ExecuteRequest{
 			Command: command,
@@ -64,7 +70,20 @@ var ExecCmd = &cobra.Command{
 		// Execute the command via toolbox
 		response, err := toolboxClient.ExecuteCommand(ctx, sandbox, executeRequest)
 		if err != nil {
-			return err
+			return execFailure(err)
+		}
+
+		exitCode := int(response.ExitCode)
+
+		if common.FormatFlag != "" {
+			common.NewFormatter(execResult{
+				Result:   response.Result,
+				ExitCode: exitCode,
+			}).Print()
+			if exitCode != 0 {
+				os.Exit(exitCode)
+			}
+			return nil
 		}
 
 		// Print the output (stdout + stderr combined)
@@ -73,7 +92,6 @@ var ExecCmd = &cobra.Command{
 		}
 
 		// Exit with the command's exit code
-		exitCode := int(response.ExitCode)
 		if exitCode != 0 {
 			if response.Result == "" {
 				fmt.Fprintf(os.Stderr, "Command failed with exit code %d\n", exitCode)
@@ -85,6 +103,18 @@ var ExecCmd = &cobra.Command{
 	},
 }
 
+// execFailure marks a CLI-side failure (as opposed to a non-zero exit of the
+// remote command) so `daytona exec` exits with 255 per the documented
+// exit-code contract. A *clierr.Error keeps its category and hint; other
+// errors are wrapped as server errors.
+func execFailure(err error) error {
+	var cliErr *clierr.Error
+	if errors.As(err, &cliErr) {
+		return cliErr.WithCode(255)
+	}
+	return clierr.New(clierr.CategoryServer, err.Error()).WithCode(255)
+}
+
 var (
 	execCwd     string
 	execTimeout int
@@ -93,4 +123,5 @@ var (
 func init() {
 	ExecCmd.Flags().StringVar(&execCwd, "cwd", "", "Working directory for command execution")
 	ExecCmd.Flags().IntVar(&execTimeout, "timeout", 0, "Command timeout in seconds (0 for no timeout)")
+	common.RegisterFormatFlag(ExecCmd)
 }

--- a/apps/cli/cmd/sandbox/exec.go
+++ b/apps/cli/cmd/sandbox/exec.go
@@ -28,6 +28,9 @@ var ExecCmd = &cobra.Command{
 	Long: `Execute a command in a running sandbox.
 
 Exits with the remote command's exit code; exit code 255 indicates a CLI-side failure (for example the sandbox was not found or is not running).`,
+	Example: `  daytona exec my-sandbox -- ls -la /workspace
+  daytona exec my-sandbox -- python -c "print('hi')"
+  daytona exec my-sandbox --cwd /workspace --format json -- npm test`,
 	Args: cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()

--- a/apps/cli/cmd/sandbox/exec_test.go
+++ b/apps/cli/cmd/sandbox/exec_test.go
@@ -4,12 +4,17 @@
 package sandbox
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"testing"
 
 	"github.com/daytonaio/daytona/cli/internal/clierr"
+	"github.com/daytonaio/daytona/cli/toolbox"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 )
 
 func TestExecFailure(t *testing.T) {
@@ -92,5 +97,154 @@ func TestExecResultTags(t *testing.T) {
 				t.Errorf("yaml tag = %q, want %q", got, tt.tag)
 			}
 		})
+	}
+}
+
+func TestExecArgsValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{name: "no arguments", args: nil, wantErr: true},
+		{name: "sandbox without command", args: []string{"my-sandbox"}, wantErr: true},
+		{name: "sandbox and command", args: []string{"my-sandbox", "ls"}, wantErr: false},
+		{name: "sandbox and command with args", args: []string{"my-sandbox", "ls", "-la"}, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ExecCmd.Args(ExecCmd, tt.args)
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("Args(%v) unexpected error: %v", tt.args, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Args(%v) expected error, got nil", tt.args)
+			}
+			if !clierr.HasCategory(err, clierr.CategoryUsage) {
+				t.Errorf("HasCategory(err, usage) = false, err = %v", err)
+			}
+			if want := "missing required arguments: sandbox and command"; err.Error() != want {
+				t.Errorf("error = %q, want %q", err.Error(), want)
+			}
+			if got := clierr.ExitCode(err); got != 2 {
+				t.Errorf("ExitCode = %d, want 2", got)
+			}
+		})
+	}
+}
+
+func TestExecSuccessPrintsResult(t *testing.T) {
+	mux := http.NewServeMux()
+	server := newTestAPIServer(t, mux)
+
+	var gotCommand string
+	mux.HandleFunc("GET /sandbox/my-sandbox", func(w http.ResponseWriter, r *http.Request) {
+		writeSandboxJSON(t, w, "started")
+	})
+	mux.HandleFunc("GET /sandbox/sbx-1/toolbox-proxy-url", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprintf(w, `{"url":%q}`, server.URL+"/proxy"); err != nil {
+			t.Errorf("writing proxy-url payload: %v", err)
+		}
+	})
+	mux.HandleFunc("POST /proxy/sbx-1/process/execute", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Command string `json:"command"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decoding execute request: %v", err)
+		}
+		gotCommand = req.Command
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprint(w, `{"result":"hello\n","exitCode":0}`); err != nil {
+			t.Errorf("writing execute payload: %v", err)
+		}
+	})
+
+	out, err := captureStdout(t, func() error {
+		return ExecCmd.RunE(ExecCmd, []string{"my-sandbox", "echo", "hello"})
+	})
+	if err != nil {
+		t.Fatalf("ExecCmd.RunE() unexpected error: %v", err)
+	}
+	if out != "hello\n" {
+		t.Errorf("stdout = %q, want %q", out, "hello\n")
+	}
+	if gotCommand != "echo hello" {
+		t.Errorf("proxy received command %q, want %q", gotCommand, "echo hello")
+	}
+}
+
+// TestExecRemoteFailureResultJSON exercises the toolbox-proxy path for a
+// remote command exiting non-zero and asserts the JSON shape of the result
+// struct. The full RunE path cannot be used here: a non-zero remote exit
+// code makes the command call os.Exit, which would kill the test process.
+func TestExecRemoteFailureResultJSON(t *testing.T) {
+	mux := http.NewServeMux()
+	server := newTestAPIServer(t, mux)
+
+	mux.HandleFunc("GET /sandbox/sbx-1/toolbox-proxy-url", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprintf(w, `{"url":%q}`, server.URL+"/proxy"); err != nil {
+			t.Errorf("writing proxy-url payload: %v", err)
+		}
+	})
+	mux.HandleFunc("POST /proxy/sbx-1/process/execute", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprint(w, `{"result":"boom","exitCode":3}`); err != nil {
+			t.Errorf("writing execute payload: %v", err)
+		}
+	})
+
+	clientConfig := apiclient.NewConfiguration()
+	clientConfig.Servers = apiclient.ServerConfigurations{{URL: server.URL}}
+	client := apiclient.NewAPIClient(clientConfig)
+
+	sandbox := apiclient.Sandbox{Id: "sbx-1", Target: "us"}
+	response, err := toolbox.NewClient(client).ExecuteCommand(context.Background(), &sandbox, toolbox.ExecuteRequest{Command: "exit 3"})
+	if err != nil {
+		t.Fatalf("ExecuteCommand() unexpected error: %v", err)
+	}
+
+	data, err := json.Marshal(execResult{Result: response.Result, ExitCode: int(response.ExitCode)})
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if want := `{"result":"boom","exitCode":3}`; string(data) != want {
+		t.Errorf("execResult JSON = %s, want %s", data, want)
+	}
+}
+
+func TestExecGetSandboxNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /sandbox/missing", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		if _, err := fmt.Fprint(w, `{"error":"Sandbox not found"}`); err != nil {
+			t.Errorf("writing not-found payload: %v", err)
+		}
+	})
+	newTestAPIServer(t, mux)
+
+	err := ExecCmd.RunE(ExecCmd, []string{"missing", "ls"})
+	if err == nil {
+		t.Fatal("expected error for missing sandbox, got nil")
+	}
+	if !clierr.HasCategory(err, clierr.CategoryNotFound) {
+		t.Errorf("HasCategory(err, not_found) = false, err = %v", err)
+	}
+	var cliErr *clierr.Error
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *clierr.Error, got %T: %v", err, err)
+	}
+	if cliErr.Code != 255 {
+		t.Errorf("Code = %d, want 255", cliErr.Code)
+	}
+	if got := clierr.ExitCode(err); got != 255 {
+		t.Errorf("ExitCode = %d, want 255", got)
 	}
 }

--- a/apps/cli/cmd/sandbox/exec_test.go
+++ b/apps/cli/cmd/sandbox/exec_test.go
@@ -1,0 +1,96 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+)
+
+func TestExecFailure(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		wantCategory clierr.Category
+		wantMessage  string
+		wantHint     string
+	}{
+		{
+			name:         "clierr passthrough keeps category and hint",
+			err:          clierr.New(clierr.CategoryNotFound, "sandbox not found").WithHint("check the sandbox ID"),
+			wantCategory: clierr.CategoryNotFound,
+			wantMessage:  "sandbox not found",
+			wantHint:     "check the sandbox ID",
+		},
+		{
+			name:         "wrapped clierr is unwrapped and keeps category",
+			err:          fmt.Errorf("toolbox: %w", clierr.New(clierr.CategoryAuth, "unauthorized")),
+			wantCategory: clierr.CategoryAuth,
+			wantMessage:  "unauthorized",
+		},
+		{
+			name:         "plain error becomes server-category clierr",
+			err:          errors.New("connection reset"),
+			wantCategory: clierr.CategoryServer,
+			wantMessage:  "connection reset",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := execFailure(tt.err)
+
+			var cliErr *clierr.Error
+			if !errors.As(got, &cliErr) {
+				t.Fatalf("execFailure(%v) = %T, want *clierr.Error", tt.err, got)
+			}
+			if cliErr.Code != 255 {
+				t.Errorf("Code = %d, want 255", cliErr.Code)
+			}
+			if cliErr.Category != tt.wantCategory {
+				t.Errorf("Category = %q, want %q", cliErr.Category, tt.wantCategory)
+			}
+			if cliErr.Message != tt.wantMessage {
+				t.Errorf("Message = %q, want %q", cliErr.Message, tt.wantMessage)
+			}
+			if cliErr.Hint != tt.wantHint {
+				t.Errorf("Hint = %q, want %q", cliErr.Hint, tt.wantHint)
+			}
+			if exitCode := clierr.ExitCode(got); exitCode != 255 {
+				t.Errorf("ExitCode = %d, want 255", exitCode)
+			}
+		})
+	}
+}
+
+func TestExecResultTags(t *testing.T) {
+	typ := reflect.TypeOf(execResult{})
+
+	tests := []struct {
+		field string
+		tag   string
+	}{
+		{field: "Result", tag: "result"},
+		{field: "ExitCode", tag: "exitCode"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			f, ok := typ.FieldByName(tt.field)
+			if !ok {
+				t.Fatalf("execResult has no field %s", tt.field)
+			}
+			if got := f.Tag.Get("json"); got != tt.tag {
+				t.Errorf("json tag = %q, want %q", got, tt.tag)
+			}
+			if got := f.Tag.Get("yaml"); got != tt.tag {
+				t.Errorf("yaml tag = %q, want %q", got, tt.tag)
+			}
+		})
+	}
+}

--- a/apps/cli/cmd/sandbox/info.go
+++ b/apps/cli/cmd/sandbox/info.go
@@ -13,8 +13,10 @@ import (
 )
 
 var InfoCmd = &cobra.Command{
-	Use:     "info [SANDBOX_ID] | [SANDBOX_NAME]",
-	Short:   "Get sandbox info",
+	Use:   "info [SANDBOX_ID] | [SANDBOX_NAME]",
+	Short: "Get sandbox info",
+	Example: `  daytona info my-sandbox
+  daytona info my-sandbox --format json`,
 	Args:    cobra.ExactArgs(1),
 	Aliases: common.GetAliases("info"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/sandbox/info.go
+++ b/apps/cli/cmd/sandbox/info.go
@@ -13,7 +13,7 @@ import (
 )
 
 var InfoCmd = &cobra.Command{
-	Use:   "info [SANDBOX_ID] | [SANDBOX_NAME]",
+	Use:   "info [SANDBOX_ID | SANDBOX_NAME]",
 	Short: "Get sandbox info",
 	Example: `  daytona info my-sandbox
   daytona info my-sandbox --format json`,

--- a/apps/cli/cmd/sandbox/lifecycle_test.go
+++ b/apps/cli/cmd/sandbox/lifecycle_test.go
@@ -1,0 +1,118 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package sandbox
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+	"gopkg.in/yaml.v2"
+)
+
+func TestRequireSandboxArg(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{name: "no args returns usage error", args: []string{}, wantErr: true},
+		{name: "one arg accepted", args: []string{"my-sandbox"}},
+		{name: "two args returns usage error", args: []string{"my-sandbox", "extra"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := requireSandboxArg(nil, tt.args)
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("requireSandboxArg(%v) unexpected error: %v", tt.args, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("requireSandboxArg(%v) expected error, got nil", tt.args)
+			}
+			var cliErr *clierr.Error
+			if !errors.As(err, &cliErr) {
+				t.Fatalf("requireSandboxArg(%v) expected *clierr.Error, got %T", tt.args, err)
+			}
+			if cliErr.Category != clierr.CategoryUsage {
+				t.Errorf("requireSandboxArg(%v) category = %q, want %q", tt.args, cliErr.Category, clierr.CategoryUsage)
+			}
+		})
+	}
+}
+
+func TestRequireSandboxArgMissingArgMessage(t *testing.T) {
+	err := requireSandboxArg(nil, nil)
+	if err == nil {
+		t.Fatal("requireSandboxArg(nil) expected error, got nil")
+	}
+	want := "missing required argument: sandbox ID or name"
+	if err.Error() != want {
+		t.Errorf("requireSandboxArg(nil) error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestNewPreviewUrlOutput(t *testing.T) {
+	previewUrl := &apiclient.SignedPortPreviewUrl{
+		SandboxId: "sb-123",
+		Port:      8080,
+		Token:     "secret",
+		Url:       "https://8080-sb-123.preview.daytona.io?token=secret",
+	}
+
+	out := newPreviewUrlOutput(previewUrl, 600, "my-sandbox")
+
+	if out.Url != previewUrl.Url {
+		t.Errorf("Url = %q, want %q", out.Url, previewUrl.Url)
+	}
+	if out.Port != previewUrl.Port {
+		t.Errorf("Port = %d, want %d", out.Port, previewUrl.Port)
+	}
+	if out.ExpiresInSeconds != 600 {
+		t.Errorf("ExpiresInSeconds = %d, want 600", out.ExpiresInSeconds)
+	}
+	if out.Sandbox != "my-sandbox" {
+		t.Errorf("Sandbox = %q, want %q (the user-supplied argument)", out.Sandbox, "my-sandbox")
+	}
+}
+
+func TestPreviewUrlOutputFieldNames(t *testing.T) {
+	out := newPreviewUrlOutput(&apiclient.SignedPortPreviewUrl{Port: 3000, Url: "https://example"}, 3600, "my-sandbox")
+	wantKeys := []string{"url", "port", "expiresInSeconds", "sandbox"}
+
+	jsonBytes, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	var jsonMap map[string]any
+	if err := json.Unmarshal(jsonBytes, &jsonMap); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	yamlBytes, err := yaml.Marshal(out)
+	if err != nil {
+		t.Fatalf("yaml.Marshal failed: %v", err)
+	}
+	yamlMap := map[string]any{}
+	if err := yaml.Unmarshal(yamlBytes, &yamlMap); err != nil {
+		t.Fatalf("yaml.Unmarshal failed: %v", err)
+	}
+
+	for _, key := range wantKeys {
+		if _, ok := jsonMap[key]; !ok {
+			t.Errorf("json output missing key %q (got %v)", key, jsonMap)
+		}
+		if _, ok := yamlMap[key]; !ok {
+			t.Errorf("yaml output missing key %q (got %v)", key, yamlMap)
+		}
+	}
+	if len(jsonMap) != len(wantKeys) {
+		t.Errorf("json output has %d keys, want %d: %v", len(jsonMap), len(wantKeys), jsonMap)
+	}
+}

--- a/apps/cli/cmd/sandbox/lifecycle_test.go
+++ b/apps/cli/cmd/sandbox/lifecycle_test.go
@@ -6,6 +6,14 @@ package sandbox
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/daytonaio/daytona/cli/internal/clierr"
@@ -114,5 +122,183 @@ func TestPreviewUrlOutputFieldNames(t *testing.T) {
 	}
 	if len(jsonMap) != len(wantKeys) {
 		t.Errorf("json output has %d keys, want %d: %v", len(jsonMap), len(wantKeys), jsonMap)
+	}
+}
+
+// newTestAPIServer starts an httptest server backed by mux and points the
+// CLI at it through the env-based profile (DAYTONA_API_KEY/DAYTONA_API_URL),
+// sandboxing the profile/toolbox-proxy cache in a temp DAYTONA_CONFIG_DIR.
+func newTestAPIServer(t *testing.T, mux *http.ServeMux) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	configDir := t.TempDir()
+	// Pre-create config.json so config.GetConfig does not run the first-time
+	// autocompletion setup, which writes to the user's shell profile.
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"activeProfile":"","profiles":[]}`), 0o600); err != nil {
+		t.Fatalf("writing config.json: %v", err)
+	}
+	t.Setenv("DAYTONA_CONFIG_DIR", configDir)
+	t.Setenv("DAYTONA_API_KEY", "test-api-key")
+	t.Setenv("DAYTONA_API_URL", server.URL)
+	return server
+}
+
+// testSandboxJSON renders a minimal Sandbox payload containing every
+// property the generated client requires plus the given state.
+func testSandboxJSON(state string) string {
+	return fmt.Sprintf(`{
+		"id": "sbx-1",
+		"organizationId": "org-1",
+		"name": "my-sandbox",
+		"user": "daytona",
+		"env": {},
+		"labels": {},
+		"public": false,
+		"networkBlockAll": false,
+		"target": "us",
+		"cpu": 1,
+		"gpu": 0,
+		"memory": 1,
+		"disk": 1,
+		"toolboxProxyUrl": "",
+		"state": %q
+	}`, state)
+}
+
+func writeSandboxJSON(t *testing.T, w http.ResponseWriter, state string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := fmt.Fprint(w, testSandboxJSON(state)); err != nil {
+		t.Errorf("writing sandbox payload: %v", err)
+	}
+}
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns
+// everything written along with fn's error.
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	runErr := fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing pipe writer: %v", err)
+	}
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading captured stdout: %v", err)
+	}
+	return string(out), runErr
+}
+
+func TestStopAlreadyStoppedSkipsStopRequest(t *testing.T) {
+	var stopCalls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /sandbox/my-sandbox", func(w http.ResponseWriter, r *http.Request) {
+		writeSandboxJSON(t, w, "stopped")
+	})
+	mux.HandleFunc("POST /sandbox/my-sandbox/stop", func(w http.ResponseWriter, r *http.Request) {
+		stopCalls.Add(1)
+	})
+	newTestAPIServer(t, mux)
+
+	out, err := captureStdout(t, func() error {
+		return StopCmd.RunE(StopCmd, []string{"my-sandbox"})
+	})
+	if err != nil {
+		t.Fatalf("StopCmd.RunE() unexpected error: %v", err)
+	}
+	if got := stopCalls.Load(); got != 0 {
+		t.Errorf("stop endpoint called %d times, want 0", got)
+	}
+	if !strings.Contains(out, "already stopped") {
+		t.Errorf("output %q does not mention the sandbox is already stopped", out)
+	}
+}
+
+func TestStartAlreadyStartedPassthrough(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /sandbox/my-sandbox/start", func(w http.ResponseWriter, r *http.Request) {
+		// The server treats starting an already-started sandbox as success.
+		writeSandboxJSON(t, w, "started")
+	})
+	newTestAPIServer(t, mux)
+
+	_, err := captureStdout(t, func() error {
+		return StartCmd.RunE(StartCmd, []string{"my-sandbox"})
+	})
+	if err != nil {
+		t.Fatalf("StartCmd.RunE() unexpected error: %v", err)
+	}
+}
+
+func TestStartWithoutWaitDoesNotPollSandbox(t *testing.T) {
+	var getCalls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /sandbox/my-sandbox/start", func(w http.ResponseWriter, r *http.Request) {
+		writeSandboxJSON(t, w, "starting")
+	})
+	mux.HandleFunc("GET /sandbox/my-sandbox", func(w http.ResponseWriter, r *http.Request) {
+		getCalls.Add(1)
+		writeSandboxJSON(t, w, "starting")
+	})
+	newTestAPIServer(t, mux)
+
+	oldWait := startWaitFlag
+	startWaitFlag = false
+	t.Cleanup(func() { startWaitFlag = oldWait })
+
+	_, err := captureStdout(t, func() error {
+		return StartCmd.RunE(StartCmd, []string{"my-sandbox"})
+	})
+	if err != nil {
+		t.Fatalf("StartCmd.RunE() unexpected error: %v", err)
+	}
+	if got := getCalls.Load(); got != 0 {
+		t.Errorf("GetSandbox polled %d times without --wait, want 0", got)
+	}
+}
+
+func TestCreateIfExistsReuse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /sandbox", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		if _, err := fmt.Fprint(w, `{"error":"Sandbox with name my-sandbox already exists"}`); err != nil {
+			t.Errorf("writing conflict payload: %v", err)
+		}
+	})
+	mux.HandleFunc("GET /sandbox/my-sandbox", func(w http.ResponseWriter, r *http.Request) {
+		writeSandboxJSON(t, w, "started")
+	})
+	mux.HandleFunc("GET /sandbox/sbx-1/ports/22222/preview-url", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprint(w, `{"sandboxId":"sbx-1","url":"https://preview.example.com","token":"tok"}`); err != nil {
+			t.Errorf("writing preview-url payload: %v", err)
+		}
+	})
+	newTestAPIServer(t, mux)
+
+	oldName, oldIfExists := nameFlag, createIfExistsFlag
+	nameFlag, createIfExistsFlag = "my-sandbox", "reuse"
+	t.Cleanup(func() { nameFlag, createIfExistsFlag = oldName, oldIfExists })
+
+	out, err := captureStdout(t, func() error {
+		return CreateCmd.RunE(CreateCmd, nil)
+	})
+	if err != nil {
+		t.Fatalf("CreateCmd.RunE() unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "already exists, reusing it") {
+		t.Errorf("output %q does not mention the sandbox is being reused", out)
 	}
 }

--- a/apps/cli/cmd/sandbox/list.go
+++ b/apps/cli/cmd/sandbox/list.go
@@ -20,8 +20,11 @@ var (
 )
 
 var ListCmd = &cobra.Command{
-	Use:     "list",
-	Short:   "List sandboxes",
+	Use:   "list",
+	Short: "List sandboxes",
+	Example: `  daytona list
+  daytona list --limit 50
+  daytona list --format json`,
 	Args:    cobra.NoArgs,
 	Aliases: common.GetAliases("list"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/sandbox/logs.go
+++ b/apps/cli/cmd/sandbox/logs.go
@@ -1,0 +1,129 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package sandbox
+
+import (
+	"context"
+	"time"
+
+	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
+	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+	"github.com/daytonaio/daytona/cli/util"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+	"github.com/spf13/cobra"
+)
+
+var logsFollowFlag bool
+
+var LogsCmd = &cobra.Command{
+	Use:     "logs [SANDBOX_ID | SANDBOX_NAME]",
+	Short:   "View the build logs of a sandbox",
+	Long:    "View the build logs of a sandbox. With --follow the logs are streamed until the sandbox build reaches a terminal state.",
+	Args:    cobra.ExactArgs(1),
+	Aliases: common.GetAliases("logs"),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+
+		apiClient, err := apiclient_cli.GetApiClient(nil, nil)
+		if err != nil {
+			return err
+		}
+
+		sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, args[0]).Execute()
+		if err != nil {
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
+
+		c, err := config.GetConfig()
+		if err != nil {
+			return err
+		}
+
+		activeProfile, err := c.GetActiveProfile()
+		if err != nil {
+			return err
+		}
+
+		params := common.ReadLogParams{
+			Id:                   sandbox.Id,
+			ServerUrl:            activeProfile.Api.Url,
+			ServerApi:            activeProfile.Api,
+			ActiveOrganizationId: activeProfile.ActiveOrganizationId,
+			Follow:               util.Pointer(logsFollowFlag),
+			ResourceType:         common.ResourceTypeSandbox,
+		}
+
+		if !logsFollowFlag {
+			return common.ReadBuildLogs(ctx, params)
+		}
+
+		logsCtx, stopLogs := context.WithCancel(ctx)
+		defer stopLogs()
+
+		streamDone := make(chan error, 1)
+		go func() {
+			streamDone <- common.ReadBuildLogs(logsCtx, params)
+		}()
+
+		for {
+			sb, res, err := apiClient.SandboxAPI.GetSandbox(ctx, sandbox.Id).Execute()
+			if err != nil {
+				return apiclient_cli.HandleErrorResponse(res, err)
+			}
+
+			if sb.State != nil {
+				if done, failed := isSandboxBuildDone(*sb.State); done {
+					// Grace period so trailing log output is flushed before the
+					// stream is canceled.
+					time.Sleep(250 * time.Millisecond)
+					stopLogs()
+					if streamDone != nil {
+						<-streamDone
+					}
+					if failed {
+						if reason := sb.GetErrorReason(); reason != "" {
+							return clierr.Newf(clierr.CategoryServer, "sandbox processing failed: %s", reason)
+						}
+						return clierr.New(clierr.CategoryServer, "sandbox processing failed")
+					}
+					return nil
+				}
+			}
+
+			select {
+			case err := <-streamDone:
+				streamDone = nil
+				if err != nil {
+					return err
+				}
+			case <-time.After(time.Second):
+			}
+		}
+	},
+}
+
+// isSandboxBuildDone reports whether the sandbox state is terminal for log
+// streaming purposes and whether it represents a failure.
+func isSandboxBuildDone(state apiclient.SandboxState) (done bool, failed bool) {
+	switch state {
+	case apiclient.SANDBOXSTATE_ERROR, apiclient.SANDBOXSTATE_BUILD_FAILED:
+		return true, true
+	case apiclient.SANDBOXSTATE_STARTED,
+		apiclient.SANDBOXSTATE_STOPPED,
+		apiclient.SANDBOXSTATE_STOPPING,
+		apiclient.SANDBOXSTATE_ARCHIVED,
+		apiclient.SANDBOXSTATE_ARCHIVING,
+		apiclient.SANDBOXSTATE_DESTROYED,
+		apiclient.SANDBOXSTATE_DESTROYING:
+		return true, false
+	default:
+		return false, false
+	}
+}
+
+func init() {
+	LogsCmd.Flags().BoolVarP(&logsFollowFlag, "follow", "f", false, "Follow the logs until the sandbox build reaches a terminal state")
+}

--- a/apps/cli/cmd/sandbox/logs.go
+++ b/apps/cli/cmd/sandbox/logs.go
@@ -19,9 +19,11 @@ import (
 var logsFollowFlag bool
 
 var LogsCmd = &cobra.Command{
-	Use:     "logs [SANDBOX_ID | SANDBOX_NAME]",
-	Short:   "View the build logs of a sandbox",
-	Long:    "View the build logs of a sandbox. With --follow the logs are streamed until the sandbox build reaches a terminal state.",
+	Use:   "logs [SANDBOX_ID | SANDBOX_NAME]",
+	Short: "View the build logs of a sandbox",
+	Long:  "View the build logs of a sandbox. With --follow the logs are streamed until the sandbox build reaches a terminal state.",
+	Example: `  daytona logs my-sandbox
+  daytona logs my-sandbox --follow`,
 	Args:    cobra.ExactArgs(1),
 	Aliases: common.GetAliases("logs"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/sandbox/logs.go
+++ b/apps/cli/cmd/sandbox/logs.go
@@ -5,7 +5,6 @@ package sandbox
 
 import (
 	"context"
-	"time"
 
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
@@ -24,7 +23,7 @@ var LogsCmd = &cobra.Command{
 	Long:  "View the build logs of a sandbox. With --follow the logs are streamed until the sandbox build reaches a terminal state.",
 	Example: `  daytona logs my-sandbox
   daytona logs my-sandbox --follow`,
-	Args:    cobra.ExactArgs(1),
+	Args:    requireSandboxArg,
 	Aliases: common.GetAliases("logs"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
@@ -62,48 +61,26 @@ var LogsCmd = &cobra.Command{
 			return common.ReadBuildLogs(ctx, params)
 		}
 
-		logsCtx, stopLogs := context.WithCancel(ctx)
-		defer stopLogs()
-
-		streamDone := make(chan error, 1)
-		go func() {
-			streamDone <- common.ReadBuildLogs(logsCtx, params)
-		}()
-
-		for {
+		return common.FollowBuildLogs(ctx, params, func(ctx context.Context) (bool, error) {
 			sb, res, err := apiClient.SandboxAPI.GetSandbox(ctx, sandbox.Id).Execute()
 			if err != nil {
-				return apiclient_cli.HandleErrorResponse(res, err)
+				return false, apiclient_cli.HandleErrorResponse(res, err)
 			}
-
-			if sb.State != nil {
-				if done, failed := isSandboxBuildDone(*sb.State); done {
-					// Grace period so trailing log output is flushed before the
-					// stream is canceled.
-					time.Sleep(250 * time.Millisecond)
-					stopLogs()
-					if streamDone != nil {
-						<-streamDone
-					}
-					if failed {
-						if reason := sb.GetErrorReason(); reason != "" {
-							return clierr.Newf(clierr.CategoryServer, "sandbox processing failed: %s", reason)
-						}
-						return clierr.New(clierr.CategoryServer, "sandbox processing failed")
-					}
-					return nil
-				}
+			if sb.State == nil {
+				return false, nil
 			}
-
-			select {
-			case err := <-streamDone:
-				streamDone = nil
-				if err != nil {
-					return err
-				}
-			case <-time.After(time.Second):
+			done, failed := isSandboxBuildDone(*sb.State)
+			if !done {
+				return false, nil
 			}
-		}
+			if !failed {
+				return true, nil
+			}
+			if reason := sb.GetErrorReason(); reason != "" {
+				return true, clierr.Newf(clierr.CategoryServer, "sandbox processing failed: %s", reason)
+			}
+			return true, clierr.New(clierr.CategoryServer, "sandbox processing failed")
+		})
 	},
 }
 

--- a/apps/cli/cmd/sandbox/logs_test.go
+++ b/apps/cli/cmd/sandbox/logs_test.go
@@ -4,8 +4,16 @@
 package sandbox
 
 import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 )
 
@@ -40,5 +48,216 @@ func TestIsSandboxBuildDone(t *testing.T) {
 				t.Errorf("isSandboxBuildDone(%q) = (%v, %v), want (%v, %v)", tt.state, done, failed, tt.wantDone, tt.wantFailed)
 			}
 		})
+	}
+}
+
+// logsRequestRecorder tracks the build-logs requests served by the test server.
+type logsRequestRecorder struct {
+	mu      sync.Mutex
+	hits    int
+	follows []bool
+}
+
+func (r *logsRequestRecorder) record(req *http.Request) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.hits++
+	r.follows = append(r.follows, req.URL.Query().Get("follow") == "true")
+}
+
+func (r *logsRequestRecorder) snapshot() (int, []bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.hits, append([]bool(nil), r.follows...)
+}
+
+// logsTestSandboxJSON renders a minimal Sandbox payload containing every
+// property the generated client requires plus the given state and error reason.
+func logsTestSandboxJSON(state, errorReason string) string {
+	reason := "null"
+	if errorReason != "" {
+		reason = fmt.Sprintf("%q", errorReason)
+	}
+	return fmt.Sprintf(`{
+		"id": "sbx-1",
+		"organizationId": "org-1",
+		"name": "my-sandbox",
+		"user": "daytona",
+		"env": {},
+		"labels": {},
+		"public": false,
+		"networkBlockAll": false,
+		"target": "us",
+		"cpu": 1,
+		"gpu": 0,
+		"memory": 1,
+		"disk": 1,
+		"toolboxProxyUrl": "",
+		"state": %q,
+		"errorReason": %s
+	}`, state, reason)
+}
+
+// logsTestServer emulates the API routes the logs command hits: GetSandbox
+// and the raw build-logs stream.
+func logsTestServer(t *testing.T, state, errorReason, logBody string, rec *logsRequestRecorder) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sandbox/sbx-1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, logsTestSandboxJSON(state, errorReason))
+	})
+	mux.HandleFunc("/sandbox/sbx-1/build-logs", func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		_, _ = io.WriteString(w, logBody)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+// logsTestEnv points profile resolution at the test server and sandboxes the
+// config cache away from the real machine config.
+func logsTestEnv(t *testing.T, serverURL string) {
+	t.Helper()
+	t.Setenv("DAYTONA_CONFIG_DIR", t.TempDir())
+	t.Setenv("DAYTONA_API_KEY", "test-api-key")
+	t.Setenv("DAYTONA_API_URL", serverURL)
+}
+
+func logsSetFollowFlag(t *testing.T, v bool) {
+	t.Helper()
+	orig := logsFollowFlag
+	logsFollowFlag = v
+	t.Cleanup(func() { logsFollowFlag = orig })
+}
+
+// logsCaptureStdout redirects os.Stdout for the duration of fn and returns
+// everything written to it.
+func logsCaptureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	collected := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(r)
+		collected <- string(data)
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing stdout pipe: %v", err)
+	}
+	os.Stdout = orig
+	return <-collected
+}
+
+func TestLogsCmdNonFollowStreamsBody(t *testing.T) {
+	body := "build log line 1\nbuild log line 2\n"
+	rec := &logsRequestRecorder{}
+	server := logsTestServer(t, "started", "", body, rec)
+	logsTestEnv(t, server.URL)
+	logsSetFollowFlag(t, false)
+
+	var err error
+	out := logsCaptureStdout(t, func() {
+		err = LogsCmd.RunE(LogsCmd, []string{"sbx-1"})
+	})
+
+	if err != nil {
+		t.Fatalf("LogsCmd.RunE() error: %v", err)
+	}
+	if out != body {
+		t.Errorf("stdout = %q, want %q", out, body)
+	}
+	hits, follows := rec.snapshot()
+	if hits != 1 {
+		t.Fatalf("build-logs requests = %d, want 1", hits)
+	}
+	if follows[0] {
+		t.Error("non-follow fetch sent follow=true")
+	}
+}
+
+func TestLogsCmdNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"message":"sandbox not found","statusCode":404}`)
+	}))
+	t.Cleanup(server.Close)
+	logsTestEnv(t, server.URL)
+	logsSetFollowFlag(t, false)
+
+	err := LogsCmd.RunE(LogsCmd, []string{"missing"})
+	if err == nil {
+		t.Fatal("LogsCmd.RunE() expected error, got nil")
+	}
+	if !clierr.HasCategory(err, clierr.CategoryNotFound) {
+		t.Errorf("LogsCmd.RunE() error = %v, want not_found-category clierr", err)
+	}
+}
+
+// TestLogsCmdFollowAlreadyTerminalCompleteFetch is the regression test for
+// follow mode truncating output when the sandbox is already terminal at
+// entry: the complete log history must arrive via exactly one plain
+// (non-follow) fetch.
+func TestLogsCmdFollowAlreadyTerminalCompleteFetch(t *testing.T) {
+	body := strings.Repeat("a long line of build output that must not be truncated\n", 200)
+	rec := &logsRequestRecorder{}
+	server := logsTestServer(t, "started", "", body, rec)
+	logsTestEnv(t, server.URL)
+	logsSetFollowFlag(t, true)
+
+	var err error
+	out := logsCaptureStdout(t, func() {
+		err = LogsCmd.RunE(LogsCmd, []string{"sbx-1"})
+	})
+
+	if err != nil {
+		t.Fatalf("LogsCmd.RunE() error: %v", err)
+	}
+	if out != body {
+		t.Errorf("streamed %d bytes, want the complete %d-byte log output", len(out), len(body))
+	}
+	hits, follows := rec.snapshot()
+	if hits != 1 {
+		t.Fatalf("build-logs requests = %d, want exactly 1", hits)
+	}
+	if follows[0] {
+		t.Error("already-terminal fetch used follow=true, want a plain fetch")
+	}
+}
+
+func TestLogsCmdFollowBuildFailedPropagatesReason(t *testing.T) {
+	body := "build log output\n"
+	rec := &logsRequestRecorder{}
+	server := logsTestServer(t, "build_failed", "docker build exploded", body, rec)
+	logsTestEnv(t, server.URL)
+	logsSetFollowFlag(t, true)
+
+	var err error
+	out := logsCaptureStdout(t, func() {
+		err = LogsCmd.RunE(LogsCmd, []string{"sbx-1"})
+	})
+
+	if !clierr.HasCategory(err, clierr.CategoryServer) {
+		t.Fatalf("LogsCmd.RunE() error = %v, want server-category clierr", err)
+	}
+	if !strings.Contains(err.Error(), "docker build exploded") {
+		t.Errorf("LogsCmd.RunE() error = %q, want it to mention the error reason", err.Error())
+	}
+	if out != body {
+		t.Errorf("stdout = %q, want %q", out, body)
+	}
+	if hits, _ := rec.snapshot(); hits != 1 {
+		t.Errorf("build-logs requests = %d, want 1", hits)
 	}
 }

--- a/apps/cli/cmd/sandbox/logs_test.go
+++ b/apps/cli/cmd/sandbox/logs_test.go
@@ -1,0 +1,44 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package sandbox
+
+import (
+	"testing"
+
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+)
+
+func TestIsSandboxBuildDone(t *testing.T) {
+	tests := []struct {
+		state      apiclient.SandboxState
+		wantDone   bool
+		wantFailed bool
+	}{
+		{apiclient.SANDBOXSTATE_STARTED, true, false},
+		{apiclient.SANDBOXSTATE_STOPPED, true, false},
+		{apiclient.SANDBOXSTATE_STOPPING, true, false},
+		{apiclient.SANDBOXSTATE_ARCHIVED, true, false},
+		{apiclient.SANDBOXSTATE_ARCHIVING, true, false},
+		{apiclient.SANDBOXSTATE_DESTROYED, true, false},
+		{apiclient.SANDBOXSTATE_DESTROYING, true, false},
+		{apiclient.SANDBOXSTATE_ERROR, true, true},
+		{apiclient.SANDBOXSTATE_BUILD_FAILED, true, true},
+		{apiclient.SANDBOXSTATE_CREATING, false, false},
+		{apiclient.SANDBOXSTATE_PENDING_BUILD, false, false},
+		{apiclient.SANDBOXSTATE_BUILDING_SNAPSHOT, false, false},
+		{apiclient.SANDBOXSTATE_PULLING_SNAPSHOT, false, false},
+		{apiclient.SANDBOXSTATE_STARTING, false, false},
+		{apiclient.SANDBOXSTATE_RESTORING, false, false},
+		{apiclient.SANDBOXSTATE_UNKNOWN, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			done, failed := isSandboxBuildDone(tt.state)
+			if done != tt.wantDone || failed != tt.wantFailed {
+				t.Errorf("isSandboxBuildDone(%q) = (%v, %v), want (%v, %v)", tt.state, done, failed, tt.wantDone, tt.wantFailed)
+			}
+		})
+	}
+}

--- a/apps/cli/cmd/sandbox/preview_url.go
+++ b/apps/cli/cmd/sandbox/preview_url.go
@@ -34,8 +34,11 @@ func newPreviewUrlOutput(previewUrl *apiclient.SignedPortPreviewUrl, expiresInSe
 }
 
 var PreviewUrlCmd = &cobra.Command{
-	Use:     "preview-url [SANDBOX_ID | SANDBOX_NAME]",
-	Short:   "Get signed preview URL for a sandbox port",
+	Use:   "preview-url [SANDBOX_ID | SANDBOX_NAME]",
+	Short: "Get signed preview URL for a sandbox port",
+	Example: `  daytona preview-url my-sandbox --port 3000
+  daytona preview-url my-sandbox --port 3000 --expires 7200
+  daytona preview-url my-sandbox --port 3000 --format json`,
 	Args:    requireSandboxArg,
 	Aliases: common.GetAliases("preview-url"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/sandbox/preview_url.go
+++ b/apps/cli/cmd/sandbox/preview_url.go
@@ -7,20 +7,41 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/daytonaio/daytona/cli/apiclient"
+	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/spf13/cobra"
 )
+
+// previewUrlOutput is the structured-output shape of the preview-url command.
+type previewUrlOutput struct {
+	Url              string `json:"url" yaml:"url"`
+	Port             int32  `json:"port" yaml:"port"`
+	ExpiresInSeconds int32  `json:"expiresInSeconds" yaml:"expiresInSeconds"`
+	Sandbox          string `json:"sandbox" yaml:"sandbox"`
+}
+
+// newPreviewUrlOutput assembles the structured output for a signed preview
+// URL; sandbox echoes the user-supplied sandbox ID or name argument.
+func newPreviewUrlOutput(previewUrl *apiclient.SignedPortPreviewUrl, expiresInSeconds int32, sandbox string) previewUrlOutput {
+	return previewUrlOutput{
+		Url:              previewUrl.Url,
+		Port:             previewUrl.Port,
+		ExpiresInSeconds: expiresInSeconds,
+		Sandbox:          sandbox,
+	}
+}
 
 var PreviewUrlCmd = &cobra.Command{
 	Use:     "preview-url [SANDBOX_ID | SANDBOX_NAME]",
 	Short:   "Get signed preview URL for a sandbox port",
-	Args:    cobra.ExactArgs(1),
+	Args:    requireSandboxArg,
 	Aliases: common.GetAliases("preview-url"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
-		apiClient, err := apiclient.GetApiClient(nil, nil)
+		apiClient, err := apiclient_cli.GetApiClient(nil, nil)
 		if err != nil {
 			return err
 		}
@@ -28,7 +49,7 @@ var PreviewUrlCmd = &cobra.Command{
 		sandboxIdOrName := args[0]
 
 		if previewUrlPort == 0 {
-			return fmt.Errorf("port flag is required")
+			return clierr.New(clierr.CategoryUsage, "port flag is required")
 		}
 
 		req := apiClient.SandboxAPI.GetSignedPortPreviewUrl(ctx, sandboxIdOrName, previewUrlPort).
@@ -36,7 +57,12 @@ var PreviewUrlCmd = &cobra.Command{
 
 		previewUrl, res, err := req.Execute()
 		if err != nil {
-			return apiclient.HandleErrorResponse(res, err)
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
+
+		if common.FormatFlag != "" {
+			common.NewFormatter(newPreviewUrlOutput(previewUrl, previewUrlExpires, sandboxIdOrName)).Print()
+			return nil
 		}
 
 		fmt.Println(previewUrl.Url)
@@ -55,4 +81,5 @@ func init() {
 	PreviewUrlCmd.Flags().Int32Var(&previewUrlExpires, "expires", 3600, "URL expiration time in seconds")
 
 	_ = PreviewUrlCmd.MarkFlagRequired("port")
+	common.RegisterFormatFlag(PreviewUrlCmd)
 }

--- a/apps/cli/cmd/sandbox/sandbox.go
+++ b/apps/cli/cmd/sandbox/sandbox.go
@@ -28,4 +28,6 @@ func init() {
 	SandboxCmd.AddCommand(SSHCmd)
 	SandboxCmd.AddCommand(ExecCmd)
 	SandboxCmd.AddCommand(PreviewUrlCmd)
+	SandboxCmd.AddCommand(CpCmd)
+	SandboxCmd.AddCommand(LogsCmd)
 }

--- a/apps/cli/cmd/sandbox/ssh.go
+++ b/apps/cli/cmd/sandbox/ssh.go
@@ -13,7 +13,7 @@ import (
 )
 
 var SSHCmd = &cobra.Command{
-	Use:   "ssh [SANDBOX_ID] | [SANDBOX_NAME]",
+	Use:   "ssh [SANDBOX_ID | SANDBOX_NAME]",
 	Short: "SSH into a sandbox",
 	Long:  "Establish an SSH connection to a running sandbox",
 	Example: `  daytona ssh my-sandbox

--- a/apps/cli/cmd/sandbox/ssh.go
+++ b/apps/cli/cmd/sandbox/ssh.go
@@ -16,7 +16,9 @@ var SSHCmd = &cobra.Command{
 	Use:   "ssh [SANDBOX_ID] | [SANDBOX_NAME]",
 	Short: "SSH into a sandbox",
 	Long:  "Establish an SSH connection to a running sandbox",
-	Args:  cobra.ExactArgs(1),
+	Example: `  daytona ssh my-sandbox
+  daytona ssh my-sandbox --expires 60`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 

--- a/apps/cli/cmd/sandbox/start.go
+++ b/apps/cli/cmd/sandbox/start.go
@@ -28,6 +28,30 @@ func requireSandboxArg(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// finishLifecycleAction is the shared epilogue of the start/stop/archive
+// commands: optionally wait for the sandbox to reach the target state, then
+// either print the fresh sandbox via the formatter (--format) or render the
+// human success message.
+func finishLifecycleAction(ctx context.Context, apiClient *apiclient.APIClient, ref string, wait bool, timeout time.Duration, target apiclient.SandboxState, humanMsg string) error {
+	if wait {
+		if err := common.AwaitSandboxState(ctx, apiClient, ref, timeout, target); err != nil {
+			return err
+		}
+	}
+
+	if common.FormatFlag != "" {
+		sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, ref).Execute()
+		if err != nil {
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
+		common.NewFormatter(sandbox).Print()
+		return nil
+	}
+
+	view_common.RenderInfoMessageBold(humanMsg)
+	return nil
+}
+
 var (
 	startWaitFlag    bool
 	startTimeoutFlag time.Duration
@@ -55,25 +79,7 @@ var StartCmd = &cobra.Command{
 			return apiclient_cli.HandleErrorResponse(res, err)
 		}
 
-		if startWaitFlag {
-			err = common.AwaitSandboxState(ctx, apiClient, sandboxIdOrNameArg, startTimeoutFlag, apiclient.SANDBOXSTATE_STARTED)
-			if err != nil {
-				return err
-			}
-		}
-
-		if common.FormatFlag != "" {
-			sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, sandboxIdOrNameArg).Execute()
-			if err != nil {
-				return apiclient_cli.HandleErrorResponse(res, err)
-			}
-			common.NewFormatter(sandbox).Print()
-			return nil
-		}
-
-		view_common.RenderInfoMessageBold(fmt.Sprintf("Sandbox %s started", sandboxIdOrNameArg))
-
-		return nil
+		return finishLifecycleAction(ctx, apiClient, sandboxIdOrNameArg, startWaitFlag, startTimeoutFlag, apiclient.SANDBOXSTATE_STARTED, fmt.Sprintf("Sandbox %s started", sandboxIdOrNameArg))
 	},
 }
 

--- a/apps/cli/cmd/sandbox/start.go
+++ b/apps/cli/cmd/sandbox/start.go
@@ -6,20 +6,41 @@ package sandbox
 import (
 	"context"
 	"fmt"
+	"time"
 
-	"github.com/daytonaio/daytona/cli/apiclient"
+	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
+	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	view_common "github.com/daytonaio/daytona/cli/views/common"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/spf13/cobra"
 )
 
+// requireSandboxArg validates that exactly one sandbox ID or name argument
+// is provided, returning a usage-category error otherwise.
+func requireSandboxArg(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return clierr.New(clierr.CategoryUsage, "missing required argument: sandbox ID or name")
+	}
+	if len(args) > 1 {
+		return clierr.Newf(clierr.CategoryUsage, "expected a single sandbox ID or name argument, received %d arguments", len(args))
+	}
+	return nil
+}
+
+var (
+	startWaitFlag    bool
+	startTimeoutFlag time.Duration
+)
+
 var StartCmd = &cobra.Command{
-	Use:   "start [SANDBOX_ID] | [SANDBOX_NAME]",
+	Use:   "start [SANDBOX_ID | SANDBOX_NAME]",
 	Short: "Start a sandbox",
-	Args:  cobra.MaximumNArgs(1),
+	Args:  requireSandboxArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
-		apiClient, err := apiclient.GetApiClient(nil, nil)
+		apiClient, err := apiclient_cli.GetApiClient(nil, nil)
 		if err != nil {
 			return err
 		}
@@ -28,7 +49,23 @@ var StartCmd = &cobra.Command{
 
 		_, res, err := apiClient.SandboxAPI.StartSandbox(ctx, sandboxIdOrNameArg).Execute()
 		if err != nil {
-			return apiclient.HandleErrorResponse(res, err)
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
+
+		if startWaitFlag {
+			err = common.AwaitSandboxState(ctx, apiClient, sandboxIdOrNameArg, startTimeoutFlag, apiclient.SANDBOXSTATE_STARTED)
+			if err != nil {
+				return err
+			}
+		}
+
+		if common.FormatFlag != "" {
+			sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, sandboxIdOrNameArg).Execute()
+			if err != nil {
+				return apiclient_cli.HandleErrorResponse(res, err)
+			}
+			common.NewFormatter(sandbox).Print()
+			return nil
 		}
 
 		view_common.RenderInfoMessageBold(fmt.Sprintf("Sandbox %s started", sandboxIdOrNameArg))
@@ -38,4 +75,7 @@ var StartCmd = &cobra.Command{
 }
 
 func init() {
+	StartCmd.Flags().BoolVar(&startWaitFlag, "wait", false, "Wait until the sandbox is started")
+	StartCmd.Flags().DurationVar(&startTimeoutFlag, "timeout", 5*time.Minute, "Maximum time to wait with --wait (0 waits indefinitely)")
+	common.RegisterFormatFlag(StartCmd)
 }

--- a/apps/cli/cmd/sandbox/start.go
+++ b/apps/cli/cmd/sandbox/start.go
@@ -36,7 +36,10 @@ var (
 var StartCmd = &cobra.Command{
 	Use:   "start [SANDBOX_ID | SANDBOX_NAME]",
 	Short: "Start a sandbox",
-	Args:  requireSandboxArg,
+	Example: `  daytona start my-sandbox
+  daytona start my-sandbox --wait --timeout 2m
+  daytona start my-sandbox --wait --format json`,
+	Args: requireSandboxArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 

--- a/apps/cli/cmd/sandbox/stop.go
+++ b/apps/cli/cmd/sandbox/stop.go
@@ -24,7 +24,10 @@ var (
 var StopCmd = &cobra.Command{
 	Use:   "stop [SANDBOX_ID | SANDBOX_NAME]",
 	Short: "Stop a sandbox",
-	Args:  requireSandboxArg,
+	Example: `  daytona stop my-sandbox
+  daytona stop my-sandbox --wait --timeout 2m
+  daytona stop my-sandbox --force --format json`,
+	Args: requireSandboxArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 

--- a/apps/cli/cmd/sandbox/stop.go
+++ b/apps/cli/cmd/sandbox/stop.go
@@ -62,24 +62,7 @@ var StopCmd = &cobra.Command{
 			return apiclient_cli.HandleErrorResponse(res, err)
 		}
 
-		if stopWaitFlag {
-			err = common.AwaitSandboxState(ctx, apiClient, sandboxIdOrNameArg, stopTimeoutFlag, apiclient.SANDBOXSTATE_STOPPED)
-			if err != nil {
-				return err
-			}
-		}
-
-		if common.FormatFlag != "" {
-			sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, sandboxIdOrNameArg).Execute()
-			if err != nil {
-				return apiclient_cli.HandleErrorResponse(res, err)
-			}
-			common.NewFormatter(sandbox).Print()
-			return nil
-		}
-
-		view_common.RenderInfoMessageBold(fmt.Sprintf("Sandbox %s stopped", sandboxIdOrNameArg))
-		return nil
+		return finishLifecycleAction(ctx, apiClient, sandboxIdOrNameArg, stopWaitFlag, stopTimeoutFlag, apiclient.SANDBOXSTATE_STOPPED, fmt.Sprintf("Sandbox %s stopped", sandboxIdOrNameArg))
 	},
 }
 

--- a/apps/cli/cmd/sandbox/stop.go
+++ b/apps/cli/cmd/sandbox/stop.go
@@ -6,35 +6,73 @@ package sandbox
 import (
 	"context"
 	"fmt"
+	"time"
 
-	"github.com/daytonaio/daytona/cli/apiclient"
+	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
+	"github.com/daytonaio/daytona/cli/cmd/common"
 	view_common "github.com/daytonaio/daytona/cli/views/common"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/spf13/cobra"
 )
 
-var forceFlag bool
+var (
+	forceFlag       bool
+	stopWaitFlag    bool
+	stopTimeoutFlag time.Duration
+)
 
 var StopCmd = &cobra.Command{
-	Use:   "stop [SANDBOX_ID] | [SANDBOX_NAME]",
+	Use:   "stop [SANDBOX_ID | SANDBOX_NAME]",
 	Short: "Stop a sandbox",
-	Args:  cobra.MaximumNArgs(1),
+	Args:  requireSandboxArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
-		apiClient, err := apiclient.GetApiClient(nil, nil)
+		apiClient, err := apiclient_cli.GetApiClient(nil, nil)
 		if err != nil {
 			return err
 		}
 
 		sandboxIdOrNameArg := args[0]
 
+		// Pre-check so stopping an already-stopped sandbox succeeds idempotently.
+		sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, sandboxIdOrNameArg).Execute()
+		if err != nil {
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
+
+		if sandbox.State != nil && *sandbox.State == apiclient.SANDBOXSTATE_STOPPED {
+			if common.FormatFlag != "" {
+				common.NewFormatter(sandbox).Print()
+				return nil
+			}
+			view_common.RenderInfoMessageBold(fmt.Sprintf("Sandbox %s is already stopped", sandboxIdOrNameArg))
+			return nil
+		}
+
 		req := apiClient.SandboxAPI.StopSandbox(ctx, sandboxIdOrNameArg)
 		if forceFlag {
 			req = req.Force(forceFlag)
 		}
-		_, res, err := req.Execute()
+		_, res, err = req.Execute()
 		if err != nil {
-			return apiclient.HandleErrorResponse(res, err)
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
+
+		if stopWaitFlag {
+			err = common.AwaitSandboxState(ctx, apiClient, sandboxIdOrNameArg, stopTimeoutFlag, apiclient.SANDBOXSTATE_STOPPED)
+			if err != nil {
+				return err
+			}
+		}
+
+		if common.FormatFlag != "" {
+			sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, sandboxIdOrNameArg).Execute()
+			if err != nil {
+				return apiclient_cli.HandleErrorResponse(res, err)
+			}
+			common.NewFormatter(sandbox).Print()
+			return nil
 		}
 
 		view_common.RenderInfoMessageBold(fmt.Sprintf("Sandbox %s stopped", sandboxIdOrNameArg))
@@ -44,4 +82,7 @@ var StopCmd = &cobra.Command{
 
 func init() {
 	StopCmd.Flags().BoolVarP(&forceFlag, "force", "f", false, "Force stop the sandbox using SIGKILL")
+	StopCmd.Flags().BoolVar(&stopWaitFlag, "wait", false, "Wait until the sandbox is stopped")
+	StopCmd.Flags().DurationVar(&stopTimeoutFlag, "timeout", 5*time.Minute, "Maximum time to wait with --wait (0 waits indefinitely)")
+	common.RegisterFormatFlagNoShorthand(StopCmd)
 }

--- a/apps/cli/cmd/snapshot/create.go
+++ b/apps/cli/cmd/snapshot/create.go
@@ -95,17 +95,19 @@ var CreateCmd = &cobra.Command{
 			logsContext, stopLogs := context.WithCancel(context.Background())
 			defer stopLogs()
 
-			go common.ReadBuildLogs(logsContext, common.ReadLogParams{
-				Id:                   snapshot.Id,
-				ServerUrl:            activeProfile.Api.Url,
-				ServerApi:            activeProfile.Api,
-				ActiveOrganizationId: activeProfile.ActiveOrganizationId,
-				Follow:               util.Pointer(true),
-				ResourceType:         common.ResourceTypeSnapshot,
-			})
+			go func() {
+				_ = common.ReadBuildLogs(logsContext, common.ReadLogParams{
+					Id:                   snapshot.Id,
+					ServerUrl:            activeProfile.Api.Url,
+					ServerApi:            activeProfile.Api,
+					ActiveOrganizationId: activeProfile.ActiveOrganizationId,
+					Follow:               util.Pointer(true),
+					ResourceType:         common.ResourceTypeSnapshot,
+				})
+			}()
 
 			// Accept any post-build state — transient states can be skipped between polls.
-			err = common.AwaitSnapshotState(ctx, apiClient, snapshotName,
+			err = common.AwaitSnapshotState(ctx, apiClient, snapshotName, 0,
 				apiclient.SNAPSHOTSTATE_PENDING,
 				apiclient.SNAPSHOTSTATE_PULLING,
 				apiclient.SNAPSHOTSTATE_ACTIVE,
@@ -121,7 +123,7 @@ var CreateCmd = &cobra.Command{
 		}
 
 		err = views_util.WithInlineSpinner("Waiting for the snapshot to be validated", func() error {
-			return common.AwaitSnapshotState(ctx, apiClient, snapshotName, apiclient.SNAPSHOTSTATE_ACTIVE)
+			return common.AwaitSnapshotState(ctx, apiClient, snapshotName, 0, apiclient.SNAPSHOTSTATE_ACTIVE)
 		})
 		if err != nil {
 			return err

--- a/apps/cli/cmd/snapshot/create.go
+++ b/apps/cli/cmd/snapshot/create.go
@@ -110,7 +110,7 @@ var CreateCmd = &cobra.Command{
 			}()
 
 			// Accept any post-build state — transient states can be skipped between polls.
-			err = common.AwaitSnapshotState(ctx, apiClient, snapshotName, 0,
+			err = common.AwaitSnapshotState(ctx, apiClient, snapshotName, createTimeoutFlag,
 				apiclient.SNAPSHOTSTATE_PENDING,
 				apiclient.SNAPSHOTSTATE_PULLING,
 				apiclient.SNAPSHOTSTATE_ACTIVE,
@@ -126,7 +126,7 @@ var CreateCmd = &cobra.Command{
 		}
 
 		err = views_util.WithInlineSpinner("Waiting for the snapshot to be validated", func() error {
-			return common.AwaitSnapshotState(ctx, apiClient, snapshotName, 0, apiclient.SNAPSHOTSTATE_ACTIVE)
+			return common.AwaitSnapshotState(ctx, apiClient, snapshotName, createTimeoutFlag, apiclient.SNAPSHOTSTATE_ACTIVE)
 		})
 		if err != nil {
 			return err
@@ -147,6 +147,7 @@ var (
 	memoryFlag         int32
 	diskFlag           int32
 	regionIdFlag       string
+	createTimeoutFlag  time.Duration
 )
 
 func init() {
@@ -158,6 +159,7 @@ func init() {
 	CreateCmd.Flags().Int32Var(&memoryFlag, "memory", 0, "Memory that will be allocated to the underlying sandboxes in GB (default: 1)")
 	CreateCmd.Flags().Int32Var(&diskFlag, "disk", 0, "Disk space that will be allocated to the underlying sandboxes in GB (default: 3)")
 	CreateCmd.Flags().StringVar(&regionIdFlag, "region", "", "ID of the region where the snapshot will be available (defaults to organization default region)")
+	CreateCmd.Flags().DurationVar(&createTimeoutFlag, "timeout", 0, "Maximum time to wait for the snapshot to become active (0 means wait indefinitely)")
 
 	CreateCmd.MarkFlagsMutuallyExclusive("image", "dockerfile")
 	CreateCmd.MarkFlagsMutuallyExclusive("image", "context")

--- a/apps/cli/cmd/snapshot/create.go
+++ b/apps/cli/cmd/snapshot/create.go
@@ -20,8 +20,11 @@ import (
 )
 
 var CreateCmd = &cobra.Command{
-	Use:     "create [SNAPSHOT]",
-	Short:   "Create a snapshot",
+	Use:   "create [SNAPSHOT]",
+	Short: "Create a snapshot",
+	Example: `  daytona snapshot create my-snapshot:1.0 --image ubuntu:22.04 --entrypoint "sleep infinity"
+  daytona snapshot create my-snapshot:1.0 --dockerfile ./Dockerfile --context ./app
+  daytona snapshot create my-snapshot:1.0 --image ubuntu:22.04 --cpu 2 --memory 4 --disk 10`,
 	Args:    cobra.ExactArgs(1),
 	Aliases: common.GetAliases("create"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/snapshot/delete.go
+++ b/apps/cli/cmd/snapshot/delete.go
@@ -59,8 +59,11 @@ type deleteSingleResult struct {
 }
 
 var DeleteCmd = &cobra.Command{
-	Use:     "delete [SNAPSHOT_ID | SNAPSHOT_NAME]",
-	Short:   "Delete a snapshot",
+	Use:   "delete [SNAPSHOT_ID | SNAPSHOT_NAME]",
+	Short: "Delete a snapshot",
+	Example: `  daytona snapshot delete my-snapshot:1.0
+  daytona snapshot delete --all --dry-run
+  daytona snapshot delete --all --yes --format json`,
 	Args:    cobra.MaximumNArgs(1),
 	Aliases: common.GetAliases("delete"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/snapshot/delete.go
+++ b/apps/cli/cmd/snapshot/delete.go
@@ -5,14 +5,58 @@ package snapshot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	view_common "github.com/daytonaio/daytona/cli/views/common"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/spf13/cobra"
 )
+
+// deleteDryRunItem describes one snapshot that would be deleted.
+type deleteDryRunItem struct {
+	Id    string `json:"id" yaml:"id"`
+	Name  string `json:"name" yaml:"name"`
+	State string `json:"state" yaml:"state"`
+}
+
+// deleteDryRunResult is the structured output of `delete --dry-run`.
+type deleteDryRunResult struct {
+	DryRun    bool               `json:"dryRun" yaml:"dryRun"`
+	Count     int                `json:"count" yaml:"count"`
+	Snapshots []deleteDryRunItem `json:"snapshots" yaml:"snapshots"`
+}
+
+type deleteBulkDeletedItem struct {
+	Id   string `json:"id" yaml:"id"`
+	Name string `json:"name" yaml:"name"`
+}
+
+type deleteBulkFailedItem struct {
+	Id    string `json:"id" yaml:"id"`
+	Error string `json:"error" yaml:"error"`
+}
+
+// deleteBulkResult is the structured output of `delete --all`. Deleted and
+// Failed are always non-nil so both keys appear in the output.
+type deleteBulkResult struct {
+	DryRun  bool                    `json:"dryRun" yaml:"dryRun"`
+	Count   int                     `json:"count" yaml:"count"`
+	Deleted []deleteBulkDeletedItem `json:"deleted" yaml:"deleted"`
+	Failed  []deleteBulkFailedItem  `json:"failed" yaml:"failed"`
+}
+
+// deleteSingleResult is the structured output of a single snapshot delete.
+// Name is a pointer so a missing snapshot renders "name": null.
+type deleteSingleResult struct {
+	Id      string  `json:"id" yaml:"id"`
+	Name    *string `json:"name" yaml:"name"`
+	Deleted bool    `json:"deleted" yaml:"deleted"`
+	Found   bool    `json:"found" yaml:"found"`
+}
 
 var DeleteCmd = &cobra.Command{
 	Use:     "delete [SNAPSHOT_ID | SNAPSHOT_NAME]",
@@ -27,69 +71,179 @@ var DeleteCmd = &cobra.Command{
 			return err
 		}
 
-		// Handle case when no snapshot ID is provided and allFlag is true
 		if len(args) == 0 {
 			if allFlag {
-				page := float32(1.0)
-				limit := float32(200.0) // 200 is the maximum limit for the API
-				var allSnapshots []apiclient.SnapshotDto
-
-				for {
-					snapshotBatch, res, err := apiClient.SnapshotsAPI.GetAllSnapshots(ctx).Page(page).Limit(limit).Execute()
-					if err != nil {
-						return apiclient_cli.HandleErrorResponse(res, err)
-					}
-
-					allSnapshots = append(allSnapshots, snapshotBatch.Items...)
-
-					if len(snapshotBatch.Items) < int(limit) || page >= snapshotBatch.TotalPages {
-						break
-					}
-					page++
-				}
-
-				if len(allSnapshots) == 0 {
-					view_common.RenderInfoMessageBold("No snapshots to delete")
-					return nil
-				}
-
-				var deletedCount int
-
-				for _, snapshot := range allSnapshots {
-					res, err := apiClient.SnapshotsAPI.RemoveSnapshot(ctx, snapshot.Id).Execute()
-					if err != nil {
-						fmt.Printf("Failed to delete snapshot %s: %s\n", snapshot.Id, apiclient_cli.HandleErrorResponse(res, err))
-					} else {
-						deletedCount++
-					}
-				}
-
-				view_common.RenderInfoMessageBold(fmt.Sprintf("Deleted %d snapshots", deletedCount))
-				return nil
+				return deleteAllSnapshots(ctx, apiClient)
 			}
 			return cmd.Help()
 		}
 
-		snapshotIdOrName := args[0]
-
-		snapshot, res, err := apiClient.SnapshotsAPI.GetSnapshot(ctx, snapshotIdOrName).Execute()
-		if err != nil {
-			return apiclient_cli.HandleErrorResponse(res, err)
-		}
-
-		res, err = apiClient.SnapshotsAPI.RemoveSnapshot(ctx, snapshot.Id).Execute()
-		if err != nil {
-			return apiclient_cli.HandleErrorResponse(res, err)
-		}
-
-		view_common.RenderInfoMessageBold(fmt.Sprintf("Snapshot %s deleted", snapshotIdOrName))
-
-		return nil
+		return deleteSingleSnapshot(ctx, apiClient, args[0])
 	},
 }
 
-var allFlag bool
+// deleteIsNotFound reports whether err is a not_found CLI error.
+func deleteIsNotFound(err error) bool {
+	var cliErr *clierr.Error
+	return errors.As(err, &cliErr) && cliErr.Category == clierr.CategoryNotFound
+}
+
+// snapshotDryRunResult builds the dry-run payload for the given snapshots.
+func snapshotDryRunResult(items []apiclient.SnapshotDto) deleteDryRunResult {
+	result := deleteDryRunResult{DryRun: true, Count: len(items), Snapshots: []deleteDryRunItem{}}
+	for _, snapshot := range items {
+		result.Snapshots = append(result.Snapshots, deleteDryRunItem{Id: snapshot.Id, Name: snapshot.Name, State: string(snapshot.State)})
+	}
+	return result
+}
+
+// newDeleteBulkResult builds an empty bulk-delete payload with non-nil
+// Deleted and Failed slices.
+func newDeleteBulkResult(count int) deleteBulkResult {
+	return deleteBulkResult{Count: count, Deleted: []deleteBulkDeletedItem{}, Failed: []deleteBulkFailedItem{}}
+}
+
+func deleteAllSnapshots(ctx context.Context, apiClient *apiclient.APIClient) error {
+	page := float32(1.0)
+	limit := float32(200.0) // 200 is the maximum limit for the API
+	var allSnapshots []apiclient.SnapshotDto
+
+	for {
+		snapshotBatch, res, err := apiClient.SnapshotsAPI.GetAllSnapshots(ctx).Page(page).Limit(limit).Execute()
+		if err != nil {
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
+
+		allSnapshots = append(allSnapshots, snapshotBatch.Items...)
+
+		if len(snapshotBatch.Items) < int(limit) || page >= snapshotBatch.TotalPages {
+			break
+		}
+		page++
+	}
+
+	if deleteDryRunFlag {
+		if common.FormatFlag != "" {
+			common.NewFormatter(snapshotDryRunResult(allSnapshots)).Print()
+			return nil
+		}
+		if len(allSnapshots) == 0 {
+			view_common.RenderInfoMessageBold("No snapshots to delete")
+			return nil
+		}
+		for _, snapshot := range allSnapshots {
+			view_common.RenderInfoMessage(fmt.Sprintf("Would delete snapshot %s (%s)", snapshot.Name, snapshot.Id))
+		}
+		return nil
+	}
+
+	if len(allSnapshots) == 0 {
+		if common.FormatFlag != "" {
+			common.NewFormatter(newDeleteBulkResult(0)).Print()
+			return nil
+		}
+		view_common.RenderInfoMessageBold("No snapshots to delete")
+		return nil
+	}
+
+	if !deleteYesFlag {
+		confirmed, err := view_common.Confirm(fmt.Sprintf("Delete %d snapshots?", len(allSnapshots)))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return errors.New("aborted")
+		}
+	}
+
+	result := newDeleteBulkResult(len(allSnapshots))
+
+	for _, snapshot := range allSnapshots {
+		res, err := apiClient.SnapshotsAPI.RemoveSnapshot(ctx, snapshot.Id).Execute()
+		if err != nil {
+			handled := apiclient_cli.HandleErrorResponse(res, err)
+			if common.FormatFlag == "" {
+				fmt.Printf("Failed to delete snapshot %s: %s\n", snapshot.Id, handled)
+			}
+			result.Failed = append(result.Failed, deleteBulkFailedItem{Id: snapshot.Id, Error: handled.Error()})
+		} else {
+			result.Deleted = append(result.Deleted, deleteBulkDeletedItem{Id: snapshot.Id, Name: snapshot.Name})
+		}
+	}
+
+	if common.FormatFlag != "" {
+		common.NewFormatter(result).Print()
+		return nil
+	}
+
+	view_common.RenderInfoMessageBold(fmt.Sprintf("Deleted %d snapshots", len(result.Deleted)))
+	return nil
+}
+
+func deleteSingleSnapshot(ctx context.Context, apiClient *apiclient.APIClient, snapshotIdOrName string) error {
+	snapshot, res, err := apiClient.SnapshotsAPI.GetSnapshot(ctx, snapshotIdOrName).Execute()
+	if err != nil {
+		handled := apiclient_cli.HandleErrorResponse(res, err)
+		if deleteIgnoreNotFoundFlag && deleteIsNotFound(handled) {
+			return snapshotNotFoundOutput(snapshotIdOrName)
+		}
+		return handled
+	}
+
+	if deleteDryRunFlag {
+		if common.FormatFlag != "" {
+			result := deleteDryRunResult{
+				DryRun:    true,
+				Count:     1,
+				Snapshots: []deleteDryRunItem{{Id: snapshot.Id, Name: snapshot.Name, State: string(snapshot.State)}},
+			}
+			common.NewFormatter(result).Print()
+			return nil
+		}
+		view_common.RenderInfoMessage(fmt.Sprintf("Would delete snapshot %s (%s)", snapshot.Name, snapshot.Id))
+		return nil
+	}
+
+	res, err = apiClient.SnapshotsAPI.RemoveSnapshot(ctx, snapshot.Id).Execute()
+	if err != nil {
+		handled := apiclient_cli.HandleErrorResponse(res, err)
+		if deleteIgnoreNotFoundFlag && deleteIsNotFound(handled) {
+			return snapshotNotFoundOutput(snapshotIdOrName)
+		}
+		return handled
+	}
+
+	if common.FormatFlag != "" {
+		name := snapshot.Name
+		common.NewFormatter(deleteSingleResult{Id: snapshot.Id, Name: &name, Deleted: true, Found: true}).Print()
+		return nil
+	}
+
+	view_common.RenderInfoMessageBold(fmt.Sprintf("Snapshot %s deleted", snapshotIdOrName))
+	return nil
+}
+
+// snapshotNotFoundOutput reports a missing snapshot as success (--ignore-not-found).
+func snapshotNotFoundOutput(arg string) error {
+	if common.FormatFlag != "" {
+		common.NewFormatter(deleteSingleResult{Id: arg, Name: nil, Deleted: false, Found: false}).Print()
+		return nil
+	}
+	view_common.RenderInfoMessageBold(fmt.Sprintf("Snapshot %s not found, nothing to delete", arg))
+	return nil
+}
+
+var (
+	allFlag                  bool
+	deleteYesFlag            bool
+	deleteDryRunFlag         bool
+	deleteIgnoreNotFoundFlag bool
+)
 
 func init() {
 	DeleteCmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Delete all snapshots")
+	DeleteCmd.Flags().BoolVarP(&deleteYesFlag, "yes", "y", false, "Skip the confirmation prompt for bulk deletes")
+	DeleteCmd.Flags().BoolVar(&deleteDryRunFlag, "dry-run", false, "Show what would be deleted without deleting anything")
+	DeleteCmd.Flags().BoolVar(&deleteIgnoreNotFoundFlag, "ignore-not-found", false, "Treat a missing snapshot as a successful delete")
+	common.RegisterFormatFlag(DeleteCmd)
 }

--- a/apps/cli/cmd/snapshot/delete_test.go
+++ b/apps/cli/cmd/snapshot/delete_test.go
@@ -1,0 +1,79 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package snapshot
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+)
+
+func TestDeleteIsNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "plain error", err: errors.New("boom"), want: false},
+		{name: "not found clierr", err: clierr.New(clierr.CategoryNotFound, "snapshot not found"), want: true},
+		{name: "other category clierr", err: clierr.New(clierr.CategoryConflict, "in use"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deleteIsNotFound(tt.err); got != tt.want {
+				t.Errorf("deleteIsNotFound(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSnapshotDryRunResult(t *testing.T) {
+	items := []apiclient.SnapshotDto{
+		{Id: "snap-1", Name: "base", State: apiclient.SNAPSHOTSTATE_ACTIVE},
+		{Id: "snap-2", Name: "stale", State: apiclient.SNAPSHOTSTATE_INACTIVE},
+	}
+
+	result := snapshotDryRunResult(items)
+
+	if !result.DryRun {
+		t.Error("DryRun = false, want true")
+	}
+	if result.Count != 2 {
+		t.Errorf("Count = %d, want 2", result.Count)
+	}
+	if len(result.Snapshots) != 2 {
+		t.Fatalf("len(Snapshots) = %d, want 2", len(result.Snapshots))
+	}
+	if result.Snapshots[0].Id != "snap-1" || result.Snapshots[0].Name != "base" || result.Snapshots[0].State != "active" {
+		t.Errorf("Snapshots[0] = %+v, want {snap-1 base active}", result.Snapshots[0])
+	}
+}
+
+func TestSnapshotDryRunResultUsesSnapshotsKey(t *testing.T) {
+	data, err := json.Marshal(snapshotDryRunResult(nil))
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"snapshots":[]`) {
+		t.Errorf("marshaled dry-run result %s missing empty snapshots array", data)
+	}
+}
+
+func TestNewDeleteBulkResultJSONShape(t *testing.T) {
+	data, err := json.Marshal(newDeleteBulkResult(3))
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	for _, want := range []string{`"dryRun":false`, `"count":3`, `"deleted":[]`, `"failed":[]`} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("marshaled bulk result %s missing %s", data, want)
+		}
+	}
+}

--- a/apps/cli/cmd/snapshot/list.go
+++ b/apps/cli/cmd/snapshot/list.go
@@ -20,9 +20,12 @@ var (
 )
 
 var ListCmd = &cobra.Command{
-	Use:     "list",
-	Short:   "List all snapshots",
-	Long:    "List all available Daytona snapshots",
+	Use:   "list",
+	Short: "List all snapshots",
+	Long:  "List all available Daytona snapshots",
+	Example: `  daytona snapshot list
+  daytona snapshot list --limit 50
+  daytona snapshot list --format json`,
 	Args:    cobra.NoArgs,
 	Aliases: common.GetAliases("list"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/snapshot/list.go
+++ b/apps/cli/cmd/snapshot/list.go
@@ -23,6 +23,7 @@ var ListCmd = &cobra.Command{
 	Use:     "list",
 	Short:   "List all snapshots",
 	Long:    "List all available Daytona snapshots",
+	Args:    cobra.NoArgs,
 	Aliases: common.GetAliases("list"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()

--- a/apps/cli/cmd/snapshot/list_test.go
+++ b/apps/cli/cmd/snapshot/list_test.go
@@ -1,0 +1,30 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package snapshot
+
+import "testing"
+
+func TestListCmdArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{name: "no args accepted", args: nil},
+		{name: "one arg rejected", args: []string{"extra"}, wantErr: true},
+		{name: "two args rejected", args: []string{"extra", "more"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ListCmd.Args(ListCmd, tt.args)
+			if tt.wantErr && err == nil {
+				t.Fatalf("ListCmd.Args(%v) expected error, got nil", tt.args)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("ListCmd.Args(%v) unexpected error: %v", tt.args, err)
+			}
+		})
+	}
+}

--- a/apps/cli/cmd/snapshot/logs.go
+++ b/apps/cli/cmd/snapshot/logs.go
@@ -5,7 +5,6 @@ package snapshot
 
 import (
 	"context"
-	"time"
 
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
@@ -24,7 +23,7 @@ var LogsCmd = &cobra.Command{
 	Long:  "View the build logs of a snapshot. With --follow the logs are streamed until the snapshot build reaches a terminal state.",
 	Example: `  daytona snapshot logs my-snapshot:1.0
   daytona snapshot logs my-snapshot:1.0 --follow`,
-	Args:    cobra.ExactArgs(1),
+	Args:    requireSnapshotArg,
 	Aliases: common.GetAliases("logs"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
@@ -62,47 +61,36 @@ var LogsCmd = &cobra.Command{
 			return common.ReadBuildLogs(ctx, params)
 		}
 
-		logsCtx, stopLogs := context.WithCancel(ctx)
-		defer stopLogs()
-
-		streamDone := make(chan error, 1)
-		go func() {
-			streamDone <- common.ReadBuildLogs(logsCtx, params)
-		}()
-
-		for {
+		return common.FollowBuildLogs(ctx, params, func(ctx context.Context) (bool, error) {
 			snap, res, err := apiClient.SnapshotsAPI.GetSnapshot(ctx, snapshot.Id).Execute()
 			if err != nil {
-				return apiclient_cli.HandleErrorResponse(res, err)
+				return false, apiclient_cli.HandleErrorResponse(res, err)
 			}
-
-			if done, failed := isSnapshotBuildDone(snap.State); done {
-				// Grace period so trailing log output is flushed before the
-				// stream is canceled.
-				time.Sleep(250 * time.Millisecond)
-				stopLogs()
-				if streamDone != nil {
-					<-streamDone
-				}
-				if failed {
-					if reason := snap.GetErrorReason(); reason != "" {
-						return clierr.Newf(clierr.CategoryServer, "snapshot processing failed: %s", reason)
-					}
-					return clierr.New(clierr.CategoryServer, "snapshot processing failed")
-				}
-				return nil
+			done, failed := isSnapshotBuildDone(snap.State)
+			if !done {
+				return false, nil
 			}
-
-			select {
-			case err := <-streamDone:
-				streamDone = nil
-				if err != nil {
-					return err
-				}
-			case <-time.After(time.Second):
+			if !failed {
+				return true, nil
 			}
-		}
+			if reason := snap.GetErrorReason(); reason != "" {
+				return true, clierr.Newf(clierr.CategoryServer, "snapshot processing failed: %s", reason)
+			}
+			return true, clierr.New(clierr.CategoryServer, "snapshot processing failed")
+		})
 	},
+}
+
+// requireSnapshotArg validates that exactly one snapshot ID or name argument
+// is provided, returning a usage-category error otherwise.
+func requireSnapshotArg(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return clierr.New(clierr.CategoryUsage, "missing required argument: snapshot ID or name")
+	}
+	if len(args) > 1 {
+		return clierr.Newf(clierr.CategoryUsage, "expected a single snapshot ID or name argument, received %d arguments", len(args))
+	}
+	return nil
 }
 
 // isSnapshotBuildDone reports whether the snapshot state is terminal for log

--- a/apps/cli/cmd/snapshot/logs.go
+++ b/apps/cli/cmd/snapshot/logs.go
@@ -19,9 +19,11 @@ import (
 var logsFollowFlag bool
 
 var LogsCmd = &cobra.Command{
-	Use:     "logs [SNAPSHOT_ID | SNAPSHOT_NAME]",
-	Short:   "View the build logs of a snapshot",
-	Long:    "View the build logs of a snapshot. With --follow the logs are streamed until the snapshot build reaches a terminal state.",
+	Use:   "logs [SNAPSHOT_ID | SNAPSHOT_NAME]",
+	Short: "View the build logs of a snapshot",
+	Long:  "View the build logs of a snapshot. With --follow the logs are streamed until the snapshot build reaches a terminal state.",
+	Example: `  daytona snapshot logs my-snapshot:1.0
+  daytona snapshot logs my-snapshot:1.0 --follow`,
 	Args:    cobra.ExactArgs(1),
 	Aliases: common.GetAliases("logs"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/snapshot/logs.go
+++ b/apps/cli/cmd/snapshot/logs.go
@@ -1,0 +1,121 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package snapshot
+
+import (
+	"context"
+	"time"
+
+	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
+	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+	"github.com/daytonaio/daytona/cli/util"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+	"github.com/spf13/cobra"
+)
+
+var logsFollowFlag bool
+
+var LogsCmd = &cobra.Command{
+	Use:     "logs [SNAPSHOT_ID | SNAPSHOT_NAME]",
+	Short:   "View the build logs of a snapshot",
+	Long:    "View the build logs of a snapshot. With --follow the logs are streamed until the snapshot build reaches a terminal state.",
+	Args:    cobra.ExactArgs(1),
+	Aliases: common.GetAliases("logs"),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+
+		apiClient, err := apiclient_cli.GetApiClient(nil, nil)
+		if err != nil {
+			return err
+		}
+
+		snapshot, res, err := apiClient.SnapshotsAPI.GetSnapshot(ctx, args[0]).Execute()
+		if err != nil {
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
+
+		c, err := config.GetConfig()
+		if err != nil {
+			return err
+		}
+
+		activeProfile, err := c.GetActiveProfile()
+		if err != nil {
+			return err
+		}
+
+		params := common.ReadLogParams{
+			Id:                   snapshot.Id,
+			ServerUrl:            activeProfile.Api.Url,
+			ServerApi:            activeProfile.Api,
+			ActiveOrganizationId: activeProfile.ActiveOrganizationId,
+			Follow:               util.Pointer(logsFollowFlag),
+			ResourceType:         common.ResourceTypeSnapshot,
+		}
+
+		if !logsFollowFlag {
+			return common.ReadBuildLogs(ctx, params)
+		}
+
+		logsCtx, stopLogs := context.WithCancel(ctx)
+		defer stopLogs()
+
+		streamDone := make(chan error, 1)
+		go func() {
+			streamDone <- common.ReadBuildLogs(logsCtx, params)
+		}()
+
+		for {
+			snap, res, err := apiClient.SnapshotsAPI.GetSnapshot(ctx, snapshot.Id).Execute()
+			if err != nil {
+				return apiclient_cli.HandleErrorResponse(res, err)
+			}
+
+			if done, failed := isSnapshotBuildDone(snap.State); done {
+				// Grace period so trailing log output is flushed before the
+				// stream is canceled.
+				time.Sleep(250 * time.Millisecond)
+				stopLogs()
+				if streamDone != nil {
+					<-streamDone
+				}
+				if failed {
+					if reason := snap.GetErrorReason(); reason != "" {
+						return clierr.Newf(clierr.CategoryServer, "snapshot processing failed: %s", reason)
+					}
+					return clierr.New(clierr.CategoryServer, "snapshot processing failed")
+				}
+				return nil
+			}
+
+			select {
+			case err := <-streamDone:
+				streamDone = nil
+				if err != nil {
+					return err
+				}
+			case <-time.After(time.Second):
+			}
+		}
+	},
+}
+
+// isSnapshotBuildDone reports whether the snapshot state is terminal for log
+// streaming purposes and whether it represents a failure.
+func isSnapshotBuildDone(state apiclient.SnapshotState) (done bool, failed bool) {
+	switch state {
+	case apiclient.SNAPSHOTSTATE_ERROR, apiclient.SNAPSHOTSTATE_BUILD_FAILED:
+		return true, true
+	case apiclient.SNAPSHOTSTATE_ACTIVE, apiclient.SNAPSHOTSTATE_INACTIVE:
+		return true, false
+	default:
+		return false, false
+	}
+}
+
+func init() {
+	LogsCmd.Flags().BoolVarP(&logsFollowFlag, "follow", "f", false, "Follow the logs until the snapshot build reaches a terminal state")
+}

--- a/apps/cli/cmd/snapshot/logs_test.go
+++ b/apps/cli/cmd/snapshot/logs_test.go
@@ -1,0 +1,36 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package snapshot
+
+import (
+	"testing"
+
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+)
+
+func TestIsSnapshotBuildDone(t *testing.T) {
+	tests := []struct {
+		state      apiclient.SnapshotState
+		wantDone   bool
+		wantFailed bool
+	}{
+		{apiclient.SNAPSHOTSTATE_ACTIVE, true, false},
+		{apiclient.SNAPSHOTSTATE_INACTIVE, true, false},
+		{apiclient.SNAPSHOTSTATE_ERROR, true, true},
+		{apiclient.SNAPSHOTSTATE_BUILD_FAILED, true, true},
+		{apiclient.SNAPSHOTSTATE_BUILDING, false, false},
+		{apiclient.SNAPSHOTSTATE_PENDING, false, false},
+		{apiclient.SNAPSHOTSTATE_PULLING, false, false},
+		{apiclient.SNAPSHOTSTATE_REMOVING, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			done, failed := isSnapshotBuildDone(tt.state)
+			if done != tt.wantDone || failed != tt.wantFailed {
+				t.Errorf("isSnapshotBuildDone(%q) = (%v, %v), want (%v, %v)", tt.state, done, failed, tt.wantDone, tt.wantFailed)
+			}
+		})
+	}
+}

--- a/apps/cli/cmd/snapshot/logs_test.go
+++ b/apps/cli/cmd/snapshot/logs_test.go
@@ -4,8 +4,17 @@
 package snapshot
 
 import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 )
 
@@ -32,5 +41,259 @@ func TestIsSnapshotBuildDone(t *testing.T) {
 				t.Errorf("isSnapshotBuildDone(%q) = (%v, %v), want (%v, %v)", tt.state, done, failed, tt.wantDone, tt.wantFailed)
 			}
 		})
+	}
+}
+
+func TestRequireSnapshotArg(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{name: "no args", args: nil, wantErr: true},
+		{name: "one arg", args: []string{"my-snapshot"}, wantErr: false},
+		{name: "two args", args: []string{"a", "b"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := requireSnapshotArg(nil, tt.args)
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("requireSnapshotArg(%v) unexpected error: %v", tt.args, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("requireSnapshotArg(%v) expected error, got nil", tt.args)
+			}
+			var cliErr *clierr.Error
+			if !errors.As(err, &cliErr) {
+				t.Fatalf("requireSnapshotArg(%v) expected *clierr.Error, got %T", tt.args, err)
+			}
+			if cliErr.Category != clierr.CategoryUsage {
+				t.Errorf("requireSnapshotArg(%v) category = %q, want %q", tt.args, cliErr.Category, clierr.CategoryUsage)
+			}
+		})
+	}
+}
+
+func TestRequireSnapshotArgMissingArgMessage(t *testing.T) {
+	err := requireSnapshotArg(nil, nil)
+	if err == nil {
+		t.Fatal("requireSnapshotArg(nil) expected error, got nil")
+	}
+	want := "missing required argument: snapshot ID or name"
+	if err.Error() != want {
+		t.Errorf("requireSnapshotArg(nil) error = %q, want %q", err.Error(), want)
+	}
+}
+
+// logsRequestRecorder tracks the build-logs requests served by the test server.
+type logsRequestRecorder struct {
+	mu      sync.Mutex
+	hits    int
+	follows []bool
+}
+
+func (r *logsRequestRecorder) record(req *http.Request) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.hits++
+	r.follows = append(r.follows, req.URL.Query().Get("follow") == "true")
+}
+
+func (r *logsRequestRecorder) snapshot() (int, []bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.hits, append([]bool(nil), r.follows...)
+}
+
+// logsTestSnapshotJSON renders a minimal SnapshotDto payload containing every
+// property the generated client requires plus the given state and error reason.
+func logsTestSnapshotJSON(state, errorReason string) string {
+	reason := "null"
+	if errorReason != "" {
+		reason = fmt.Sprintf("%q", errorReason)
+	}
+	return fmt.Sprintf(`{
+		"id": "snap-1",
+		"general": false,
+		"name": "my-snapshot",
+		"state": %q,
+		"size": null,
+		"entrypoint": [],
+		"cpu": 1,
+		"gpu": 0,
+		"mem": 1,
+		"disk": 1,
+		"errorReason": %s,
+		"createdAt": "2025-01-01T00:00:00Z",
+		"updatedAt": "2025-01-01T00:00:00Z",
+		"lastUsedAt": null
+	}`, state, reason)
+}
+
+// logsTestServer emulates the API routes the logs command hits: GetSnapshot
+// and the raw build-logs stream.
+func logsTestServer(t *testing.T, state, errorReason, logBody string, rec *logsRequestRecorder) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/snapshots/snap-1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, logsTestSnapshotJSON(state, errorReason))
+	})
+	mux.HandleFunc("/snapshots/snap-1/build-logs", func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		_, _ = io.WriteString(w, logBody)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+// logsTestEnv points profile resolution at the test server and sandboxes the
+// config cache away from the real machine config.
+func logsTestEnv(t *testing.T, serverURL string) {
+	t.Helper()
+	t.Setenv("DAYTONA_CONFIG_DIR", t.TempDir())
+	t.Setenv("DAYTONA_API_KEY", "test-api-key")
+	t.Setenv("DAYTONA_API_URL", serverURL)
+}
+
+func logsSetFollowFlag(t *testing.T, v bool) {
+	t.Helper()
+	orig := logsFollowFlag
+	logsFollowFlag = v
+	t.Cleanup(func() { logsFollowFlag = orig })
+}
+
+// logsCaptureStdout redirects os.Stdout for the duration of fn and returns
+// everything written to it.
+func logsCaptureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	collected := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(r)
+		collected <- string(data)
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing stdout pipe: %v", err)
+	}
+	os.Stdout = orig
+	return <-collected
+}
+
+func TestLogsCmdNonFollowStreamsBody(t *testing.T) {
+	body := "build log line 1\nbuild log line 2\n"
+	rec := &logsRequestRecorder{}
+	server := logsTestServer(t, "active", "", body, rec)
+	logsTestEnv(t, server.URL)
+	logsSetFollowFlag(t, false)
+
+	var err error
+	out := logsCaptureStdout(t, func() {
+		err = LogsCmd.RunE(LogsCmd, []string{"snap-1"})
+	})
+
+	if err != nil {
+		t.Fatalf("LogsCmd.RunE() error: %v", err)
+	}
+	if out != body {
+		t.Errorf("stdout = %q, want %q", out, body)
+	}
+	hits, follows := rec.snapshot()
+	if hits != 1 {
+		t.Fatalf("build-logs requests = %d, want 1", hits)
+	}
+	if follows[0] {
+		t.Error("non-follow fetch sent follow=true")
+	}
+}
+
+func TestLogsCmdNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"message":"snapshot not found","statusCode":404}`)
+	}))
+	t.Cleanup(server.Close)
+	logsTestEnv(t, server.URL)
+	logsSetFollowFlag(t, false)
+
+	err := LogsCmd.RunE(LogsCmd, []string{"missing"})
+	if err == nil {
+		t.Fatal("LogsCmd.RunE() expected error, got nil")
+	}
+	if !clierr.HasCategory(err, clierr.CategoryNotFound) {
+		t.Errorf("LogsCmd.RunE() error = %v, want not_found-category clierr", err)
+	}
+}
+
+// TestLogsCmdFollowAlreadyTerminalCompleteFetch is the regression test for
+// follow mode truncating output when the snapshot is already terminal at
+// entry: the complete log history must arrive via exactly one plain
+// (non-follow) fetch.
+func TestLogsCmdFollowAlreadyTerminalCompleteFetch(t *testing.T) {
+	body := strings.Repeat("a long line of build output that must not be truncated\n", 200)
+	rec := &logsRequestRecorder{}
+	server := logsTestServer(t, "active", "", body, rec)
+	logsTestEnv(t, server.URL)
+	logsSetFollowFlag(t, true)
+
+	var err error
+	out := logsCaptureStdout(t, func() {
+		err = LogsCmd.RunE(LogsCmd, []string{"snap-1"})
+	})
+
+	if err != nil {
+		t.Fatalf("LogsCmd.RunE() error: %v", err)
+	}
+	if out != body {
+		t.Errorf("streamed %d bytes, want the complete %d-byte log output", len(out), len(body))
+	}
+	hits, follows := rec.snapshot()
+	if hits != 1 {
+		t.Fatalf("build-logs requests = %d, want exactly 1", hits)
+	}
+	if follows[0] {
+		t.Error("already-terminal fetch used follow=true, want a plain fetch")
+	}
+}
+
+func TestLogsCmdFollowBuildFailedPropagatesReason(t *testing.T) {
+	body := "build log output\n"
+	rec := &logsRequestRecorder{}
+	server := logsTestServer(t, "build_failed", "docker build exploded", body, rec)
+	logsTestEnv(t, server.URL)
+	logsSetFollowFlag(t, true)
+
+	var err error
+	out := logsCaptureStdout(t, func() {
+		err = LogsCmd.RunE(LogsCmd, []string{"snap-1"})
+	})
+
+	if !clierr.HasCategory(err, clierr.CategoryServer) {
+		t.Fatalf("LogsCmd.RunE() error = %v, want server-category clierr", err)
+	}
+	if !strings.Contains(err.Error(), "docker build exploded") {
+		t.Errorf("LogsCmd.RunE() error = %q, want it to mention the error reason", err.Error())
+	}
+	if out != body {
+		t.Errorf("stdout = %q, want %q", out, body)
+	}
+	if hits, _ := rec.snapshot(); hits != 1 {
+		t.Errorf("build-logs requests = %d, want 1", hits)
 	}
 }

--- a/apps/cli/cmd/snapshot/push.go
+++ b/apps/cli/cmd/snapshot/push.go
@@ -15,6 +15,7 @@ import (
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/docker"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	views_common "github.com/daytonaio/daytona/cli/views/common"
 	views_util "github.com/daytonaio/daytona/cli/views/util"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
@@ -128,11 +129,18 @@ var PushCmd = &cobra.Command{
 
 		// Poll until the image is really available on the registry
 		// This is a workaround for harbor's delay in making newly created images available
+		registryDeadline := time.Time{}
+		if pushTimeoutFlag > 0 {
+			registryDeadline = time.Now().Add(pushTimeoutFlag)
+		}
 		for {
 			_, err := dockerClient.DistributionInspect(ctx, targetImage,
 				base64.URLEncoding.EncodeToString(encodedAuthConfig))
 			if err == nil {
 				break
+			}
+			if !registryDeadline.IsZero() && time.Now().After(registryDeadline) {
+				return clierr.Newf(clierr.CategoryTimeout, "timed out after %s waiting for image %q to become available on the registry", pushTimeoutFlag, targetImage)
 			}
 			time.Sleep(time.Second)
 		}

--- a/apps/cli/cmd/snapshot/push.go
+++ b/apps/cli/cmd/snapshot/push.go
@@ -158,7 +158,7 @@ var PushCmd = &cobra.Command{
 		views_common.RenderInfoMessageBold(fmt.Sprintf("Successfully pushed %s to Daytona", sourceImage))
 
 		err = views_util.WithInlineSpinner("Waiting for the snapshot to be validated", func() error {
-			return common.AwaitSnapshotState(ctx, apiClient, nameFlag, 0, apiclient.SNAPSHOTSTATE_ACTIVE)
+			return common.AwaitSnapshotState(ctx, apiClient, nameFlag, pushTimeoutFlag, apiclient.SNAPSHOTSTATE_ACTIVE)
 		})
 		if err != nil {
 			return err
@@ -170,7 +170,8 @@ var PushCmd = &cobra.Command{
 }
 
 var (
-	nameFlag string
+	nameFlag        string
+	pushTimeoutFlag time.Duration
 )
 
 func init() {
@@ -180,6 +181,7 @@ func init() {
 	PushCmd.Flags().Int32Var(&memoryFlag, "memory", 0, "Memory that will be allocated to the underlying sandboxes in GB (default: 1)")
 	PushCmd.Flags().Int32Var(&diskFlag, "disk", 0, "Disk space that will be allocated to the underlying sandboxes in GB (default: 3)")
 	PushCmd.Flags().StringVar(&regionIdFlag, "region", "", "ID of the region where the snapshot will be available (defaults to organization default region)")
+	PushCmd.Flags().DurationVar(&pushTimeoutFlag, "timeout", 0, "Maximum time to wait for the snapshot to be validated (0 means wait indefinitely)")
 
 	_ = PushCmd.MarkFlagRequired("name")
 }

--- a/apps/cli/cmd/snapshot/push.go
+++ b/apps/cli/cmd/snapshot/push.go
@@ -29,7 +29,9 @@ var PushCmd = &cobra.Command{
 	Use:   "push [SNAPSHOT]",
 	Short: "Push local snapshot",
 	Long:  "Push a local Docker image to Daytona. To securely build it on our infrastructure, use 'daytona snapshot build'",
-	Args:  cobra.ExactArgs(1),
+	Example: `  daytona snapshot push my-image:latest --name my-snapshot:1.0
+  daytona snapshot push my-image:latest --name my-snapshot:1.0 --cpu 2 --memory 4`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		sourceImage := args[0]

--- a/apps/cli/cmd/snapshot/push.go
+++ b/apps/cli/cmd/snapshot/push.go
@@ -156,7 +156,7 @@ var PushCmd = &cobra.Command{
 		views_common.RenderInfoMessageBold(fmt.Sprintf("Successfully pushed %s to Daytona", sourceImage))
 
 		err = views_util.WithInlineSpinner("Waiting for the snapshot to be validated", func() error {
-			return common.AwaitSnapshotState(ctx, apiClient, nameFlag, apiclient.SNAPSHOTSTATE_ACTIVE)
+			return common.AwaitSnapshotState(ctx, apiClient, nameFlag, 0, apiclient.SNAPSHOTSTATE_ACTIVE)
 		})
 		if err != nil {
 			return err

--- a/apps/cli/cmd/snapshot/snapshot.go
+++ b/apps/cli/cmd/snapshot/snapshot.go
@@ -21,4 +21,5 @@ func init() {
 	SnapshotsCmd.AddCommand(CreateCmd)
 	SnapshotsCmd.AddCommand(PushCmd)
 	SnapshotsCmd.AddCommand(DeleteCmd)
+	SnapshotsCmd.AddCommand(LogsCmd)
 }

--- a/apps/cli/cmd/volume/create.go
+++ b/apps/cli/cmd/volume/create.go
@@ -38,9 +38,3 @@ var CreateCmd = &cobra.Command{
 		return nil
 	},
 }
-
-var sizeFlag int32
-
-func init() {
-	CreateCmd.Flags().Int32VarP(&sizeFlag, "size", "s", 10, "Size of the volume in GB")
-}

--- a/apps/cli/cmd/volume/create.go
+++ b/apps/cli/cmd/volume/create.go
@@ -15,8 +15,11 @@ import (
 )
 
 var CreateCmd = &cobra.Command{
-	Use:     "create [NAME]",
-	Short:   "Create a volume",
+	Use:   "create [NAME]",
+	Short: "Create a volume",
+	Example: `  daytona volume create my-volume
+  # Mount it when creating a sandbox
+  daytona create --snapshot my-snapshot:1.0 --volume my-volume:/data`,
 	Args:    cobra.ExactArgs(1),
 	Aliases: common.GetAliases("create"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/volume/create_test.go
+++ b/apps/cli/cmd/volume/create_test.go
@@ -1,0 +1,12 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package volume
+
+import "testing"
+
+func TestCreateCmdHasNoSizeFlag(t *testing.T) {
+	if flag := CreateCmd.Flags().Lookup("size"); flag != nil {
+		t.Errorf("CreateCmd has a --size flag, want none (the API model has no size field)")
+	}
+}

--- a/apps/cli/cmd/volume/delete.go
+++ b/apps/cli/cmd/volume/delete.go
@@ -14,8 +14,10 @@ import (
 )
 
 var DeleteCmd = &cobra.Command{
-	Use:     "delete [VOLUME_ID_OR_NAME]",
-	Short:   "Delete a volume",
+	Use:   "delete [VOLUME_ID_OR_NAME]",
+	Short: "Delete a volume",
+	Example: `  # Delete a volume by name or ID
+  daytona volume delete my-volume`,
 	Args:    cobra.ExactArgs(1),
 	Aliases: common.GetAliases("delete"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/volume/get.go
+++ b/apps/cli/cmd/volume/get.go
@@ -13,8 +13,10 @@ import (
 )
 
 var GetCmd = &cobra.Command{
-	Use:     "get [VOLUME_ID_OR_NAME]",
-	Short:   "Get volume details",
+	Use:   "get [VOLUME_ID_OR_NAME]",
+	Short: "Get volume details",
+	Example: `  daytona volume get my-volume
+  daytona volume get my-volume --format json`,
 	Args:    cobra.ExactArgs(1),
 	Aliases: common.GetAliases("get"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/cmd/volume/list.go
+++ b/apps/cli/cmd/volume/list.go
@@ -14,8 +14,10 @@ import (
 )
 
 var ListCmd = &cobra.Command{
-	Use:     "list",
-	Short:   "List all volumes",
+	Use:   "list",
+	Short: "List all volumes",
+	Example: `  daytona volume list
+  daytona volume list --format json`,
 	Args:    cobra.NoArgs,
 	Aliases: common.GetAliases("list"),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/apps/cli/config/config.go
+++ b/apps/cli/config/config.go
@@ -82,14 +82,21 @@ func (c *Config) GetActiveProfile() (Profile, error) {
 	apiUrl := os.Getenv(DAYTONA_API_URL_ENV_VAR)
 	apiKey := os.Getenv(DAYTONA_API_KEY_ENV_VAR)
 
-	if apiUrl != "" && apiKey != "" {
-		return Profile{
-			Id: "env",
-			Api: ServerApi{
-				Url: apiUrl,
-				Key: &apiKey,
-			},
-		}, nil
+	if apiKey != "" {
+		if apiUrl == "" {
+			// Fall back to the default API URL baked into release builds;
+			// dev builds have none and fall through to stored profiles.
+			apiUrl = GetDaytonaApiUrl()
+		}
+		if apiUrl != "" {
+			return Profile{
+				Id: "env",
+				Api: ServerApi{
+					Url: apiUrl,
+					Key: &apiKey,
+				},
+			}, nil
+		}
 	}
 
 	if len(c.Profiles) == 0 {

--- a/apps/cli/config/config_test.go
+++ b/apps/cli/config/config_test.go
@@ -1,0 +1,95 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package config_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal"
+)
+
+func TestGetActiveProfile(t *testing.T) {
+	storedKey := "stored-key"
+	cfg := config.Config{
+		ActiveProfileId: "p1",
+		Profiles: []config.Profile{
+			{Id: "p1", Name: "default", Api: config.ServerApi{Url: "https://stored.example.com/api", Key: &storedKey}},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		envKey     string
+		envUrl     string
+		builtinUrl string
+		wantId     string
+		wantUrl    string
+	}{
+		{
+			name:    "key and url env set uses env profile",
+			envKey:  "env-key",
+			envUrl:  "https://env.example.com/api",
+			wantId:  "env",
+			wantUrl: "https://env.example.com/api",
+		},
+		{
+			name:       "key env only falls back to built-in api url",
+			envKey:     "env-key",
+			builtinUrl: "https://builtin.example.com/api",
+			wantId:     "env",
+			wantUrl:    "https://builtin.example.com/api",
+		},
+		{
+			name:    "key env only without built-in url falls back to stored profile",
+			envKey:  "env-key",
+			wantId:  "p1",
+			wantUrl: "https://stored.example.com/api",
+		},
+		{
+			name:    "url env only falls back to stored profile",
+			envUrl:  "https://env.example.com/api",
+			wantId:  "p1",
+			wantUrl: "https://stored.example.com/api",
+		},
+		{
+			name:    "no env uses active profile",
+			wantId:  "p1",
+			wantUrl: "https://stored.example.com/api",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(config.DAYTONA_API_KEY_ENV_VAR, tt.envKey)
+			t.Setenv(config.DAYTONA_API_URL_ENV_VAR, tt.envUrl)
+			prevBuiltin := internal.DaytonaApiUrl
+			internal.DaytonaApiUrl = tt.builtinUrl
+			t.Cleanup(func() { internal.DaytonaApiUrl = prevBuiltin })
+
+			profile, err := cfg.GetActiveProfile()
+			if err != nil {
+				t.Fatalf("GetActiveProfile() unexpected error: %v", err)
+			}
+			if profile.Id != tt.wantId {
+				t.Errorf("GetActiveProfile() profile id = %q, want %q", profile.Id, tt.wantId)
+			}
+			if profile.Api.Url != tt.wantUrl {
+				t.Errorf("GetActiveProfile() api url = %q, want %q", profile.Api.Url, tt.wantUrl)
+			}
+		})
+	}
+}
+
+func TestGetActiveProfileNoProfiles(t *testing.T) {
+	t.Setenv(config.DAYTONA_API_KEY_ENV_VAR, "")
+	t.Setenv(config.DAYTONA_API_URL_ENV_VAR, "")
+
+	cfg := config.Config{}
+	_, err := cfg.GetActiveProfile()
+	if !errors.Is(err, config.ErrNoProfilesFound) {
+		t.Errorf("GetActiveProfile() error = %v, want ErrNoProfilesFound", err)
+	}
+}

--- a/apps/cli/docs/daytona.md
+++ b/apps/cli/docs/daytona.md
@@ -6,6 +6,8 @@ Daytona CLI
 
 Command line interface for Daytona Sandboxes
 
+Exit codes: 0 success; 1 runtime failure; 2 invalid flags or arguments (where validated); 124 wait timeout. 'daytona exec' exits with the remote command's exit code; 255 indicates a CLI-side failure.
+
 ```
 daytona [flags]
 ```
@@ -13,14 +15,17 @@ daytona [flags]
 ### Options
 
 ```
-      --help      help for daytona
-  -v, --version   Display the version of Daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
+  -v, --version    Display the version of Daytona
 ```
 
 ### SEE ALSO
 
+* [daytona api](daytona_api.md)  - Make an authenticated request to the Daytona API
 * [daytona archive](daytona_archive.md)  - Archive a sandbox
 * [daytona autocomplete](daytona_autocomplete.md)  - Adds a completion script for your shell environment
+* [daytona cp](daytona_cp.md)  - Copy files between the local machine and a sandbox
 * [daytona create](daytona_create.md)  - Create a new sandbox
 * [daytona delete](daytona_delete.md)  - Delete a sandbox
 * [daytona docs](daytona_docs.md)  - Opens the Daytona documentation in your default browser.
@@ -29,6 +34,7 @@ daytona [flags]
 * [daytona list](daytona_list.md)  - List sandboxes
 * [daytona login](daytona_login.md)  - Log in to Daytona
 * [daytona logout](daytona_logout.md)  - Logout from Daytona
+* [daytona logs](daytona_logs.md)  - View the build logs of a sandbox
 * [daytona mcp](daytona_mcp.md)  - Manage Daytona MCP Server
 * [daytona organization](daytona_organization.md)  - Manage Daytona organizations
 * [daytona preview-url](daytona_preview-url.md)  - Get signed preview URL for a sandbox port

--- a/apps/cli/docs/daytona_api.md
+++ b/apps/cli/docs/daytona_api.md
@@ -1,0 +1,40 @@
+## daytona api
+
+Make an authenticated request to the Daytona API
+
+### Synopsis
+
+Make an authenticated HTTP request to the Daytona API and print the raw response body to stdout.
+
+PATH is resolved against the active profile's API URL and the request is authenticated with the active profile's credentials. Responses with status 400 or above still print the body, then exit non-zero.
+
+```
+daytona api PATH [flags]
+```
+
+### Examples
+
+```
+  daytona api /sandbox
+  daytona api /sandbox/my-sandbox -X DELETE
+  daytona api /snapshots -X POST --input snapshot.json
+  cat body.json | daytona api /sandbox -X POST --input -
+```
+
+### Options
+
+```
+      --input string    Request body source: a file path or '-' for stdin (POST, PUT, and PATCH only)
+  -X, --method string   HTTP method (GET, POST, PUT, PATCH, DELETE, HEAD) (default "GET")
+```
+
+### Options inherited from parent commands
+
+```
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
+```
+
+### SEE ALSO
+
+* [daytona](daytona.md)  - Daytona CLI

--- a/apps/cli/docs/daytona_archive.md
+++ b/apps/cli/docs/daytona_archive.md
@@ -3,13 +3,30 @@
 Archive a sandbox
 
 ```
-daytona archive [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+daytona archive [SANDBOX_ID | SANDBOX_NAME] [flags]
+```
+
+### Examples
+
+```
+  daytona archive my-sandbox
+  daytona archive my-sandbox --wait --timeout 10m
+  daytona archive my-sandbox --wait --format json
+```
+
+### Options
+
+```
+  -f, --format string      Output format. Must be one of (yaml, json)
+      --timeout duration   Maximum time to wait with --wait (0 waits indefinitely) (default 5m0s)
+      --wait               Wait until the sandbox is archived
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_autocomplete.md
+++ b/apps/cli/docs/daytona_autocomplete.md
@@ -9,7 +9,8 @@ daytona autocomplete [bash|zsh|fish|powershell] [flags]
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_cp.md
+++ b/apps/cli/docs/daytona_cp.md
@@ -1,0 +1,41 @@
+## daytona cp
+
+Copy files between the local machine and a sandbox
+
+### Synopsis
+
+Copy files or directories between the local filesystem and a sandbox.
+
+Exactly one of SOURCE or DESTINATION must reference a sandbox path using the
+<sandbox>:<path> form, where <sandbox> is a sandbox ID or name. Directories
+are copied recursively. Copying into an existing directory places the source
+basename inside it, and missing parent directories are created.
+
+```
+daytona cp SOURCE DESTINATION [flags]
+```
+
+### Examples
+
+```
+  daytona cp ./config.yaml my-sandbox:/workspace/config.yaml
+  daytona cp my-sandbox:/workspace/output ./output
+  daytona cp ./src my-sandbox:/workspace/src --format json
+```
+
+### Options
+
+```
+  -f, --format string   Output format. Must be one of (yaml, json)
+```
+
+### Options inherited from parent commands
+
+```
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
+```
+
+### SEE ALSO
+
+* [daytona](daytona.md)  - Daytona CLI

--- a/apps/cli/docs/daytona_create.md
+++ b/apps/cli/docs/daytona_create.md
@@ -6,6 +6,14 @@ Create a new sandbox
 daytona create [flags]
 ```
 
+### Examples
+
+```
+  daytona create --snapshot my-snapshot:1.0 --name my-sandbox
+  daytona create --name my-sandbox --env-file .env --if-exists reuse
+  daytona create --snapshot my-snapshot:1.0 --name my-sandbox --format json
+```
+
 ### Options
 
 ```
@@ -17,8 +25,12 @@ daytona create [flags]
       --disk int32                  Disk space allocated to the sandbox in GB
   -f, --dockerfile string           Path to Dockerfile for Sandbox snapshot
   -e, --env stringArray             Environment variables (format: KEY=VALUE)
+      --env-file string             Read environment variables from a dotenv-style file (entries from --env override file values)
+      --format string               Output format. Must be one of (yaml, json)
       --gpu int32                   GPU units allocated to the sandbox
+      --if-exists string            Behavior when a sandbox with the same name already exists (error, reuse; reuse requires --name) (default "error")
   -l, --label stringArray           Labels (format: KEY=VALUE)
+      --label-file string           Read labels from a dotenv-style file (entries from --label override file values)
       --memory int32                Memory allocated to the sandbox in MB
       --name string                 Name of the sandbox
       --network-allow-list string   Comma-separated list of allowed CIDR network addresses for the sandbox
@@ -26,6 +38,7 @@ daytona create [flags]
       --public                      Make sandbox publicly accessible
       --snapshot string             Snapshot to use for the sandbox
       --target string               Target region (eu, us)
+      --timeout duration            Maximum time to wait for the sandbox to start (0 means wait indefinitely)
       --user string                 User associated with the sandbox
   -v, --volume stringArray          Volumes to mount (format: VOLUME_ID_OR_NAME:MOUNT_PATH)
 ```
@@ -33,7 +46,8 @@ daytona create [flags]
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_delete.md
+++ b/apps/cli/docs/daytona_delete.md
@@ -3,19 +3,35 @@
 Delete a sandbox
 
 ```
-daytona delete [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+daytona delete [SANDBOX_ID | SANDBOX_NAME] [flags]
+```
+
+### Examples
+
+```
+  daytona delete my-sandbox
+  daytona delete my-sandbox --wait --format json
+  daytona delete --all --dry-run
+  daytona delete --all --yes
 ```
 
 ### Options
 
 ```
-  -a, --all   Delete all sandboxes
+  -a, --all                Delete all sandboxes
+      --dry-run            Show what would be deleted without deleting anything
+  -f, --format string      Output format. Must be one of (yaml, json)
+      --ignore-not-found   Treat a missing sandbox as a successful delete
+      --timeout duration   Maximum time to wait with --wait (0 waits indefinitely) (default 5m0s)
+      --wait               Wait until the sandbox is fully deleted
+  -y, --yes                Skip the confirmation prompt for bulk deletes
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_docs.md
+++ b/apps/cli/docs/daytona_docs.md
@@ -9,7 +9,8 @@ daytona docs [flags]
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_exec.md
+++ b/apps/cli/docs/daytona_exec.md
@@ -4,23 +4,35 @@ Execute a command in a sandbox
 
 ### Synopsis
 
-Execute a command in a running sandbox
+Execute a command in a running sandbox.
+
+Exits with the remote command's exit code; exit code 255 indicates a CLI-side failure (for example the sandbox was not found or is not running).
 
 ```
 daytona exec [SANDBOX_ID | SANDBOX_NAME] -- [COMMAND] [ARGS...] [flags]
 ```
 
+### Examples
+
+```
+  daytona exec my-sandbox -- ls -la /workspace
+  daytona exec my-sandbox -- python -c "print('hi')"
+  daytona exec my-sandbox --cwd /workspace --format json -- npm test
+```
+
 ### Options
 
 ```
-      --cwd string    Working directory for command execution
-      --timeout int   Command timeout in seconds (0 for no timeout)
+      --cwd string      Working directory for command execution
+  -f, --format string   Output format. Must be one of (yaml, json)
+      --timeout int     Command timeout in seconds (0 for no timeout)
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_info.md
+++ b/apps/cli/docs/daytona_info.md
@@ -6,6 +6,13 @@ Get sandbox info
 daytona info [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 ```
 
+### Examples
+
+```
+  daytona info my-sandbox
+  daytona info my-sandbox --format json
+```
+
 ### Options
 
 ```
@@ -15,7 +22,8 @@ daytona info [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_info.md
+++ b/apps/cli/docs/daytona_info.md
@@ -3,7 +3,7 @@
 Get sandbox info
 
 ```
-daytona info [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+daytona info [SANDBOX_ID | SANDBOX_NAME] [flags]
 ```
 
 ### Examples

--- a/apps/cli/docs/daytona_list.md
+++ b/apps/cli/docs/daytona_list.md
@@ -6,6 +6,14 @@ List sandboxes
 daytona list [flags]
 ```
 
+### Examples
+
+```
+  daytona list
+  daytona list --limit 50
+  daytona list --format json
+```
+
 ### Options
 
 ```
@@ -17,7 +25,8 @@ daytona list [flags]
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_login.md
+++ b/apps/cli/docs/daytona_login.md
@@ -6,16 +6,27 @@ Log in to Daytona
 daytona login [flags]
 ```
 
+### Examples
+
+```
+  daytona login
+  daytona login --api-key $DAYTONA_API_KEY
+  daytona login --api-key-stdin < ~/.daytona-api-key
+```
+
 ### Options
 
 ```
-      --api-key string   API key to use for authentication
+      --api-key string        API key to use for authentication
+      --api-key-file string   Read the API key from a file
+      --api-key-stdin         Read the API key from stdin
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_logout.md
+++ b/apps/cli/docs/daytona_logout.md
@@ -9,7 +9,8 @@ daytona logout [flags]
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_logs.md
+++ b/apps/cli/docs/daytona_logs.md
@@ -1,0 +1,35 @@
+## daytona logs
+
+View the build logs of a sandbox
+
+### Synopsis
+
+View the build logs of a sandbox. With --follow the logs are streamed until the sandbox build reaches a terminal state.
+
+```
+daytona logs [SANDBOX_ID | SANDBOX_NAME] [flags]
+```
+
+### Examples
+
+```
+  daytona logs my-sandbox
+  daytona logs my-sandbox --follow
+```
+
+### Options
+
+```
+  -f, --follow   Follow the logs until the sandbox build reaches a terminal state
+```
+
+### Options inherited from parent commands
+
+```
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
+```
+
+### SEE ALSO
+
+* [daytona](daytona.md)  - Daytona CLI

--- a/apps/cli/docs/daytona_mcp.md
+++ b/apps/cli/docs/daytona_mcp.md
@@ -9,7 +9,8 @@ Commands for managing Daytona MCP Server
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_mcp_config.md
+++ b/apps/cli/docs/daytona_mcp_config.md
@@ -3,13 +3,21 @@
 Outputs JSON configuration for Daytona MCP Server
 
 ```
-daytona mcp config [AGENT_NAME] [flags]
+daytona mcp config [flags]
+```
+
+### Examples
+
+```
+  daytona mcp config
+  daytona mcp config > daytona-mcp.json
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_mcp_init.md
+++ b/apps/cli/docs/daytona_mcp_init.md
@@ -6,10 +6,18 @@ Initialize Daytona MCP Server with an agent (currently supported: claude, windsu
 daytona mcp init [AGENT_NAME] [flags]
 ```
 
+### Examples
+
+```
+  daytona mcp init claude
+  daytona mcp init cursor
+```
+
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_mcp_start.md
+++ b/apps/cli/docs/daytona_mcp_start.md
@@ -6,10 +6,18 @@ Start Daytona MCP Server
 daytona mcp start [flags]
 ```
 
+### Examples
+
+```
+  # Typically launched by an MCP client (see 'daytona mcp init')
+  daytona mcp start
+```
+
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_organization.md
+++ b/apps/cli/docs/daytona_organization.md
@@ -9,7 +9,8 @@ Commands for managing Daytona organizations
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_organization_create.md
+++ b/apps/cli/docs/daytona_organization_create.md
@@ -6,10 +6,24 @@ Create a new organization and set it as active
 daytona organization create [ORGANIZATION_NAME] [flags]
 ```
 
+### Examples
+
+```
+  daytona organization create my-org
+  daytona organization create my-org --region us
+```
+
+### Options
+
+```
+  -r, --region string   Default region (id or name) for the organization
+```
+
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_organization_delete.md
+++ b/apps/cli/docs/daytona_organization_delete.md
@@ -6,10 +6,19 @@ Delete an organization
 daytona organization delete [ORGANIZATION] [flags]
 ```
 
+### Examples
+
+```
+  daytona organization delete my-org
+  # With no argument, pick from a list interactively
+  daytona organization delete
+```
+
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_organization_list.md
+++ b/apps/cli/docs/daytona_organization_list.md
@@ -6,6 +6,13 @@ List all organizations
 daytona organization list [flags]
 ```
 
+### Examples
+
+```
+  daytona organization list
+  daytona organization list --format json
+```
+
 ### Options
 
 ```
@@ -15,7 +22,8 @@ daytona organization list [flags]
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_organization_use.md
+++ b/apps/cli/docs/daytona_organization_use.md
@@ -6,10 +6,19 @@ Set active organization
 daytona organization use [ORGANIZATION] [flags]
 ```
 
+### Examples
+
+```
+  daytona organization use my-org
+  # With no argument, pick from a list interactively
+  daytona organization use
+```
+
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_preview-url.md
+++ b/apps/cli/docs/daytona_preview-url.md
@@ -6,17 +6,27 @@ Get signed preview URL for a sandbox port
 daytona preview-url [SANDBOX_ID | SANDBOX_NAME] [flags]
 ```
 
+### Examples
+
+```
+  daytona preview-url my-sandbox --port 3000
+  daytona preview-url my-sandbox --port 3000 --expires 7200
+  daytona preview-url my-sandbox --port 3000 --format json
+```
+
 ### Options
 
 ```
       --expires int32   URL expiration time in seconds (default 3600)
+  -f, --format string   Output format. Must be one of (yaml, json)
   -p, --port int32      Port number to get preview URL for (required)
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_snapshot.md
+++ b/apps/cli/docs/daytona_snapshot.md
@@ -9,7 +9,8 @@ Commands for managing Daytona snapshots
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO
@@ -18,4 +19,5 @@ Commands for managing Daytona snapshots
 * [daytona snapshot create](daytona_snapshot_create.md)  - Create a snapshot
 * [daytona snapshot delete](daytona_snapshot_delete.md)  - Delete a snapshot
 * [daytona snapshot list](daytona_snapshot_list.md)  - List all snapshots
+* [daytona snapshot logs](daytona_snapshot_logs.md)  - View the build logs of a snapshot
 * [daytona snapshot push](daytona_snapshot_push.md)  - Push local snapshot

--- a/apps/cli/docs/daytona_snapshot_create.md
+++ b/apps/cli/docs/daytona_snapshot_create.md
@@ -25,6 +25,7 @@ daytona snapshot create [SNAPSHOT] [flags]
   -i, --image string          The image name for the snapshot
       --memory int32          Memory that will be allocated to the underlying sandboxes in GB (default: 1)
       --region string         ID of the region where the snapshot will be available (defaults to organization default region)
+      --timeout duration      Maximum time to wait for the snapshot to become active (0 means wait indefinitely)
 ```
 
 ### Options inherited from parent commands

--- a/apps/cli/docs/daytona_snapshot_create.md
+++ b/apps/cli/docs/daytona_snapshot_create.md
@@ -6,6 +6,14 @@ Create a snapshot
 daytona snapshot create [SNAPSHOT] [flags]
 ```
 
+### Examples
+
+```
+  daytona snapshot create my-snapshot:1.0 --image ubuntu:22.04 --entrypoint "sleep infinity"
+  daytona snapshot create my-snapshot:1.0 --dockerfile ./Dockerfile --context ./app
+  daytona snapshot create my-snapshot:1.0 --image ubuntu:22.04 --cpu 2 --memory 4 --disk 10
+```
+
 ### Options
 
 ```
@@ -22,7 +30,8 @@ daytona snapshot create [SNAPSHOT] [flags]
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_snapshot_delete.md
+++ b/apps/cli/docs/daytona_snapshot_delete.md
@@ -6,16 +6,29 @@ Delete a snapshot
 daytona snapshot delete [SNAPSHOT_ID | SNAPSHOT_NAME] [flags]
 ```
 
+### Examples
+
+```
+  daytona snapshot delete my-snapshot:1.0
+  daytona snapshot delete --all --dry-run
+  daytona snapshot delete --all --yes --format json
+```
+
 ### Options
 
 ```
-  -a, --all   Delete all snapshots
+  -a, --all                Delete all snapshots
+      --dry-run            Show what would be deleted without deleting anything
+  -f, --format string      Output format. Must be one of (yaml, json)
+      --ignore-not-found   Treat a missing snapshot as a successful delete
+  -y, --yes                Skip the confirmation prompt for bulk deletes
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_snapshot_list.md
+++ b/apps/cli/docs/daytona_snapshot_list.md
@@ -10,6 +10,14 @@ List all available Daytona snapshots
 daytona snapshot list [flags]
 ```
 
+### Examples
+
+```
+  daytona snapshot list
+  daytona snapshot list --limit 50
+  daytona snapshot list --format json
+```
+
 ### Options
 
 ```
@@ -21,7 +29,8 @@ daytona snapshot list [flags]
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_snapshot_logs.md
+++ b/apps/cli/docs/daytona_snapshot_logs.md
@@ -1,0 +1,35 @@
+## daytona snapshot logs
+
+View the build logs of a snapshot
+
+### Synopsis
+
+View the build logs of a snapshot. With --follow the logs are streamed until the snapshot build reaches a terminal state.
+
+```
+daytona snapshot logs [SNAPSHOT_ID | SNAPSHOT_NAME] [flags]
+```
+
+### Examples
+
+```
+  daytona snapshot logs my-snapshot:1.0
+  daytona snapshot logs my-snapshot:1.0 --follow
+```
+
+### Options
+
+```
+  -f, --follow   Follow the logs until the snapshot build reaches a terminal state
+```
+
+### Options inherited from parent commands
+
+```
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
+```
+
+### SEE ALSO
+
+* [daytona snapshot](daytona_snapshot.md)  - Manage Daytona snapshots

--- a/apps/cli/docs/daytona_snapshot_push.md
+++ b/apps/cli/docs/daytona_snapshot_push.md
@@ -26,6 +26,7 @@ daytona snapshot push [SNAPSHOT] [flags]
       --memory int32        Memory that will be allocated to the underlying sandboxes in GB (default: 1)
   -n, --name string         Specify the Snapshot name
       --region string       ID of the region where the snapshot will be available (defaults to organization default region)
+      --timeout duration    Maximum time to wait for the snapshot to be validated (0 means wait indefinitely)
 ```
 
 ### Options inherited from parent commands

--- a/apps/cli/docs/daytona_snapshot_push.md
+++ b/apps/cli/docs/daytona_snapshot_push.md
@@ -10,6 +10,13 @@ Push a local Docker image to Daytona. To securely build it on our infrastructure
 daytona snapshot push [SNAPSHOT] [flags]
 ```
 
+### Examples
+
+```
+  daytona snapshot push my-image:latest --name my-snapshot:1.0
+  daytona snapshot push my-image:latest --name my-snapshot:1.0 --cpu 2 --memory 4
+```
+
 ### Options
 
 ```
@@ -24,7 +31,8 @@ daytona snapshot push [SNAPSHOT] [flags]
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_ssh.md
+++ b/apps/cli/docs/daytona_ssh.md
@@ -7,7 +7,7 @@ SSH into a sandbox
 Establish an SSH connection to a running sandbox
 
 ```
-daytona ssh [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+daytona ssh [SANDBOX_ID | SANDBOX_NAME] [flags]
 ```
 
 ### Examples

--- a/apps/cli/docs/daytona_ssh.md
+++ b/apps/cli/docs/daytona_ssh.md
@@ -10,6 +10,13 @@ Establish an SSH connection to a running sandbox
 daytona ssh [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 ```
 
+### Examples
+
+```
+  daytona ssh my-sandbox
+  daytona ssh my-sandbox --expires 60
+```
+
 ### Options
 
 ```
@@ -19,7 +26,8 @@ daytona ssh [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_start.md
+++ b/apps/cli/docs/daytona_start.md
@@ -3,13 +3,30 @@
 Start a sandbox
 
 ```
-daytona start [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+daytona start [SANDBOX_ID | SANDBOX_NAME] [flags]
+```
+
+### Examples
+
+```
+  daytona start my-sandbox
+  daytona start my-sandbox --wait --timeout 2m
+  daytona start my-sandbox --wait --format json
+```
+
+### Options
+
+```
+  -f, --format string      Output format. Must be one of (yaml, json)
+      --timeout duration   Maximum time to wait with --wait (0 waits indefinitely) (default 5m0s)
+      --wait               Wait until the sandbox is started
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_stop.md
+++ b/apps/cli/docs/daytona_stop.md
@@ -3,19 +3,31 @@
 Stop a sandbox
 
 ```
-daytona stop [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+daytona stop [SANDBOX_ID | SANDBOX_NAME] [flags]
+```
+
+### Examples
+
+```
+  daytona stop my-sandbox
+  daytona stop my-sandbox --wait --timeout 2m
+  daytona stop my-sandbox --force --format json
 ```
 
 ### Options
 
 ```
-  -f, --force   Force stop the sandbox using SIGKILL
+  -f, --force              Force stop the sandbox using SIGKILL
+      --format string      Output format. Must be one of (yaml, json)
+      --timeout duration   Maximum time to wait with --wait (0 waits indefinitely) (default 5m0s)
+      --wait               Wait until the sandbox is stopped
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_version.md
+++ b/apps/cli/docs/daytona_version.md
@@ -9,7 +9,8 @@ daytona version [flags]
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_volume.md
+++ b/apps/cli/docs/daytona_volume.md
@@ -9,7 +9,8 @@ Commands for managing Daytona volumes
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_volume_create.md
+++ b/apps/cli/docs/daytona_volume_create.md
@@ -6,16 +6,19 @@ Create a volume
 daytona volume create [NAME] [flags]
 ```
 
-### Options
+### Examples
 
 ```
-  -s, --size int32   Size of the volume in GB (default 10)
+  daytona volume create my-volume
+  # Mount it when creating a sandbox
+  daytona create --snapshot my-snapshot:1.0 --volume my-volume:/data
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_volume_delete.md
+++ b/apps/cli/docs/daytona_volume_delete.md
@@ -6,10 +6,18 @@ Delete a volume
 daytona volume delete [VOLUME_ID_OR_NAME] [flags]
 ```
 
+### Examples
+
+```
+  # Delete a volume by name or ID
+  daytona volume delete my-volume
+```
+
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_volume_get.md
+++ b/apps/cli/docs/daytona_volume_get.md
@@ -6,6 +6,13 @@ Get volume details
 daytona volume get [VOLUME_ID_OR_NAME] [flags]
 ```
 
+### Examples
+
+```
+  daytona volume get my-volume
+  daytona volume get my-volume --format json
+```
+
 ### Options
 
 ```
@@ -15,7 +22,8 @@ daytona volume get [VOLUME_ID_OR_NAME] [flags]
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/docs/daytona_volume_list.md
+++ b/apps/cli/docs/daytona_volume_list.md
@@ -6,6 +6,13 @@ List all volumes
 daytona volume list [flags]
 ```
 
+### Examples
+
+```
+  daytona volume list
+  daytona volume list --format json
+```
+
 ### Options
 
 ```
@@ -15,7 +22,8 @@ daytona volume list [flags]
 ### Options inherited from parent commands
 
 ```
-      --help   help for daytona
+      --help       help for daytona
+      --no-input   Never prompt for input; fail instead when input would be required
 ```
 
 ### SEE ALSO

--- a/apps/cli/hack/docs/daytona.yaml
+++ b/apps/cli/hack/docs/daytona.yaml
@@ -1,32 +1,42 @@
 name: daytona
 synopsis: Daytona CLI
-description: Command line interface for Daytona Sandboxes
+description: |-
+    Command line interface for Daytona Sandboxes
+
+    Exit codes: 0 success; 1 runtime failure; 2 invalid flags or arguments (where validated); 124 wait timeout. 'daytona exec' exits with the remote command's exit code; 255 indicates a CLI-side failure.
 usage: daytona [flags]
 options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
-  - name: version
-    shorthand: v
-    default_value: 'false'
-    usage: Display the version of Daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+    - name: version
+      shorthand: v
+      default_value: "false"
+      usage: Display the version of Daytona
 see_also:
-  - daytona archive - Archive a sandbox
-  - daytona autocomplete - Adds a completion script for your shell environment
-  - daytona create - Create a new sandbox
-  - daytona delete - Delete a sandbox
-  - daytona docs - Opens the Daytona documentation in your default browser.
-  - daytona exec - Execute a command in a sandbox
-  - daytona info - Get sandbox info
-  - daytona list - List sandboxes
-  - daytona login - Log in to Daytona
-  - daytona logout - Logout from Daytona
-  - daytona mcp - Manage Daytona MCP Server
-  - daytona organization - Manage Daytona organizations
-  - daytona preview-url - Get signed preview URL for a sandbox port
-  - daytona snapshot - Manage Daytona snapshots
-  - daytona ssh - SSH into a sandbox
-  - daytona start - Start a sandbox
-  - daytona stop - Stop a sandbox
-  - daytona version - Print the version number
-  - daytona volume - Manage Daytona volumes
+    - daytona api - Make an authenticated request to the Daytona API
+    - daytona archive - Archive a sandbox
+    - daytona autocomplete - Adds a completion script for your shell environment
+    - daytona cp - Copy files between the local machine and a sandbox
+    - daytona create - Create a new sandbox
+    - daytona delete - Delete a sandbox
+    - daytona docs - Opens the Daytona documentation in your default browser.
+    - daytona exec - Execute a command in a sandbox
+    - daytona info - Get sandbox info
+    - daytona list - List sandboxes
+    - daytona login - Log in to Daytona
+    - daytona logout - Logout from Daytona
+    - daytona logs - View the build logs of a sandbox
+    - daytona mcp - Manage Daytona MCP Server
+    - daytona organization - Manage Daytona organizations
+    - daytona preview-url - Get signed preview URL for a sandbox port
+    - daytona snapshot - Manage Daytona snapshots
+    - daytona ssh - SSH into a sandbox
+    - daytona start - Start a sandbox
+    - daytona stop - Stop a sandbox
+    - daytona version - Print the version number
+    - daytona volume - Manage Daytona volumes

--- a/apps/cli/hack/docs/daytona.yaml
+++ b/apps/cli/hack/docs/daytona.yaml
@@ -1,42 +1,42 @@
 name: daytona
 synopsis: Daytona CLI
 description: |-
-    Command line interface for Daytona Sandboxes
+  Command line interface for Daytona Sandboxes
 
-    Exit codes: 0 success; 1 runtime failure; 2 invalid flags or arguments (where validated); 124 wait timeout. 'daytona exec' exits with the remote command's exit code; 255 indicates a CLI-side failure.
+  Exit codes: 0 success; 1 runtime failure; 2 invalid flags or arguments (where validated); 124 wait timeout. 'daytona exec' exits with the remote command's exit code; 255 indicates a CLI-side failure.
 usage: daytona [flags]
 options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
-    - name: version
-      shorthand: v
-      default_value: "false"
-      usage: Display the version of Daytona
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
+  - name: version
+    shorthand: v
+    default_value: 'false'
+    usage: Display the version of Daytona
 see_also:
-    - daytona api - Make an authenticated request to the Daytona API
-    - daytona archive - Archive a sandbox
-    - daytona autocomplete - Adds a completion script for your shell environment
-    - daytona cp - Copy files between the local machine and a sandbox
-    - daytona create - Create a new sandbox
-    - daytona delete - Delete a sandbox
-    - daytona docs - Opens the Daytona documentation in your default browser.
-    - daytona exec - Execute a command in a sandbox
-    - daytona info - Get sandbox info
-    - daytona list - List sandboxes
-    - daytona login - Log in to Daytona
-    - daytona logout - Logout from Daytona
-    - daytona logs - View the build logs of a sandbox
-    - daytona mcp - Manage Daytona MCP Server
-    - daytona organization - Manage Daytona organizations
-    - daytona preview-url - Get signed preview URL for a sandbox port
-    - daytona snapshot - Manage Daytona snapshots
-    - daytona ssh - SSH into a sandbox
-    - daytona start - Start a sandbox
-    - daytona stop - Stop a sandbox
-    - daytona version - Print the version number
-    - daytona volume - Manage Daytona volumes
+  - daytona api - Make an authenticated request to the Daytona API
+  - daytona archive - Archive a sandbox
+  - daytona autocomplete - Adds a completion script for your shell environment
+  - daytona cp - Copy files between the local machine and a sandbox
+  - daytona create - Create a new sandbox
+  - daytona delete - Delete a sandbox
+  - daytona docs - Opens the Daytona documentation in your default browser.
+  - daytona exec - Execute a command in a sandbox
+  - daytona info - Get sandbox info
+  - daytona list - List sandboxes
+  - daytona login - Log in to Daytona
+  - daytona logout - Logout from Daytona
+  - daytona logs - View the build logs of a sandbox
+  - daytona mcp - Manage Daytona MCP Server
+  - daytona organization - Manage Daytona organizations
+  - daytona preview-url - Get signed preview URL for a sandbox port
+  - daytona snapshot - Manage Daytona snapshots
+  - daytona ssh - SSH into a sandbox
+  - daytona start - Start a sandbox
+  - daytona stop - Stop a sandbox
+  - daytona version - Print the version number
+  - daytona volume - Manage Daytona volumes

--- a/apps/cli/hack/docs/daytona_api.yaml
+++ b/apps/cli/hack/docs/daytona_api.yaml
@@ -1,30 +1,30 @@
 name: daytona api
 synopsis: Make an authenticated request to the Daytona API
 description: |-
-    Make an authenticated HTTP request to the Daytona API and print the raw response body to stdout.
+  Make an authenticated HTTP request to the Daytona API and print the raw response body to stdout.
 
-    PATH is resolved against the active profile's API URL and the request is authenticated with the active profile's credentials. Responses with status 400 or above still print the body, then exit non-zero.
+  PATH is resolved against the active profile's API URL and the request is authenticated with the active profile's credentials. Responses with status 400 or above still print the body, then exit non-zero.
 usage: daytona api PATH [flags]
 options:
-    - name: input
-      usage: |
-        Request body source: a file path or '-' for stdin (POST, PUT, and PATCH only)
-    - name: method
-      shorthand: X
-      default_value: GET
-      usage: HTTP method (GET, POST, PUT, PATCH, DELETE, HEAD)
+  - name: input
+    usage: |
+      Request body source: a file path or '-' for stdin (POST, PUT, and PATCH only)
+  - name: method
+    shorthand: X
+    default_value: GET
+    usage: HTTP method (GET, POST, PUT, PATCH, DELETE, HEAD)
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona api /sandbox
       daytona api /sandbox/my-sandbox -X DELETE
       daytona api /snapshots -X POST --input snapshot.json
       cat body.json | daytona api /sandbox -X POST --input -
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_api.yaml
+++ b/apps/cli/hack/docs/daytona_api.yaml
@@ -1,0 +1,30 @@
+name: daytona api
+synopsis: Make an authenticated request to the Daytona API
+description: |-
+    Make an authenticated HTTP request to the Daytona API and print the raw response body to stdout.
+
+    PATH is resolved against the active profile's API URL and the request is authenticated with the active profile's credentials. Responses with status 400 or above still print the body, then exit non-zero.
+usage: daytona api PATH [flags]
+options:
+    - name: input
+      usage: |
+        Request body source: a file path or '-' for stdin (POST, PUT, and PATCH only)
+    - name: method
+      shorthand: X
+      default_value: GET
+      usage: HTTP method (GET, POST, PUT, PATCH, DELETE, HEAD)
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona api /sandbox
+      daytona api /sandbox/my-sandbox -X DELETE
+      daytona api /snapshots -X POST --input snapshot.json
+      cat body.json | daytona api /sandbox -X POST --input -
+see_also:
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_archive.yaml
+++ b/apps/cli/hack/docs/daytona_archive.yaml
@@ -1,9 +1,27 @@
 name: daytona archive
 synopsis: Archive a sandbox
-usage: daytona archive [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+usage: daytona archive [SANDBOX_ID | SANDBOX_NAME] [flags]
+options:
+    - name: format
+      shorthand: f
+      usage: Output format. Must be one of (yaml, json)
+    - name: timeout
+      default_value: 5m0s
+      usage: Maximum time to wait with --wait (0 waits indefinitely)
+    - name: wait
+      default_value: "false"
+      usage: Wait until the sandbox is archived
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona archive my-sandbox
+      daytona archive my-sandbox --wait --timeout 10m
+      daytona archive my-sandbox --wait --format json
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_archive.yaml
+++ b/apps/cli/hack/docs/daytona_archive.yaml
@@ -2,26 +2,26 @@ name: daytona archive
 synopsis: Archive a sandbox
 usage: daytona archive [SANDBOX_ID | SANDBOX_NAME] [flags]
 options:
-    - name: format
-      shorthand: f
-      usage: Output format. Must be one of (yaml, json)
-    - name: timeout
-      default_value: 5m0s
-      usage: Maximum time to wait with --wait (0 waits indefinitely)
-    - name: wait
-      default_value: "false"
-      usage: Wait until the sandbox is archived
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
+  - name: timeout
+    default_value: 5m0s
+    usage: Maximum time to wait with --wait (0 waits indefinitely)
+  - name: wait
+    default_value: 'false'
+    usage: Wait until the sandbox is archived
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona archive my-sandbox
       daytona archive my-sandbox --wait --timeout 10m
       daytona archive my-sandbox --wait --format json
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_autocomplete.yaml
+++ b/apps/cli/hack/docs/daytona_autocomplete.yaml
@@ -2,12 +2,12 @@ name: daytona autocomplete
 synopsis: Adds a completion script for your shell environment
 usage: daytona autocomplete [bash|zsh|fish|powershell] [flags]
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_autocomplete.yaml
+++ b/apps/cli/hack/docs/daytona_autocomplete.yaml
@@ -2,8 +2,12 @@ name: daytona autocomplete
 synopsis: Adds a completion script for your shell environment
 usage: daytona autocomplete [bash|zsh|fish|powershell] [flags]
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_cp.yaml
+++ b/apps/cli/hack/docs/daytona_cp.yaml
@@ -1,28 +1,28 @@
 name: daytona cp
 synopsis: Copy files between the local machine and a sandbox
 description: |-
-    Copy files or directories between the local filesystem and a sandbox.
+  Copy files or directories between the local filesystem and a sandbox.
 
-    Exactly one of SOURCE or DESTINATION must reference a sandbox path using the
-    <sandbox>:<path> form, where <sandbox> is a sandbox ID or name. Directories
-    are copied recursively. Copying into an existing directory places the source
-    basename inside it, and missing parent directories are created.
+  Exactly one of SOURCE or DESTINATION must reference a sandbox path using the
+  <sandbox>:<path> form, where <sandbox> is a sandbox ID or name. Directories
+  are copied recursively. Copying into an existing directory places the source
+  basename inside it, and missing parent directories are created.
 usage: daytona cp SOURCE DESTINATION [flags]
 options:
-    - name: format
-      shorthand: f
-      usage: Output format. Must be one of (yaml, json)
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona cp ./config.yaml my-sandbox:/workspace/config.yaml
       daytona cp my-sandbox:/workspace/output ./output
       daytona cp ./src my-sandbox:/workspace/src --format json
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_cp.yaml
+++ b/apps/cli/hack/docs/daytona_cp.yaml
@@ -1,0 +1,28 @@
+name: daytona cp
+synopsis: Copy files between the local machine and a sandbox
+description: |-
+    Copy files or directories between the local filesystem and a sandbox.
+
+    Exactly one of SOURCE or DESTINATION must reference a sandbox path using the
+    <sandbox>:<path> form, where <sandbox> is a sandbox ID or name. Directories
+    are copied recursively. Copying into an existing directory places the source
+    basename inside it, and missing parent directories are created.
+usage: daytona cp SOURCE DESTINATION [flags]
+options:
+    - name: format
+      shorthand: f
+      usage: Output format. Must be one of (yaml, json)
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona cp ./config.yaml my-sandbox:/workspace/config.yaml
+      daytona cp my-sandbox:/workspace/output ./output
+      daytona cp ./src my-sandbox:/workspace/src --format json
+see_also:
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_create.yaml
+++ b/apps/cli/hack/docs/daytona_create.yaml
@@ -2,69 +2,93 @@ name: daytona create
 synopsis: Create a new sandbox
 usage: daytona create [flags]
 options:
-  - name: auto-archive
-    default_value: '10080'
-    usage: |
-      Auto-archive interval in minutes (0 means the maximum interval will be used)
-  - name: auto-delete
-    default_value: '-1'
-    usage: |
-      Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)
-  - name: auto-stop
-    default_value: '15'
-    usage: Auto-stop interval in minutes (0 means disabled)
-  - name: context
-    shorthand: c
-    default_value: '[]'
-    usage: |
-      Files or directories to include in the build context (can be specified multiple times)
-  - name: cpu
-    default_value: '0'
-    usage: CPU cores allocated to the sandbox
-  - name: disk
-    default_value: '0'
-    usage: Disk space allocated to the sandbox in GB
-  - name: dockerfile
-    shorthand: f
-    usage: Path to Dockerfile for Sandbox snapshot
-  - name: env
-    shorthand: e
-    default_value: '[]'
-    usage: 'Environment variables (format: KEY=VALUE)'
-  - name: gpu
-    default_value: '0'
-    usage: GPU units allocated to the sandbox
-  - name: label
-    shorthand: l
-    default_value: '[]'
-    usage: 'Labels (format: KEY=VALUE)'
-  - name: memory
-    default_value: '0'
-    usage: Memory allocated to the sandbox in MB
-  - name: name
-    usage: Name of the sandbox
-  - name: network-allow-list
-    usage: |
-      Comma-separated list of allowed CIDR network addresses for the sandbox
-  - name: network-block-all
-    default_value: 'false'
-    usage: Whether to block all network access for the sandbox
-  - name: public
-    default_value: 'false'
-    usage: Make sandbox publicly accessible
-  - name: snapshot
-    usage: Snapshot to use for the sandbox
-  - name: target
-    usage: Target region (eu, us)
-  - name: user
-    usage: User associated with the sandbox
-  - name: volume
-    shorthand: v
-    default_value: '[]'
-    usage: 'Volumes to mount (format: VOLUME_ID_OR_NAME:MOUNT_PATH)'
+    - name: auto-archive
+      default_value: "10080"
+      usage: |
+        Auto-archive interval in minutes (0 means the maximum interval will be used)
+    - name: auto-delete
+      default_value: "-1"
+      usage: |
+        Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)
+    - name: auto-stop
+      default_value: "15"
+      usage: Auto-stop interval in minutes (0 means disabled)
+    - name: context
+      shorthand: c
+      default_value: '[]'
+      usage: |
+        Files or directories to include in the build context (can be specified multiple times)
+    - name: cpu
+      default_value: "0"
+      usage: CPU cores allocated to the sandbox
+    - name: disk
+      default_value: "0"
+      usage: Disk space allocated to the sandbox in GB
+    - name: dockerfile
+      shorthand: f
+      usage: Path to Dockerfile for Sandbox snapshot
+    - name: env
+      shorthand: e
+      default_value: '[]'
+      usage: 'Environment variables (format: KEY=VALUE)'
+    - name: env-file
+      usage: |
+        Read environment variables from a dotenv-style file (entries from --env override file values)
+    - name: format
+      usage: Output format. Must be one of (yaml, json)
+    - name: gpu
+      default_value: "0"
+      usage: GPU units allocated to the sandbox
+    - name: if-exists
+      default_value: error
+      usage: |
+        Behavior when a sandbox with the same name already exists (error, reuse; reuse requires --name)
+    - name: label
+      shorthand: l
+      default_value: '[]'
+      usage: 'Labels (format: KEY=VALUE)'
+    - name: label-file
+      usage: |
+        Read labels from a dotenv-style file (entries from --label override file values)
+    - name: memory
+      default_value: "0"
+      usage: Memory allocated to the sandbox in MB
+    - name: name
+      usage: Name of the sandbox
+    - name: network-allow-list
+      usage: |
+        Comma-separated list of allowed CIDR network addresses for the sandbox
+    - name: network-block-all
+      default_value: "false"
+      usage: Whether to block all network access for the sandbox
+    - name: public
+      default_value: "false"
+      usage: Make sandbox publicly accessible
+    - name: snapshot
+      usage: Snapshot to use for the sandbox
+    - name: target
+      usage: Target region (eu, us)
+    - name: timeout
+      default_value: 0s
+      usage: |
+        Maximum time to wait for the sandbox to start (0 means wait indefinitely)
+    - name: user
+      usage: User associated with the sandbox
+    - name: volume
+      shorthand: v
+      default_value: '[]'
+      usage: 'Volumes to mount (format: VOLUME_ID_OR_NAME:MOUNT_PATH)'
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona create --snapshot my-snapshot:1.0 --name my-sandbox
+      daytona create --name my-sandbox --env-file .env --if-exists reuse
+      daytona create --snapshot my-snapshot:1.0 --name my-sandbox --format json
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_create.yaml
+++ b/apps/cli/hack/docs/daytona_create.yaml
@@ -2,93 +2,93 @@ name: daytona create
 synopsis: Create a new sandbox
 usage: daytona create [flags]
 options:
-    - name: auto-archive
-      default_value: "10080"
-      usage: |
-        Auto-archive interval in minutes (0 means the maximum interval will be used)
-    - name: auto-delete
-      default_value: "-1"
-      usage: |
-        Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)
-    - name: auto-stop
-      default_value: "15"
-      usage: Auto-stop interval in minutes (0 means disabled)
-    - name: context
-      shorthand: c
-      default_value: '[]'
-      usage: |
-        Files or directories to include in the build context (can be specified multiple times)
-    - name: cpu
-      default_value: "0"
-      usage: CPU cores allocated to the sandbox
-    - name: disk
-      default_value: "0"
-      usage: Disk space allocated to the sandbox in GB
-    - name: dockerfile
-      shorthand: f
-      usage: Path to Dockerfile for Sandbox snapshot
-    - name: env
-      shorthand: e
-      default_value: '[]'
-      usage: 'Environment variables (format: KEY=VALUE)'
-    - name: env-file
-      usage: |
-        Read environment variables from a dotenv-style file (entries from --env override file values)
-    - name: format
-      usage: Output format. Must be one of (yaml, json)
-    - name: gpu
-      default_value: "0"
-      usage: GPU units allocated to the sandbox
-    - name: if-exists
-      default_value: error
-      usage: |
-        Behavior when a sandbox with the same name already exists (error, reuse; reuse requires --name)
-    - name: label
-      shorthand: l
-      default_value: '[]'
-      usage: 'Labels (format: KEY=VALUE)'
-    - name: label-file
-      usage: |
-        Read labels from a dotenv-style file (entries from --label override file values)
-    - name: memory
-      default_value: "0"
-      usage: Memory allocated to the sandbox in MB
-    - name: name
-      usage: Name of the sandbox
-    - name: network-allow-list
-      usage: |
-        Comma-separated list of allowed CIDR network addresses for the sandbox
-    - name: network-block-all
-      default_value: "false"
-      usage: Whether to block all network access for the sandbox
-    - name: public
-      default_value: "false"
-      usage: Make sandbox publicly accessible
-    - name: snapshot
-      usage: Snapshot to use for the sandbox
-    - name: target
-      usage: Target region (eu, us)
-    - name: timeout
-      default_value: 0s
-      usage: |
-        Maximum time to wait for the sandbox to start (0 means wait indefinitely)
-    - name: user
-      usage: User associated with the sandbox
-    - name: volume
-      shorthand: v
-      default_value: '[]'
-      usage: 'Volumes to mount (format: VOLUME_ID_OR_NAME:MOUNT_PATH)'
+  - name: auto-archive
+    default_value: '10080'
+    usage: |
+      Auto-archive interval in minutes (0 means the maximum interval will be used)
+  - name: auto-delete
+    default_value: '-1'
+    usage: |
+      Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)
+  - name: auto-stop
+    default_value: '15'
+    usage: Auto-stop interval in minutes (0 means disabled)
+  - name: context
+    shorthand: c
+    default_value: '[]'
+    usage: |
+      Files or directories to include in the build context (can be specified multiple times)
+  - name: cpu
+    default_value: '0'
+    usage: CPU cores allocated to the sandbox
+  - name: disk
+    default_value: '0'
+    usage: Disk space allocated to the sandbox in GB
+  - name: dockerfile
+    shorthand: f
+    usage: Path to Dockerfile for Sandbox snapshot
+  - name: env
+    shorthand: e
+    default_value: '[]'
+    usage: 'Environment variables (format: KEY=VALUE)'
+  - name: env-file
+    usage: |
+      Read environment variables from a dotenv-style file (entries from --env override file values)
+  - name: format
+    usage: Output format. Must be one of (yaml, json)
+  - name: gpu
+    default_value: '0'
+    usage: GPU units allocated to the sandbox
+  - name: if-exists
+    default_value: error
+    usage: |
+      Behavior when a sandbox with the same name already exists (error, reuse; reuse requires --name)
+  - name: label
+    shorthand: l
+    default_value: '[]'
+    usage: 'Labels (format: KEY=VALUE)'
+  - name: label-file
+    usage: |
+      Read labels from a dotenv-style file (entries from --label override file values)
+  - name: memory
+    default_value: '0'
+    usage: Memory allocated to the sandbox in MB
+  - name: name
+    usage: Name of the sandbox
+  - name: network-allow-list
+    usage: |
+      Comma-separated list of allowed CIDR network addresses for the sandbox
+  - name: network-block-all
+    default_value: 'false'
+    usage: Whether to block all network access for the sandbox
+  - name: public
+    default_value: 'false'
+    usage: Make sandbox publicly accessible
+  - name: snapshot
+    usage: Snapshot to use for the sandbox
+  - name: target
+    usage: Target region (eu, us)
+  - name: timeout
+    default_value: 0s
+    usage: |
+      Maximum time to wait for the sandbox to start (0 means wait indefinitely)
+  - name: user
+    usage: User associated with the sandbox
+  - name: volume
+    shorthand: v
+    default_value: '[]'
+    usage: 'Volumes to mount (format: VOLUME_ID_OR_NAME:MOUNT_PATH)'
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona create --snapshot my-snapshot:1.0 --name my-sandbox
       daytona create --name my-sandbox --env-file .env --if-exists reuse
       daytona create --snapshot my-snapshot:1.0 --name my-sandbox --format json
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_delete.yaml
+++ b/apps/cli/hack/docs/daytona_delete.yaml
@@ -1,14 +1,42 @@
 name: daytona delete
 synopsis: Delete a sandbox
-usage: daytona delete [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+usage: daytona delete [SANDBOX_ID | SANDBOX_NAME] [flags]
 options:
-  - name: all
-    shorthand: a
-    default_value: 'false'
-    usage: Delete all sandboxes
+    - name: all
+      shorthand: a
+      default_value: "false"
+      usage: Delete all sandboxes
+    - name: dry-run
+      default_value: "false"
+      usage: Show what would be deleted without deleting anything
+    - name: format
+      shorthand: f
+      usage: Output format. Must be one of (yaml, json)
+    - name: ignore-not-found
+      default_value: "false"
+      usage: Treat a missing sandbox as a successful delete
+    - name: timeout
+      default_value: 5m0s
+      usage: Maximum time to wait with --wait (0 waits indefinitely)
+    - name: wait
+      default_value: "false"
+      usage: Wait until the sandbox is fully deleted
+    - name: "yes"
+      shorthand: "y"
+      default_value: "false"
+      usage: Skip the confirmation prompt for bulk deletes
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona delete my-sandbox
+      daytona delete my-sandbox --wait --format json
+      daytona delete --all --dry-run
+      daytona delete --all --yes
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_delete.yaml
+++ b/apps/cli/hack/docs/daytona_delete.yaml
@@ -2,41 +2,41 @@ name: daytona delete
 synopsis: Delete a sandbox
 usage: daytona delete [SANDBOX_ID | SANDBOX_NAME] [flags]
 options:
-    - name: all
-      shorthand: a
-      default_value: "false"
-      usage: Delete all sandboxes
-    - name: dry-run
-      default_value: "false"
-      usage: Show what would be deleted without deleting anything
-    - name: format
-      shorthand: f
-      usage: Output format. Must be one of (yaml, json)
-    - name: ignore-not-found
-      default_value: "false"
-      usage: Treat a missing sandbox as a successful delete
-    - name: timeout
-      default_value: 5m0s
-      usage: Maximum time to wait with --wait (0 waits indefinitely)
-    - name: wait
-      default_value: "false"
-      usage: Wait until the sandbox is fully deleted
-    - name: "yes"
-      shorthand: "y"
-      default_value: "false"
-      usage: Skip the confirmation prompt for bulk deletes
+  - name: all
+    shorthand: a
+    default_value: 'false'
+    usage: Delete all sandboxes
+  - name: dry-run
+    default_value: 'false'
+    usage: Show what would be deleted without deleting anything
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
+  - name: ignore-not-found
+    default_value: 'false'
+    usage: Treat a missing sandbox as a successful delete
+  - name: timeout
+    default_value: 5m0s
+    usage: Maximum time to wait with --wait (0 waits indefinitely)
+  - name: wait
+    default_value: 'false'
+    usage: Wait until the sandbox is fully deleted
+  - name: 'yes'
+    shorthand: 'y'
+    default_value: 'false'
+    usage: Skip the confirmation prompt for bulk deletes
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona delete my-sandbox
       daytona delete my-sandbox --wait --format json
       daytona delete --all --dry-run
       daytona delete --all --yes
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_docs.yaml
+++ b/apps/cli/hack/docs/daytona_docs.yaml
@@ -2,8 +2,12 @@ name: daytona docs
 synopsis: Opens the Daytona documentation in your default browser.
 usage: daytona docs [flags]
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_docs.yaml
+++ b/apps/cli/hack/docs/daytona_docs.yaml
@@ -2,12 +2,12 @@ name: daytona docs
 synopsis: Opens the Daytona documentation in your default browser.
 usage: daytona docs [flags]
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_exec.yaml
+++ b/apps/cli/hack/docs/daytona_exec.yaml
@@ -1,30 +1,30 @@
 name: daytona exec
 synopsis: Execute a command in a sandbox
 description: |-
-    Execute a command in a running sandbox.
+  Execute a command in a running sandbox.
 
-    Exits with the remote command's exit code; exit code 255 indicates a CLI-side failure (for example the sandbox was not found or is not running).
+  Exits with the remote command's exit code; exit code 255 indicates a CLI-side failure (for example the sandbox was not found or is not running).
 usage: daytona exec [SANDBOX_ID | SANDBOX_NAME] -- [COMMAND] [ARGS...] [flags]
 options:
-    - name: cwd
-      usage: Working directory for command execution
-    - name: format
-      shorthand: f
-      usage: Output format. Must be one of (yaml, json)
-    - name: timeout
-      default_value: "0"
-      usage: Command timeout in seconds (0 for no timeout)
+  - name: cwd
+    usage: Working directory for command execution
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
+  - name: timeout
+    default_value: '0'
+    usage: Command timeout in seconds (0 for no timeout)
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona exec my-sandbox -- ls -la /workspace
       daytona exec my-sandbox -- python -c "print('hi')"
       daytona exec my-sandbox --cwd /workspace --format json -- npm test
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_exec.yaml
+++ b/apps/cli/hack/docs/daytona_exec.yaml
@@ -1,16 +1,30 @@
 name: daytona exec
 synopsis: Execute a command in a sandbox
-description: Execute a command in a running sandbox
+description: |-
+    Execute a command in a running sandbox.
+
+    Exits with the remote command's exit code; exit code 255 indicates a CLI-side failure (for example the sandbox was not found or is not running).
 usage: daytona exec [SANDBOX_ID | SANDBOX_NAME] -- [COMMAND] [ARGS...] [flags]
 options:
-  - name: cwd
-    usage: Working directory for command execution
-  - name: timeout
-    default_value: '0'
-    usage: Command timeout in seconds (0 for no timeout)
+    - name: cwd
+      usage: Working directory for command execution
+    - name: format
+      shorthand: f
+      usage: Output format. Must be one of (yaml, json)
+    - name: timeout
+      default_value: "0"
+      usage: Command timeout in seconds (0 for no timeout)
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona exec my-sandbox -- ls -la /workspace
+      daytona exec my-sandbox -- python -c "print('hi')"
+      daytona exec my-sandbox --cwd /workspace --format json -- npm test
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_info.yaml
+++ b/apps/cli/hack/docs/daytona_info.yaml
@@ -2,19 +2,19 @@ name: daytona info
 synopsis: Get sandbox info
 usage: daytona info [SANDBOX_ID | SANDBOX_NAME] [flags]
 options:
-    - name: format
-      shorthand: f
-      usage: Output format. Must be one of (yaml, json)
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona info my-sandbox
       daytona info my-sandbox --format json
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_info.yaml
+++ b/apps/cli/hack/docs/daytona_info.yaml
@@ -2,12 +2,19 @@ name: daytona info
 synopsis: Get sandbox info
 usage: daytona info [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 options:
-  - name: format
-    shorthand: f
-    usage: Output format. Must be one of (yaml, json)
+    - name: format
+      shorthand: f
+      usage: Output format. Must be one of (yaml, json)
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona info my-sandbox
+      daytona info my-sandbox --format json
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_info.yaml
+++ b/apps/cli/hack/docs/daytona_info.yaml
@@ -1,6 +1,6 @@
 name: daytona info
 synopsis: Get sandbox info
-usage: daytona info [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+usage: daytona info [SANDBOX_ID | SANDBOX_NAME] [flags]
 options:
     - name: format
       shorthand: f

--- a/apps/cli/hack/docs/daytona_list.yaml
+++ b/apps/cli/hack/docs/daytona_list.yaml
@@ -2,19 +2,27 @@ name: daytona list
 synopsis: List sandboxes
 usage: daytona list [flags]
 options:
-  - name: cursor
-    shorthand: c
-    usage: Cursor for pagination
-  - name: format
-    shorthand: f
-    usage: Output format. Must be one of (yaml, json)
-  - name: limit
-    shorthand: l
-    default_value: '100'
-    usage: Maximum number of items per page
+    - name: cursor
+      shorthand: c
+      usage: Cursor for pagination
+    - name: format
+      shorthand: f
+      usage: Output format. Must be one of (yaml, json)
+    - name: limit
+      shorthand: l
+      default_value: "100"
+      usage: Maximum number of items per page
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona list
+      daytona list --limit 50
+      daytona list --format json
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_list.yaml
+++ b/apps/cli/hack/docs/daytona_list.yaml
@@ -2,27 +2,27 @@ name: daytona list
 synopsis: List sandboxes
 usage: daytona list [flags]
 options:
-    - name: cursor
-      shorthand: c
-      usage: Cursor for pagination
-    - name: format
-      shorthand: f
-      usage: Output format. Must be one of (yaml, json)
-    - name: limit
-      shorthand: l
-      default_value: "100"
-      usage: Maximum number of items per page
+  - name: cursor
+    shorthand: c
+    usage: Cursor for pagination
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
+  - name: limit
+    shorthand: l
+    default_value: '100'
+    usage: Maximum number of items per page
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona list
       daytona list --limit 50
       daytona list --format json
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_login.yaml
+++ b/apps/cli/hack/docs/daytona_login.yaml
@@ -2,11 +2,24 @@ name: daytona login
 synopsis: Log in to Daytona
 usage: daytona login [flags]
 options:
-  - name: api-key
-    usage: API key to use for authentication
+    - name: api-key
+      usage: API key to use for authentication
+    - name: api-key-file
+      usage: Read the API key from a file
+    - name: api-key-stdin
+      default_value: "false"
+      usage: Read the API key from stdin
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona login
+      daytona login --api-key $DAYTONA_API_KEY
+      daytona login --api-key-stdin < ~/.daytona-api-key
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_login.yaml
+++ b/apps/cli/hack/docs/daytona_login.yaml
@@ -2,24 +2,24 @@ name: daytona login
 synopsis: Log in to Daytona
 usage: daytona login [flags]
 options:
-    - name: api-key
-      usage: API key to use for authentication
-    - name: api-key-file
-      usage: Read the API key from a file
-    - name: api-key-stdin
-      default_value: "false"
-      usage: Read the API key from stdin
+  - name: api-key
+    usage: API key to use for authentication
+  - name: api-key-file
+    usage: Read the API key from a file
+  - name: api-key-stdin
+    default_value: 'false'
+    usage: Read the API key from stdin
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona login
       daytona login --api-key $DAYTONA_API_KEY
       daytona login --api-key-stdin < ~/.daytona-api-key
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_logout.yaml
+++ b/apps/cli/hack/docs/daytona_logout.yaml
@@ -2,12 +2,12 @@ name: daytona logout
 synopsis: Logout from Daytona
 usage: daytona logout [flags]
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_logout.yaml
+++ b/apps/cli/hack/docs/daytona_logout.yaml
@@ -2,8 +2,12 @@ name: daytona logout
 synopsis: Logout from Daytona
 usage: daytona logout [flags]
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_logs.yaml
+++ b/apps/cli/hack/docs/daytona_logs.yaml
@@ -1,24 +1,24 @@
 name: daytona logs
 synopsis: View the build logs of a sandbox
 description: |
-    View the build logs of a sandbox. With --follow the logs are streamed until the sandbox build reaches a terminal state.
+  View the build logs of a sandbox. With --follow the logs are streamed until the sandbox build reaches a terminal state.
 usage: daytona logs [SANDBOX_ID | SANDBOX_NAME] [flags]
 options:
-    - name: follow
-      shorthand: f
-      default_value: "false"
-      usage: |
-        Follow the logs until the sandbox build reaches a terminal state
+  - name: follow
+    shorthand: f
+    default_value: 'false'
+    usage: |
+      Follow the logs until the sandbox build reaches a terminal state
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona logs my-sandbox
       daytona logs my-sandbox --follow
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_logs.yaml
+++ b/apps/cli/hack/docs/daytona_logs.yaml
@@ -1,0 +1,24 @@
+name: daytona logs
+synopsis: View the build logs of a sandbox
+description: |
+    View the build logs of a sandbox. With --follow the logs are streamed until the sandbox build reaches a terminal state.
+usage: daytona logs [SANDBOX_ID | SANDBOX_NAME] [flags]
+options:
+    - name: follow
+      shorthand: f
+      default_value: "false"
+      usage: |
+        Follow the logs until the sandbox build reaches a terminal state
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona logs my-sandbox
+      daytona logs my-sandbox --follow
+see_also:
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_mcp.yaml
+++ b/apps/cli/hack/docs/daytona_mcp.yaml
@@ -2,15 +2,15 @@ name: daytona mcp
 synopsis: Manage Daytona MCP Server
 description: Commands for managing Daytona MCP Server
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 see_also:
-    - daytona - Daytona CLI
-    - daytona mcp config - Outputs JSON configuration for Daytona MCP Server
-    - 'daytona mcp init - Initialize Daytona MCP Server with an agent (currently supported: claude, windsurf, cursor)'
-    - daytona mcp start - Start Daytona MCP Server
+  - daytona - Daytona CLI
+  - daytona mcp config - Outputs JSON configuration for Daytona MCP Server
+  - 'daytona mcp init - Initialize Daytona MCP Server with an agent (currently supported: claude, windsurf, cursor)'
+  - daytona mcp start - Start Daytona MCP Server

--- a/apps/cli/hack/docs/daytona_mcp.yaml
+++ b/apps/cli/hack/docs/daytona_mcp.yaml
@@ -2,11 +2,15 @@ name: daytona mcp
 synopsis: Manage Daytona MCP Server
 description: Commands for managing Daytona MCP Server
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
 see_also:
-  - daytona - Daytona CLI
-  - daytona mcp config - Outputs JSON configuration for Daytona MCP Server
-  - 'daytona mcp init - Initialize Daytona MCP Server with an agent (currently supported: claude, windsurf, cursor)'
-  - daytona mcp start - Start Daytona MCP Server
+    - daytona - Daytona CLI
+    - daytona mcp config - Outputs JSON configuration for Daytona MCP Server
+    - 'daytona mcp init - Initialize Daytona MCP Server with an agent (currently supported: claude, windsurf, cursor)'
+    - daytona mcp start - Start Daytona MCP Server

--- a/apps/cli/hack/docs/daytona_mcp_config.yaml
+++ b/apps/cli/hack/docs/daytona_mcp_config.yaml
@@ -2,15 +2,15 @@ name: daytona mcp config
 synopsis: Outputs JSON configuration for Daytona MCP Server
 usage: daytona mcp config [flags]
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona mcp config
       daytona mcp config > daytona-mcp.json
 see_also:
-    - daytona mcp - Manage Daytona MCP Server
+  - daytona mcp - Manage Daytona MCP Server

--- a/apps/cli/hack/docs/daytona_mcp_config.yaml
+++ b/apps/cli/hack/docs/daytona_mcp_config.yaml
@@ -1,9 +1,16 @@
 name: daytona mcp config
 synopsis: Outputs JSON configuration for Daytona MCP Server
-usage: daytona mcp config [AGENT_NAME] [flags]
+usage: daytona mcp config [flags]
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona mcp config
+      daytona mcp config > daytona-mcp.json
 see_also:
-  - daytona mcp - Manage Daytona MCP Server
+    - daytona mcp - Manage Daytona MCP Server

--- a/apps/cli/hack/docs/daytona_mcp_init.yaml
+++ b/apps/cli/hack/docs/daytona_mcp_init.yaml
@@ -1,17 +1,17 @@
 name: daytona mcp init
 synopsis: |
-    Initialize Daytona MCP Server with an agent (currently supported: claude, windsurf, cursor)
+  Initialize Daytona MCP Server with an agent (currently supported: claude, windsurf, cursor)
 usage: daytona mcp init [AGENT_NAME] [flags]
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona mcp init claude
       daytona mcp init cursor
 see_also:
-    - daytona mcp - Manage Daytona MCP Server
+  - daytona mcp - Manage Daytona MCP Server

--- a/apps/cli/hack/docs/daytona_mcp_init.yaml
+++ b/apps/cli/hack/docs/daytona_mcp_init.yaml
@@ -1,10 +1,17 @@
 name: daytona mcp init
 synopsis: |
-  Initialize Daytona MCP Server with an agent (currently supported: claude, windsurf, cursor)
+    Initialize Daytona MCP Server with an agent (currently supported: claude, windsurf, cursor)
 usage: daytona mcp init [AGENT_NAME] [flags]
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona mcp init claude
+      daytona mcp init cursor
 see_also:
-  - daytona mcp - Manage Daytona MCP Server
+    - daytona mcp - Manage Daytona MCP Server

--- a/apps/cli/hack/docs/daytona_mcp_start.yaml
+++ b/apps/cli/hack/docs/daytona_mcp_start.yaml
@@ -2,8 +2,15 @@ name: daytona mcp start
 synopsis: Start Daytona MCP Server
 usage: daytona mcp start [flags]
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      # Typically launched by an MCP client (see 'daytona mcp init')
+      daytona mcp start
 see_also:
-  - daytona mcp - Manage Daytona MCP Server
+    - daytona mcp - Manage Daytona MCP Server

--- a/apps/cli/hack/docs/daytona_mcp_start.yaml
+++ b/apps/cli/hack/docs/daytona_mcp_start.yaml
@@ -2,15 +2,15 @@ name: daytona mcp start
 synopsis: Start Daytona MCP Server
 usage: daytona mcp start [flags]
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       # Typically launched by an MCP client (see 'daytona mcp init')
       daytona mcp start
 see_also:
-    - daytona mcp - Manage Daytona MCP Server
+  - daytona mcp - Manage Daytona MCP Server

--- a/apps/cli/hack/docs/daytona_organization.yaml
+++ b/apps/cli/hack/docs/daytona_organization.yaml
@@ -2,12 +2,16 @@ name: daytona organization
 synopsis: Manage Daytona organizations
 description: Commands for managing Daytona organizations
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
 see_also:
-  - daytona - Daytona CLI
-  - daytona organization create - Create a new organization and set it as active
-  - daytona organization delete - Delete an organization
-  - daytona organization list - List all organizations
-  - daytona organization use - Set active organization
+    - daytona - Daytona CLI
+    - daytona organization create - Create a new organization and set it as active
+    - daytona organization delete - Delete an organization
+    - daytona organization list - List all organizations
+    - daytona organization use - Set active organization

--- a/apps/cli/hack/docs/daytona_organization.yaml
+++ b/apps/cli/hack/docs/daytona_organization.yaml
@@ -2,16 +2,16 @@ name: daytona organization
 synopsis: Manage Daytona organizations
 description: Commands for managing Daytona organizations
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 see_also:
-    - daytona - Daytona CLI
-    - daytona organization create - Create a new organization and set it as active
-    - daytona organization delete - Delete an organization
-    - daytona organization list - List all organizations
-    - daytona organization use - Set active organization
+  - daytona - Daytona CLI
+  - daytona organization create - Create a new organization and set it as active
+  - daytona organization delete - Delete an organization
+  - daytona organization list - List all organizations
+  - daytona organization use - Set active organization

--- a/apps/cli/hack/docs/daytona_organization_create.yaml
+++ b/apps/cli/hack/docs/daytona_organization_create.yaml
@@ -2,19 +2,19 @@ name: daytona organization create
 synopsis: Create a new organization and set it as active
 usage: daytona organization create [ORGANIZATION_NAME] [flags]
 options:
-    - name: region
-      shorthand: r
-      usage: Default region (id or name) for the organization
+  - name: region
+    shorthand: r
+    usage: Default region (id or name) for the organization
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona organization create my-org
       daytona organization create my-org --region us
 see_also:
-    - daytona organization - Manage Daytona organizations
+  - daytona organization - Manage Daytona organizations

--- a/apps/cli/hack/docs/daytona_organization_create.yaml
+++ b/apps/cli/hack/docs/daytona_organization_create.yaml
@@ -1,9 +1,20 @@
 name: daytona organization create
 synopsis: Create a new organization and set it as active
 usage: daytona organization create [ORGANIZATION_NAME] [flags]
+options:
+    - name: region
+      shorthand: r
+      usage: Default region (id or name) for the organization
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona organization create my-org
+      daytona organization create my-org --region us
 see_also:
-  - daytona organization - Manage Daytona organizations
+    - daytona organization - Manage Daytona organizations

--- a/apps/cli/hack/docs/daytona_organization_delete.yaml
+++ b/apps/cli/hack/docs/daytona_organization_delete.yaml
@@ -2,16 +2,16 @@ name: daytona organization delete
 synopsis: Delete an organization
 usage: daytona organization delete [ORGANIZATION] [flags]
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona organization delete my-org
       # With no argument, pick from a list interactively
       daytona organization delete
 see_also:
-    - daytona organization - Manage Daytona organizations
+  - daytona organization - Manage Daytona organizations

--- a/apps/cli/hack/docs/daytona_organization_delete.yaml
+++ b/apps/cli/hack/docs/daytona_organization_delete.yaml
@@ -2,8 +2,16 @@ name: daytona organization delete
 synopsis: Delete an organization
 usage: daytona organization delete [ORGANIZATION] [flags]
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona organization delete my-org
+      # With no argument, pick from a list interactively
+      daytona organization delete
 see_also:
-  - daytona organization - Manage Daytona organizations
+    - daytona organization - Manage Daytona organizations

--- a/apps/cli/hack/docs/daytona_organization_list.yaml
+++ b/apps/cli/hack/docs/daytona_organization_list.yaml
@@ -2,12 +2,19 @@ name: daytona organization list
 synopsis: List all organizations
 usage: daytona organization list [flags]
 options:
-  - name: format
-    shorthand: f
-    usage: Output format. Must be one of (yaml, json)
+    - name: format
+      shorthand: f
+      usage: Output format. Must be one of (yaml, json)
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona organization list
+      daytona organization list --format json
 see_also:
-  - daytona organization - Manage Daytona organizations
+    - daytona organization - Manage Daytona organizations

--- a/apps/cli/hack/docs/daytona_organization_list.yaml
+++ b/apps/cli/hack/docs/daytona_organization_list.yaml
@@ -2,19 +2,19 @@ name: daytona organization list
 synopsis: List all organizations
 usage: daytona organization list [flags]
 options:
-    - name: format
-      shorthand: f
-      usage: Output format. Must be one of (yaml, json)
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona organization list
       daytona organization list --format json
 see_also:
-    - daytona organization - Manage Daytona organizations
+  - daytona organization - Manage Daytona organizations

--- a/apps/cli/hack/docs/daytona_organization_use.yaml
+++ b/apps/cli/hack/docs/daytona_organization_use.yaml
@@ -2,16 +2,16 @@ name: daytona organization use
 synopsis: Set active organization
 usage: daytona organization use [ORGANIZATION] [flags]
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona organization use my-org
       # With no argument, pick from a list interactively
       daytona organization use
 see_also:
-    - daytona organization - Manage Daytona organizations
+  - daytona organization - Manage Daytona organizations

--- a/apps/cli/hack/docs/daytona_organization_use.yaml
+++ b/apps/cli/hack/docs/daytona_organization_use.yaml
@@ -2,8 +2,16 @@ name: daytona organization use
 synopsis: Set active organization
 usage: daytona organization use [ORGANIZATION] [flags]
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona organization use my-org
+      # With no argument, pick from a list interactively
+      daytona organization use
 see_also:
-  - daytona organization - Manage Daytona organizations
+    - daytona organization - Manage Daytona organizations

--- a/apps/cli/hack/docs/daytona_preview-url.yaml
+++ b/apps/cli/hack/docs/daytona_preview-url.yaml
@@ -2,16 +2,27 @@ name: daytona preview-url
 synopsis: Get signed preview URL for a sandbox port
 usage: daytona preview-url [SANDBOX_ID | SANDBOX_NAME] [flags]
 options:
-  - name: expires
-    default_value: '3600'
-    usage: URL expiration time in seconds
-  - name: port
-    shorthand: p
-    default_value: '0'
-    usage: Port number to get preview URL for (required)
+    - name: expires
+      default_value: "3600"
+      usage: URL expiration time in seconds
+    - name: format
+      shorthand: f
+      usage: Output format. Must be one of (yaml, json)
+    - name: port
+      shorthand: p
+      default_value: "0"
+      usage: Port number to get preview URL for (required)
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona preview-url my-sandbox --port 3000
+      daytona preview-url my-sandbox --port 3000 --expires 7200
+      daytona preview-url my-sandbox --port 3000 --format json
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_preview-url.yaml
+++ b/apps/cli/hack/docs/daytona_preview-url.yaml
@@ -2,27 +2,27 @@ name: daytona preview-url
 synopsis: Get signed preview URL for a sandbox port
 usage: daytona preview-url [SANDBOX_ID | SANDBOX_NAME] [flags]
 options:
-    - name: expires
-      default_value: "3600"
-      usage: URL expiration time in seconds
-    - name: format
-      shorthand: f
-      usage: Output format. Must be one of (yaml, json)
-    - name: port
-      shorthand: p
-      default_value: "0"
-      usage: Port number to get preview URL for (required)
+  - name: expires
+    default_value: '3600'
+    usage: URL expiration time in seconds
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
+  - name: port
+    shorthand: p
+    default_value: '0'
+    usage: Port number to get preview URL for (required)
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona preview-url my-sandbox --port 3000
       daytona preview-url my-sandbox --port 3000 --expires 7200
       daytona preview-url my-sandbox --port 3000 --format json
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_snapshot.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot.yaml
@@ -2,17 +2,17 @@ name: daytona snapshot
 synopsis: Manage Daytona snapshots
 description: Commands for managing Daytona snapshots
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 see_also:
-    - daytona - Daytona CLI
-    - daytona snapshot create - Create a snapshot
-    - daytona snapshot delete - Delete a snapshot
-    - daytona snapshot list - List all snapshots
-    - daytona snapshot logs - View the build logs of a snapshot
-    - daytona snapshot push - Push local snapshot
+  - daytona - Daytona CLI
+  - daytona snapshot create - Create a snapshot
+  - daytona snapshot delete - Delete a snapshot
+  - daytona snapshot list - List all snapshots
+  - daytona snapshot logs - View the build logs of a snapshot
+  - daytona snapshot push - Push local snapshot

--- a/apps/cli/hack/docs/daytona_snapshot.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot.yaml
@@ -2,12 +2,17 @@ name: daytona snapshot
 synopsis: Manage Daytona snapshots
 description: Commands for managing Daytona snapshots
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
 see_also:
-  - daytona - Daytona CLI
-  - daytona snapshot create - Create a snapshot
-  - daytona snapshot delete - Delete a snapshot
-  - daytona snapshot list - List all snapshots
-  - daytona snapshot push - Push local snapshot
+    - daytona - Daytona CLI
+    - daytona snapshot create - Create a snapshot
+    - daytona snapshot delete - Delete a snapshot
+    - daytona snapshot list - List all snapshots
+    - daytona snapshot logs - View the build logs of a snapshot
+    - daytona snapshot push - Push local snapshot

--- a/apps/cli/hack/docs/daytona_snapshot_create.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot_create.yaml
@@ -2,50 +2,50 @@ name: daytona snapshot create
 synopsis: Create a snapshot
 usage: daytona snapshot create [SNAPSHOT] [flags]
 options:
-    - name: context
-      shorthand: c
-      default_value: '[]'
-      usage: |
-        Files or directories to include in the build context (can be specified multiple times). If not provided, context will be automatically determined from COPY/ADD commands in the Dockerfile
-    - name: cpu
-      default_value: "0"
-      usage: |
-        CPU cores that will be allocated to the underlying sandboxes (default: 1)
-    - name: disk
-      default_value: "0"
-      usage: |
-        Disk space that will be allocated to the underlying sandboxes in GB (default: 3)
-    - name: dockerfile
-      shorthand: f
-      usage: Path to Dockerfile to build
-    - name: entrypoint
-      shorthand: e
-      usage: The entrypoint command for the snapshot
-    - name: image
-      shorthand: i
-      usage: The image name for the snapshot
-    - name: memory
-      default_value: "0"
-      usage: |
-        Memory that will be allocated to the underlying sandboxes in GB (default: 1)
-    - name: region
-      usage: |
-        ID of the region where the snapshot will be available (defaults to organization default region)
-    - name: timeout
-      default_value: 0s
-      usage: |
-        Maximum time to wait for the snapshot to become active (0 means wait indefinitely)
+  - name: context
+    shorthand: c
+    default_value: '[]'
+    usage: |
+      Files or directories to include in the build context (can be specified multiple times). If not provided, context will be automatically determined from COPY/ADD commands in the Dockerfile
+  - name: cpu
+    default_value: '0'
+    usage: |
+      CPU cores that will be allocated to the underlying sandboxes (default: 1)
+  - name: disk
+    default_value: '0'
+    usage: |
+      Disk space that will be allocated to the underlying sandboxes in GB (default: 3)
+  - name: dockerfile
+    shorthand: f
+    usage: Path to Dockerfile to build
+  - name: entrypoint
+    shorthand: e
+    usage: The entrypoint command for the snapshot
+  - name: image
+    shorthand: i
+    usage: The image name for the snapshot
+  - name: memory
+    default_value: '0'
+    usage: |
+      Memory that will be allocated to the underlying sandboxes in GB (default: 1)
+  - name: region
+    usage: |
+      ID of the region where the snapshot will be available (defaults to organization default region)
+  - name: timeout
+    default_value: 0s
+    usage: |
+      Maximum time to wait for the snapshot to become active (0 means wait indefinitely)
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona snapshot create my-snapshot:1.0 --image ubuntu:22.04 --entrypoint "sleep infinity"
       daytona snapshot create my-snapshot:1.0 --dockerfile ./Dockerfile --context ./app
       daytona snapshot create my-snapshot:1.0 --image ubuntu:22.04 --cpu 2 --memory 4 --disk 10
 see_also:
-    - daytona snapshot - Manage Daytona snapshots
+  - daytona snapshot - Manage Daytona snapshots

--- a/apps/cli/hack/docs/daytona_snapshot_create.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot_create.yaml
@@ -31,6 +31,10 @@ options:
     - name: region
       usage: |
         ID of the region where the snapshot will be available (defaults to organization default region)
+    - name: timeout
+      default_value: 0s
+      usage: |
+        Maximum time to wait for the snapshot to become active (0 means wait indefinitely)
 inherited_options:
     - name: help
       default_value: "false"

--- a/apps/cli/hack/docs/daytona_snapshot_create.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot_create.yaml
@@ -2,38 +2,46 @@ name: daytona snapshot create
 synopsis: Create a snapshot
 usage: daytona snapshot create [SNAPSHOT] [flags]
 options:
-  - name: context
-    shorthand: c
-    default_value: '[]'
-    usage: |
-      Files or directories to include in the build context (can be specified multiple times). If not provided, context will be automatically determined from COPY/ADD commands in the Dockerfile
-  - name: cpu
-    default_value: '0'
-    usage: |
-      CPU cores that will be allocated to the underlying sandboxes (default: 1)
-  - name: disk
-    default_value: '0'
-    usage: |
-      Disk space that will be allocated to the underlying sandboxes in GB (default: 3)
-  - name: dockerfile
-    shorthand: f
-    usage: Path to Dockerfile to build
-  - name: entrypoint
-    shorthand: e
-    usage: The entrypoint command for the snapshot
-  - name: image
-    shorthand: i
-    usage: The image name for the snapshot
-  - name: memory
-    default_value: '0'
-    usage: |
-      Memory that will be allocated to the underlying sandboxes in GB (default: 1)
-  - name: region
-    usage: |
-      ID of the region where the snapshot will be available (defaults to organization default region)
+    - name: context
+      shorthand: c
+      default_value: '[]'
+      usage: |
+        Files or directories to include in the build context (can be specified multiple times). If not provided, context will be automatically determined from COPY/ADD commands in the Dockerfile
+    - name: cpu
+      default_value: "0"
+      usage: |
+        CPU cores that will be allocated to the underlying sandboxes (default: 1)
+    - name: disk
+      default_value: "0"
+      usage: |
+        Disk space that will be allocated to the underlying sandboxes in GB (default: 3)
+    - name: dockerfile
+      shorthand: f
+      usage: Path to Dockerfile to build
+    - name: entrypoint
+      shorthand: e
+      usage: The entrypoint command for the snapshot
+    - name: image
+      shorthand: i
+      usage: The image name for the snapshot
+    - name: memory
+      default_value: "0"
+      usage: |
+        Memory that will be allocated to the underlying sandboxes in GB (default: 1)
+    - name: region
+      usage: |
+        ID of the region where the snapshot will be available (defaults to organization default region)
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona snapshot create my-snapshot:1.0 --image ubuntu:22.04 --entrypoint "sleep infinity"
+      daytona snapshot create my-snapshot:1.0 --dockerfile ./Dockerfile --context ./app
+      daytona snapshot create my-snapshot:1.0 --image ubuntu:22.04 --cpu 2 --memory 4 --disk 10
 see_also:
-  - daytona snapshot - Manage Daytona snapshots
+    - daytona snapshot - Manage Daytona snapshots

--- a/apps/cli/hack/docs/daytona_snapshot_delete.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot_delete.yaml
@@ -2,34 +2,34 @@ name: daytona snapshot delete
 synopsis: Delete a snapshot
 usage: daytona snapshot delete [SNAPSHOT_ID | SNAPSHOT_NAME] [flags]
 options:
-    - name: all
-      shorthand: a
-      default_value: "false"
-      usage: Delete all snapshots
-    - name: dry-run
-      default_value: "false"
-      usage: Show what would be deleted without deleting anything
-    - name: format
-      shorthand: f
-      usage: Output format. Must be one of (yaml, json)
-    - name: ignore-not-found
-      default_value: "false"
-      usage: Treat a missing snapshot as a successful delete
-    - name: "yes"
-      shorthand: "y"
-      default_value: "false"
-      usage: Skip the confirmation prompt for bulk deletes
+  - name: all
+    shorthand: a
+    default_value: 'false'
+    usage: Delete all snapshots
+  - name: dry-run
+    default_value: 'false'
+    usage: Show what would be deleted without deleting anything
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
+  - name: ignore-not-found
+    default_value: 'false'
+    usage: Treat a missing snapshot as a successful delete
+  - name: 'yes'
+    shorthand: 'y'
+    default_value: 'false'
+    usage: Skip the confirmation prompt for bulk deletes
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona snapshot delete my-snapshot:1.0
       daytona snapshot delete --all --dry-run
       daytona snapshot delete --all --yes --format json
 see_also:
-    - daytona snapshot - Manage Daytona snapshots
+  - daytona snapshot - Manage Daytona snapshots

--- a/apps/cli/hack/docs/daytona_snapshot_delete.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot_delete.yaml
@@ -2,13 +2,34 @@ name: daytona snapshot delete
 synopsis: Delete a snapshot
 usage: daytona snapshot delete [SNAPSHOT_ID | SNAPSHOT_NAME] [flags]
 options:
-  - name: all
-    shorthand: a
-    default_value: 'false'
-    usage: Delete all snapshots
+    - name: all
+      shorthand: a
+      default_value: "false"
+      usage: Delete all snapshots
+    - name: dry-run
+      default_value: "false"
+      usage: Show what would be deleted without deleting anything
+    - name: format
+      shorthand: f
+      usage: Output format. Must be one of (yaml, json)
+    - name: ignore-not-found
+      default_value: "false"
+      usage: Treat a missing snapshot as a successful delete
+    - name: "yes"
+      shorthand: "y"
+      default_value: "false"
+      usage: Skip the confirmation prompt for bulk deletes
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona snapshot delete my-snapshot:1.0
+      daytona snapshot delete --all --dry-run
+      daytona snapshot delete --all --yes --format json
 see_also:
-  - daytona snapshot - Manage Daytona snapshots
+    - daytona snapshot - Manage Daytona snapshots

--- a/apps/cli/hack/docs/daytona_snapshot_list.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot_list.yaml
@@ -3,28 +3,28 @@ synopsis: List all snapshots
 description: List all available Daytona snapshots
 usage: daytona snapshot list [flags]
 options:
-    - name: format
-      shorthand: f
-      usage: Output format. Must be one of (yaml, json)
-    - name: limit
-      shorthand: l
-      default_value: "100"
-      usage: Maximum number of items per page
-    - name: page
-      shorthand: p
-      default_value: "1"
-      usage: Page number for pagination (starting from 1)
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
+  - name: limit
+    shorthand: l
+    default_value: '100'
+    usage: Maximum number of items per page
+  - name: page
+    shorthand: p
+    default_value: '1'
+    usage: Page number for pagination (starting from 1)
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona snapshot list
       daytona snapshot list --limit 50
       daytona snapshot list --format json
 see_also:
-    - daytona snapshot - Manage Daytona snapshots
+  - daytona snapshot - Manage Daytona snapshots

--- a/apps/cli/hack/docs/daytona_snapshot_list.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot_list.yaml
@@ -3,20 +3,28 @@ synopsis: List all snapshots
 description: List all available Daytona snapshots
 usage: daytona snapshot list [flags]
 options:
-  - name: format
-    shorthand: f
-    usage: Output format. Must be one of (yaml, json)
-  - name: limit
-    shorthand: l
-    default_value: '100'
-    usage: Maximum number of items per page
-  - name: page
-    shorthand: p
-    default_value: '1'
-    usage: Page number for pagination (starting from 1)
+    - name: format
+      shorthand: f
+      usage: Output format. Must be one of (yaml, json)
+    - name: limit
+      shorthand: l
+      default_value: "100"
+      usage: Maximum number of items per page
+    - name: page
+      shorthand: p
+      default_value: "1"
+      usage: Page number for pagination (starting from 1)
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona snapshot list
+      daytona snapshot list --limit 50
+      daytona snapshot list --format json
 see_also:
-  - daytona snapshot - Manage Daytona snapshots
+    - daytona snapshot - Manage Daytona snapshots

--- a/apps/cli/hack/docs/daytona_snapshot_logs.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot_logs.yaml
@@ -1,24 +1,24 @@
 name: daytona snapshot logs
 synopsis: View the build logs of a snapshot
 description: |
-    View the build logs of a snapshot. With --follow the logs are streamed until the snapshot build reaches a terminal state.
+  View the build logs of a snapshot. With --follow the logs are streamed until the snapshot build reaches a terminal state.
 usage: daytona snapshot logs [SNAPSHOT_ID | SNAPSHOT_NAME] [flags]
 options:
-    - name: follow
-      shorthand: f
-      default_value: "false"
-      usage: |
-        Follow the logs until the snapshot build reaches a terminal state
+  - name: follow
+    shorthand: f
+    default_value: 'false'
+    usage: |
+      Follow the logs until the snapshot build reaches a terminal state
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona snapshot logs my-snapshot:1.0
       daytona snapshot logs my-snapshot:1.0 --follow
 see_also:
-    - daytona snapshot - Manage Daytona snapshots
+  - daytona snapshot - Manage Daytona snapshots

--- a/apps/cli/hack/docs/daytona_snapshot_logs.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot_logs.yaml
@@ -1,0 +1,24 @@
+name: daytona snapshot logs
+synopsis: View the build logs of a snapshot
+description: |
+    View the build logs of a snapshot. With --follow the logs are streamed until the snapshot build reaches a terminal state.
+usage: daytona snapshot logs [SNAPSHOT_ID | SNAPSHOT_NAME] [flags]
+options:
+    - name: follow
+      shorthand: f
+      default_value: "false"
+      usage: |
+        Follow the logs until the snapshot build reaches a terminal state
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona snapshot logs my-snapshot:1.0
+      daytona snapshot logs my-snapshot:1.0 --follow
+see_also:
+    - daytona snapshot - Manage Daytona snapshots

--- a/apps/cli/hack/docs/daytona_snapshot_push.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot_push.yaml
@@ -25,6 +25,10 @@ options:
     - name: region
       usage: |
         ID of the region where the snapshot will be available (defaults to organization default region)
+    - name: timeout
+      default_value: 0s
+      usage: |
+        Maximum time to wait for the snapshot to be validated (0 means wait indefinitely)
 inherited_options:
     - name: help
       default_value: "false"

--- a/apps/cli/hack/docs/daytona_snapshot_push.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot_push.yaml
@@ -1,44 +1,44 @@
 name: daytona snapshot push
 synopsis: Push local snapshot
 description: |
-    Push a local Docker image to Daytona. To securely build it on our infrastructure, use 'daytona snapshot build'
+  Push a local Docker image to Daytona. To securely build it on our infrastructure, use 'daytona snapshot build'
 usage: daytona snapshot push [SNAPSHOT] [flags]
 options:
-    - name: cpu
-      default_value: "0"
-      usage: |
-        CPU cores that will be allocated to the underlying sandboxes (default: 1)
-    - name: disk
-      default_value: "0"
-      usage: |
-        Disk space that will be allocated to the underlying sandboxes in GB (default: 3)
-    - name: entrypoint
-      shorthand: e
-      usage: The entrypoint command for the image
-    - name: memory
-      default_value: "0"
-      usage: |
-        Memory that will be allocated to the underlying sandboxes in GB (default: 1)
-    - name: name
-      shorthand: "n"
-      usage: Specify the Snapshot name
-    - name: region
-      usage: |
-        ID of the region where the snapshot will be available (defaults to organization default region)
-    - name: timeout
-      default_value: 0s
-      usage: |
-        Maximum time to wait for the snapshot to be validated (0 means wait indefinitely)
+  - name: cpu
+    default_value: '0'
+    usage: |
+      CPU cores that will be allocated to the underlying sandboxes (default: 1)
+  - name: disk
+    default_value: '0'
+    usage: |
+      Disk space that will be allocated to the underlying sandboxes in GB (default: 3)
+  - name: entrypoint
+    shorthand: e
+    usage: The entrypoint command for the image
+  - name: memory
+    default_value: '0'
+    usage: |
+      Memory that will be allocated to the underlying sandboxes in GB (default: 1)
+  - name: name
+    shorthand: 'n'
+    usage: Specify the Snapshot name
+  - name: region
+    usage: |
+      ID of the region where the snapshot will be available (defaults to organization default region)
+  - name: timeout
+    default_value: 0s
+    usage: |
+      Maximum time to wait for the snapshot to be validated (0 means wait indefinitely)
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona snapshot push my-image:latest --name my-snapshot:1.0
       daytona snapshot push my-image:latest --name my-snapshot:1.0 --cpu 2 --memory 4
 see_also:
-    - daytona snapshot - Manage Daytona snapshots
+  - daytona snapshot - Manage Daytona snapshots

--- a/apps/cli/hack/docs/daytona_snapshot_push.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot_push.yaml
@@ -1,33 +1,40 @@
 name: daytona snapshot push
 synopsis: Push local snapshot
 description: |
-  Push a local Docker image to Daytona. To securely build it on our infrastructure, use 'daytona snapshot build'
+    Push a local Docker image to Daytona. To securely build it on our infrastructure, use 'daytona snapshot build'
 usage: daytona snapshot push [SNAPSHOT] [flags]
 options:
-  - name: cpu
-    default_value: '0'
-    usage: |
-      CPU cores that will be allocated to the underlying sandboxes (default: 1)
-  - name: disk
-    default_value: '0'
-    usage: |
-      Disk space that will be allocated to the underlying sandboxes in GB (default: 3)
-  - name: entrypoint
-    shorthand: e
-    usage: The entrypoint command for the image
-  - name: memory
-    default_value: '0'
-    usage: |
-      Memory that will be allocated to the underlying sandboxes in GB (default: 1)
-  - name: name
-    shorthand: 'n'
-    usage: Specify the Snapshot name
-  - name: region
-    usage: |
-      ID of the region where the snapshot will be available (defaults to organization default region)
+    - name: cpu
+      default_value: "0"
+      usage: |
+        CPU cores that will be allocated to the underlying sandboxes (default: 1)
+    - name: disk
+      default_value: "0"
+      usage: |
+        Disk space that will be allocated to the underlying sandboxes in GB (default: 3)
+    - name: entrypoint
+      shorthand: e
+      usage: The entrypoint command for the image
+    - name: memory
+      default_value: "0"
+      usage: |
+        Memory that will be allocated to the underlying sandboxes in GB (default: 1)
+    - name: name
+      shorthand: "n"
+      usage: Specify the Snapshot name
+    - name: region
+      usage: |
+        ID of the region where the snapshot will be available (defaults to organization default region)
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona snapshot push my-image:latest --name my-snapshot:1.0
+      daytona snapshot push my-image:latest --name my-snapshot:1.0 --cpu 2 --memory 4
 see_also:
-  - daytona snapshot - Manage Daytona snapshots
+    - daytona snapshot - Manage Daytona snapshots

--- a/apps/cli/hack/docs/daytona_ssh.yaml
+++ b/apps/cli/hack/docs/daytona_ssh.yaml
@@ -3,20 +3,20 @@ synopsis: SSH into a sandbox
 description: Establish an SSH connection to a running sandbox
 usage: daytona ssh [SANDBOX_ID | SANDBOX_NAME] [flags]
 options:
-    - name: expires
-      default_value: "1440"
-      usage: |
-        SSH access token expiration time in minutes (defaults to 24 hours)
+  - name: expires
+    default_value: '1440'
+    usage: |
+      SSH access token expiration time in minutes (defaults to 24 hours)
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona ssh my-sandbox
       daytona ssh my-sandbox --expires 60
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_ssh.yaml
+++ b/apps/cli/hack/docs/daytona_ssh.yaml
@@ -3,13 +3,20 @@ synopsis: SSH into a sandbox
 description: Establish an SSH connection to a running sandbox
 usage: daytona ssh [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 options:
-  - name: expires
-    default_value: '1440'
-    usage: |
-      SSH access token expiration time in minutes (defaults to 24 hours)
+    - name: expires
+      default_value: "1440"
+      usage: |
+        SSH access token expiration time in minutes (defaults to 24 hours)
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona ssh my-sandbox
+      daytona ssh my-sandbox --expires 60
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_ssh.yaml
+++ b/apps/cli/hack/docs/daytona_ssh.yaml
@@ -1,7 +1,7 @@
 name: daytona ssh
 synopsis: SSH into a sandbox
 description: Establish an SSH connection to a running sandbox
-usage: daytona ssh [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+usage: daytona ssh [SANDBOX_ID | SANDBOX_NAME] [flags]
 options:
     - name: expires
       default_value: "1440"

--- a/apps/cli/hack/docs/daytona_start.yaml
+++ b/apps/cli/hack/docs/daytona_start.yaml
@@ -2,26 +2,26 @@ name: daytona start
 synopsis: Start a sandbox
 usage: daytona start [SANDBOX_ID | SANDBOX_NAME] [flags]
 options:
-    - name: format
-      shorthand: f
-      usage: Output format. Must be one of (yaml, json)
-    - name: timeout
-      default_value: 5m0s
-      usage: Maximum time to wait with --wait (0 waits indefinitely)
-    - name: wait
-      default_value: "false"
-      usage: Wait until the sandbox is started
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
+  - name: timeout
+    default_value: 5m0s
+    usage: Maximum time to wait with --wait (0 waits indefinitely)
+  - name: wait
+    default_value: 'false'
+    usage: Wait until the sandbox is started
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona start my-sandbox
       daytona start my-sandbox --wait --timeout 2m
       daytona start my-sandbox --wait --format json
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_start.yaml
+++ b/apps/cli/hack/docs/daytona_start.yaml
@@ -1,9 +1,27 @@
 name: daytona start
 synopsis: Start a sandbox
-usage: daytona start [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+usage: daytona start [SANDBOX_ID | SANDBOX_NAME] [flags]
+options:
+    - name: format
+      shorthand: f
+      usage: Output format. Must be one of (yaml, json)
+    - name: timeout
+      default_value: 5m0s
+      usage: Maximum time to wait with --wait (0 waits indefinitely)
+    - name: wait
+      default_value: "false"
+      usage: Wait until the sandbox is started
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona start my-sandbox
+      daytona start my-sandbox --wait --timeout 2m
+      daytona start my-sandbox --wait --format json
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_stop.yaml
+++ b/apps/cli/hack/docs/daytona_stop.yaml
@@ -1,14 +1,30 @@
 name: daytona stop
 synopsis: Stop a sandbox
-usage: daytona stop [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+usage: daytona stop [SANDBOX_ID | SANDBOX_NAME] [flags]
 options:
-  - name: force
-    shorthand: f
-    default_value: 'false'
-    usage: Force stop the sandbox using SIGKILL
+    - name: force
+      shorthand: f
+      default_value: "false"
+      usage: Force stop the sandbox using SIGKILL
+    - name: format
+      usage: Output format. Must be one of (yaml, json)
+    - name: timeout
+      default_value: 5m0s
+      usage: Maximum time to wait with --wait (0 waits indefinitely)
+    - name: wait
+      default_value: "false"
+      usage: Wait until the sandbox is stopped
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona stop my-sandbox
+      daytona stop my-sandbox --wait --timeout 2m
+      daytona stop my-sandbox --force --format json
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_stop.yaml
+++ b/apps/cli/hack/docs/daytona_stop.yaml
@@ -2,29 +2,29 @@ name: daytona stop
 synopsis: Stop a sandbox
 usage: daytona stop [SANDBOX_ID | SANDBOX_NAME] [flags]
 options:
-    - name: force
-      shorthand: f
-      default_value: "false"
-      usage: Force stop the sandbox using SIGKILL
-    - name: format
-      usage: Output format. Must be one of (yaml, json)
-    - name: timeout
-      default_value: 5m0s
-      usage: Maximum time to wait with --wait (0 waits indefinitely)
-    - name: wait
-      default_value: "false"
-      usage: Wait until the sandbox is stopped
+  - name: force
+    shorthand: f
+    default_value: 'false'
+    usage: Force stop the sandbox using SIGKILL
+  - name: format
+    usage: Output format. Must be one of (yaml, json)
+  - name: timeout
+    default_value: 5m0s
+    usage: Maximum time to wait with --wait (0 waits indefinitely)
+  - name: wait
+    default_value: 'false'
+    usage: Wait until the sandbox is stopped
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona stop my-sandbox
       daytona stop my-sandbox --wait --timeout 2m
       daytona stop my-sandbox --force --format json
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_version.yaml
+++ b/apps/cli/hack/docs/daytona_version.yaml
@@ -2,8 +2,12 @@ name: daytona version
 synopsis: Print the version number
 usage: daytona version [flags]
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
 see_also:
-  - daytona - Daytona CLI
+    - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_version.yaml
+++ b/apps/cli/hack/docs/daytona_version.yaml
@@ -2,12 +2,12 @@ name: daytona version
 synopsis: Print the version number
 usage: daytona version [flags]
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 see_also:
-    - daytona - Daytona CLI
+  - daytona - Daytona CLI

--- a/apps/cli/hack/docs/daytona_volume.yaml
+++ b/apps/cli/hack/docs/daytona_volume.yaml
@@ -2,16 +2,16 @@ name: daytona volume
 synopsis: Manage Daytona volumes
 description: Commands for managing Daytona volumes
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 see_also:
-    - daytona - Daytona CLI
-    - daytona volume create - Create a volume
-    - daytona volume delete - Delete a volume
-    - daytona volume get - Get volume details
-    - daytona volume list - List all volumes
+  - daytona - Daytona CLI
+  - daytona volume create - Create a volume
+  - daytona volume delete - Delete a volume
+  - daytona volume get - Get volume details
+  - daytona volume list - List all volumes

--- a/apps/cli/hack/docs/daytona_volume.yaml
+++ b/apps/cli/hack/docs/daytona_volume.yaml
@@ -2,12 +2,16 @@ name: daytona volume
 synopsis: Manage Daytona volumes
 description: Commands for managing Daytona volumes
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
 see_also:
-  - daytona - Daytona CLI
-  - daytona volume create - Create a volume
-  - daytona volume delete - Delete a volume
-  - daytona volume get - Get volume details
-  - daytona volume list - List all volumes
+    - daytona - Daytona CLI
+    - daytona volume create - Create a volume
+    - daytona volume delete - Delete a volume
+    - daytona volume get - Get volume details
+    - daytona volume list - List all volumes

--- a/apps/cli/hack/docs/daytona_volume_create.yaml
+++ b/apps/cli/hack/docs/daytona_volume_create.yaml
@@ -2,16 +2,16 @@ name: daytona volume create
 synopsis: Create a volume
 usage: daytona volume create [NAME] [flags]
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona volume create my-volume
       # Mount it when creating a sandbox
       daytona create --snapshot my-snapshot:1.0 --volume my-volume:/data
 see_also:
-    - daytona volume - Manage Daytona volumes
+  - daytona volume - Manage Daytona volumes

--- a/apps/cli/hack/docs/daytona_volume_create.yaml
+++ b/apps/cli/hack/docs/daytona_volume_create.yaml
@@ -1,14 +1,17 @@
 name: daytona volume create
 synopsis: Create a volume
 usage: daytona volume create [NAME] [flags]
-options:
-  - name: size
-    shorthand: s
-    default_value: '10'
-    usage: Size of the volume in GB
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona volume create my-volume
+      # Mount it when creating a sandbox
+      daytona create --snapshot my-snapshot:1.0 --volume my-volume:/data
 see_also:
-  - daytona volume - Manage Daytona volumes
+    - daytona volume - Manage Daytona volumes

--- a/apps/cli/hack/docs/daytona_volume_delete.yaml
+++ b/apps/cli/hack/docs/daytona_volume_delete.yaml
@@ -2,8 +2,15 @@ name: daytona volume delete
 synopsis: Delete a volume
 usage: daytona volume delete [VOLUME_ID_OR_NAME] [flags]
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      # Delete a volume by name or ID
+      daytona volume delete my-volume
 see_also:
-  - daytona volume - Manage Daytona volumes
+    - daytona volume - Manage Daytona volumes

--- a/apps/cli/hack/docs/daytona_volume_delete.yaml
+++ b/apps/cli/hack/docs/daytona_volume_delete.yaml
@@ -2,15 +2,15 @@ name: daytona volume delete
 synopsis: Delete a volume
 usage: daytona volume delete [VOLUME_ID_OR_NAME] [flags]
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       # Delete a volume by name or ID
       daytona volume delete my-volume
 see_also:
-    - daytona volume - Manage Daytona volumes
+  - daytona volume - Manage Daytona volumes

--- a/apps/cli/hack/docs/daytona_volume_get.yaml
+++ b/apps/cli/hack/docs/daytona_volume_get.yaml
@@ -2,12 +2,19 @@ name: daytona volume get
 synopsis: Get volume details
 usage: daytona volume get [VOLUME_ID_OR_NAME] [flags]
 options:
-  - name: format
-    shorthand: f
-    usage: Output format. Must be one of (yaml, json)
+    - name: format
+      shorthand: f
+      usage: Output format. Must be one of (yaml, json)
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona volume get my-volume
+      daytona volume get my-volume --format json
 see_also:
-  - daytona volume - Manage Daytona volumes
+    - daytona volume - Manage Daytona volumes

--- a/apps/cli/hack/docs/daytona_volume_get.yaml
+++ b/apps/cli/hack/docs/daytona_volume_get.yaml
@@ -2,19 +2,19 @@ name: daytona volume get
 synopsis: Get volume details
 usage: daytona volume get [VOLUME_ID_OR_NAME] [flags]
 options:
-    - name: format
-      shorthand: f
-      usage: Output format. Must be one of (yaml, json)
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona volume get my-volume
       daytona volume get my-volume --format json
 see_also:
-    - daytona volume - Manage Daytona volumes
+  - daytona volume - Manage Daytona volumes

--- a/apps/cli/hack/docs/daytona_volume_list.yaml
+++ b/apps/cli/hack/docs/daytona_volume_list.yaml
@@ -2,12 +2,19 @@ name: daytona volume list
 synopsis: List all volumes
 usage: daytona volume list [flags]
 options:
-  - name: format
-    shorthand: f
-    usage: Output format. Must be one of (yaml, json)
+    - name: format
+      shorthand: f
+      usage: Output format. Must be one of (yaml, json)
 inherited_options:
-  - name: help
-    default_value: 'false'
-    usage: help for daytona
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: no-input
+      default_value: "false"
+      usage: |
+        Never prompt for input; fail instead when input would be required
+example: |4-
+      daytona volume list
+      daytona volume list --format json
 see_also:
-  - daytona volume - Manage Daytona volumes
+    - daytona volume - Manage Daytona volumes

--- a/apps/cli/hack/docs/daytona_volume_list.yaml
+++ b/apps/cli/hack/docs/daytona_volume_list.yaml
@@ -2,19 +2,19 @@ name: daytona volume list
 synopsis: List all volumes
 usage: daytona volume list [flags]
 options:
-    - name: format
-      shorthand: f
-      usage: Output format. Must be one of (yaml, json)
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
 inherited_options:
-    - name: help
-      default_value: "false"
-      usage: help for daytona
-    - name: no-input
-      default_value: "false"
-      usage: |
-        Never prompt for input; fail instead when input would be required
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+  - name: no-input
+    default_value: 'false'
+    usage: |
+      Never prompt for input; fail instead when input would be required
 example: |4-
       daytona volume list
       daytona volume list --format json
 see_also:
-    - daytona volume - Manage Daytona volumes
+  - daytona volume - Manage Daytona volumes

--- a/apps/cli/hack/generate-cli-docs.sh
+++ b/apps/cli/hack/generate-cli-docs.sh
@@ -8,3 +8,7 @@ rm -rf docs hack/docs
 
 # Generate default CLI documentation files in folder "docs"
 go run main.go generate-docs
+
+# Normalize the generated YAML to the repo prettier style so that
+# 'yarn format' produces no diff in CI (see the generate-api-clients job)
+npx prettier --write "hack/docs/**/*.yaml" --log-level warn

--- a/apps/cli/internal/clierr/clierr.go
+++ b/apps/cli/internal/clierr/clierr.go
@@ -1,0 +1,113 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+// Package clierr defines the CLI error model: categorized errors with an
+// optional remediation hint and a deterministic process exit code mapping.
+// It is a leaf package and must only import the standard library.
+package clierr
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Category classifies an error so callers (and scripts parsing --format
+// output) can react to the kind of failure without string matching.
+type Category string
+
+const (
+	CategoryUsage     Category = "usage"
+	CategoryAuth      Category = "auth"
+	CategoryNotFound  Category = "not_found"
+	CategoryConflict  Category = "conflict"
+	CategoryRateLimit Category = "rate_limit"
+	CategoryServer    Category = "server"
+	CategoryNetwork   Category = "network"
+	CategoryTimeout   Category = "timeout"
+)
+
+// Error is the structured CLI error. Message holds the failure description,
+// Hint an optional remediation suggestion, and Code an optional explicit
+// process exit code overriding the category mapping.
+type Error struct {
+	Category Category
+	Message  string
+	Hint     string
+	Code     int
+}
+
+func (e *Error) Error() string {
+	if e.Hint != "" {
+		return e.Message + " - " + e.Hint
+	}
+	return e.Message
+}
+
+func New(cat Category, msg string) *Error {
+	return &Error{Category: cat, Message: msg}
+}
+
+func Newf(cat Category, format string, a ...any) *Error {
+	return &Error{Category: cat, Message: fmt.Sprintf(format, a...)}
+}
+
+// WithHint sets the remediation hint and returns the error for chaining.
+func (e *Error) WithHint(hint string) *Error {
+	e.Hint = hint
+	return e
+}
+
+// WithCode sets an explicit process exit code and returns the error for chaining.
+func (e *Error) WithCode(code int) *Error {
+	e.Code = code
+	return e
+}
+
+// ExitCode maps an error to a process exit code: an explicit Code wins,
+// usage errors exit 2, wait timeouts exit 124, everything else exits 1.
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	var cliErr *Error
+	if !errors.As(err, &cliErr) {
+		return 1
+	}
+
+	if cliErr.Code > 0 {
+		return cliErr.Code
+	}
+
+	switch cliErr.Category {
+	case CategoryUsage:
+		return 2
+	case CategoryTimeout:
+		return 124
+	default:
+		return 1
+	}
+}
+
+// FromHTTPStatus builds an Error categorized by the HTTP response status,
+// attaching the standard remediation hint for authentication failures.
+func FromHTTPStatus(status int, msg string) *Error {
+	switch {
+	case status == 400:
+		return New(CategoryUsage, msg)
+	case status == 401:
+		return New(CategoryAuth, msg).WithHint("run 'daytona login' to reauthenticate")
+	case status == 403:
+		return New(CategoryAuth, msg).WithHint("check that your API key has sufficient permissions for this action")
+	case status == 404:
+		return New(CategoryNotFound, msg)
+	case status == 409:
+		return New(CategoryConflict, msg)
+	case status == 429:
+		return New(CategoryRateLimit, msg)
+	case status >= 500:
+		return New(CategoryServer, msg)
+	default:
+		return New(CategoryServer, msg)
+	}
+}

--- a/apps/cli/internal/clierr/clierr.go
+++ b/apps/cli/internal/clierr/clierr.go
@@ -63,6 +63,12 @@ func (e *Error) WithCode(code int) *Error {
 	return e
 }
 
+// HasCategory reports whether err is (or wraps) an *Error with the given category.
+func HasCategory(err error, cat Category) bool {
+	var cliErr *Error
+	return errors.As(err, &cliErr) && cliErr.Category == cat
+}
+
 // ExitCode maps an error to a process exit code: an explicit Code wins,
 // usage errors exit 2, wait timeouts exit 124, everything else exits 1.
 func ExitCode(err error) int {

--- a/apps/cli/internal/clierr/clierr_test.go
+++ b/apps/cli/internal/clierr/clierr_test.go
@@ -108,3 +108,26 @@ func TestWithCodeOverride(t *testing.T) {
 		t.Errorf("ExitCode after WithCode(255) = %d, want 255", got)
 	}
 }
+
+func TestHasCategory(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		cat  clierr.Category
+		want bool
+	}{
+		{name: "direct match", err: clierr.New(clierr.CategoryNotFound, "gone"), cat: clierr.CategoryNotFound, want: true},
+		{name: "wrapped match", err: fmt.Errorf("context: %w", clierr.New(clierr.CategoryNotFound, "gone")), cat: clierr.CategoryNotFound, want: true},
+		{name: "nil error", err: nil, cat: clierr.CategoryNotFound, want: false},
+		{name: "wrong category", err: clierr.New(clierr.CategoryServer, "boom"), cat: clierr.CategoryNotFound, want: false},
+		{name: "plain error", err: errors.New("boom"), cat: clierr.CategoryNotFound, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clierr.HasCategory(tt.err, tt.cat); got != tt.want {
+				t.Errorf("HasCategory(%v, %q) = %v, want %v", tt.err, tt.cat, got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/cli/internal/clierr/clierr_test.go
+++ b/apps/cli/internal/clierr/clierr_test.go
@@ -1,0 +1,110 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package clierr_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+)
+
+func TestExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "nil error", err: nil, want: 0},
+		{name: "non-clierr error", err: errors.New("boom"), want: 1},
+		{name: "usage category", err: clierr.New(clierr.CategoryUsage, "bad flag"), want: 2},
+		{name: "timeout category", err: clierr.New(clierr.CategoryTimeout, "timed out"), want: 124},
+		{name: "auth category", err: clierr.New(clierr.CategoryAuth, "unauthorized"), want: 1},
+		{name: "not_found category", err: clierr.New(clierr.CategoryNotFound, "missing"), want: 1},
+		{name: "conflict category", err: clierr.New(clierr.CategoryConflict, "exists"), want: 1},
+		{name: "rate_limit category", err: clierr.New(clierr.CategoryRateLimit, "slow down"), want: 1},
+		{name: "server category", err: clierr.New(clierr.CategoryServer, "oops"), want: 1},
+		{name: "network category", err: clierr.New(clierr.CategoryNetwork, "refused"), want: 1},
+		{name: "explicit code overrides category", err: clierr.New(clierr.CategoryUsage, "exec failed").WithCode(255), want: 255},
+		{name: "explicit code on server category", err: clierr.New(clierr.CategoryServer, "exec failed").WithCode(7), want: 7},
+		{name: "wrapped clierr is unwrapped", err: fmt.Errorf("context: %w", clierr.New(clierr.CategoryTimeout, "timed out")), want: 124},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clierr.ExitCode(tt.err); got != tt.want {
+				t.Errorf("ExitCode(%v) = %d, want %d", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFromHTTPStatus(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       int
+		wantCategory clierr.Category
+		wantHint     string
+	}{
+		{name: "400 maps to usage", status: 400, wantCategory: clierr.CategoryUsage},
+		{name: "401 maps to auth with login hint", status: 401, wantCategory: clierr.CategoryAuth, wantHint: "run 'daytona login' to reauthenticate"},
+		{name: "403 maps to auth with permissions hint", status: 403, wantCategory: clierr.CategoryAuth, wantHint: "check that your API key has sufficient permissions for this action"},
+		{name: "404 maps to not_found", status: 404, wantCategory: clierr.CategoryNotFound},
+		{name: "409 maps to conflict", status: 409, wantCategory: clierr.CategoryConflict},
+		{name: "429 maps to rate_limit", status: 429, wantCategory: clierr.CategoryRateLimit},
+		{name: "500 maps to server", status: 500, wantCategory: clierr.CategoryServer},
+		{name: "503 maps to server", status: 503, wantCategory: clierr.CategoryServer},
+		{name: "unlisted 4xx defaults to server", status: 418, wantCategory: clierr.CategoryServer},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := clierr.FromHTTPStatus(tt.status, "request failed")
+			if err.Category != tt.wantCategory {
+				t.Errorf("FromHTTPStatus(%d) category = %q, want %q", tt.status, err.Category, tt.wantCategory)
+			}
+			if err.Hint != tt.wantHint {
+				t.Errorf("FromHTTPStatus(%d) hint = %q, want %q", tt.status, err.Hint, tt.wantHint)
+			}
+			if err.Message != "request failed" {
+				t.Errorf("FromHTTPStatus(%d) message = %q, want %q", tt.status, err.Message, "request failed")
+			}
+		})
+	}
+}
+
+func TestErrorHintComposition(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *clierr.Error
+		want string
+	}{
+		{name: "no hint returns message only", err: clierr.New(clierr.CategoryServer, "request failed"), want: "request failed"},
+		{name: "hint is appended with separator", err: clierr.New(clierr.CategoryAuth, "Unauthorized").WithHint("run 'daytona login' to reauthenticate"), want: "Unauthorized - run 'daytona login' to reauthenticate"},
+		{name: "newf formats message", err: clierr.Newf(clierr.CategoryUsage, "invalid value %q", "x"), want: `invalid value "x"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWithCodeOverride(t *testing.T) {
+	err := clierr.New(clierr.CategoryTimeout, "timed out")
+	if got := clierr.ExitCode(err); got != 124 {
+		t.Fatalf("ExitCode before WithCode = %d, want 124", got)
+	}
+
+	if returned := err.WithCode(255); returned != err {
+		t.Error("WithCode should return the receiver for chaining")
+	}
+	if got := clierr.ExitCode(err); got != 255 {
+		t.Errorf("ExitCode after WithCode(255) = %d, want 255", got)
+	}
+}

--- a/apps/cli/internal/interactive.go
+++ b/apps/cli/internal/interactive.go
@@ -1,0 +1,21 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package internal
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+// NoInput is set by the root --no-input persistent flag. When true, the CLI
+// must never prompt for input and should fail instead.
+var NoInput bool
+
+// Interactive reports whether the CLI may prompt the user for input:
+// prompting was not disabled via --no-input and both stdin and stdout are
+// terminals.
+func Interactive() bool {
+	return !NoInput && term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}

--- a/apps/cli/main.go
+++ b/apps/cli/main.go
@@ -4,26 +4,33 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/daytonaio/daytona/cli/cmd"
 	"github.com/daytonaio/daytona/cli/cmd/auth"
+	"github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/cmd/mcp"
 	"github.com/daytonaio/daytona/cli/cmd/organization"
 	"github.com/daytonaio/daytona/cli/cmd/sandbox"
 	"github.com/daytonaio/daytona/cli/cmd/snapshot"
 	"github.com/daytonaio/daytona/cli/cmd/volume"
 	"github.com/daytonaio/daytona/cli/internal"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
-	Use:               "daytona",
-	Short:             "Daytona CLI",
-	Long:              "Command line interface for Daytona Sandboxes",
+	Use:   "daytona",
+	Short: "Daytona CLI",
+	Long: `Command line interface for Daytona Sandboxes
+
+Exit codes: 0 success; 1 runtime failure; 2 invalid flags or arguments (where validated); 124 wait timeout. 'daytona exec' exits with the remote command's exit code; 255 indicates a CLI-side failure.`,
 	DisableAutoGenTag: true,
 	SilenceUsage:      true,
 	SilenceErrors:     true,
@@ -62,7 +69,12 @@ func init() {
 
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 	rootCmd.PersistentFlags().BoolP("help", "", false, "help for daytona")
+	rootCmd.PersistentFlags().BoolVar(&internal.NoInput, "no-input", false, "Never prompt for input; fail instead when input would be required")
 	rootCmd.Flags().BoolP("version", "v", false, "Display the version of Daytona")
+
+	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return clierr.New(clierr.CategoryUsage, err.Error())
+	})
 
 	rootCmd.PreRun = func(command *cobra.Command, args []string) {
 		versionFlag, _ := command.Flags().GetBool("version")
@@ -82,9 +94,11 @@ func createSandboxShortcut(original *cobra.Command) *cobra.Command {
 		Use:     original.Use,
 		Short:   original.Short,
 		Long:    original.Long,
+		Example: original.Example,
 		Args:    original.Args,
 		Aliases: original.Aliases,
 		GroupID: internal.SANDBOX_GROUP,
+		PreRunE: original.PreRunE,
 		RunE:    original.RunE,
 	}
 	shortcut.Flags().AddFlagSet(original.Flags())
@@ -96,6 +110,37 @@ func main() {
 
 	err := rootCmd.Execute()
 	if err != nil {
-		log.Fatal(err)
+		reportExecuteError(err)
+		os.Exit(clierr.ExitCode(err))
 	}
+}
+
+// reportExecuteError prints the final error: a single-line JSON object on
+// stderr when a structured output format was requested, a human-readable log
+// line otherwise.
+func reportExecuteError(err error) {
+	if common.FormatFlag == "" {
+		log.Error(err)
+		return
+	}
+
+	payload := struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+		Hint  string `json:"hint,omitempty"`
+	}{Error: err.Error(), Code: "error"}
+
+	var cliErr *clierr.Error
+	if errors.As(err, &cliErr) {
+		payload.Error = cliErr.Message
+		payload.Code = string(cliErr.Category)
+		payload.Hint = cliErr.Hint
+	}
+
+	data, marshalErr := json.Marshal(payload)
+	if marshalErr != nil {
+		log.Error(err)
+		return
+	}
+	fmt.Fprintln(os.Stderr, string(data))
 }

--- a/apps/cli/main.go
+++ b/apps/cli/main.go
@@ -119,6 +119,29 @@ func main() {
 	}
 }
 
+// executeErrorBody is the single-line JSON object reported on stderr for a
+// failed command when a structured output format was requested.
+type executeErrorBody struct {
+	Error string `json:"error"`
+	Code  string `json:"code"`
+	Hint  string `json:"hint,omitempty"`
+}
+
+// executeErrorPayload shapes err into the structured error object: clierr
+// errors map to their message, category, and hint; anything else reports the
+// error text under the generic "error" code.
+func executeErrorPayload(err error) executeErrorBody {
+	payload := executeErrorBody{Error: err.Error(), Code: "error"}
+
+	var cliErr *clierr.Error
+	if errors.As(err, &cliErr) {
+		payload.Error = cliErr.Message
+		payload.Code = string(cliErr.Category)
+		payload.Hint = cliErr.Hint
+	}
+	return payload
+}
+
 // reportExecuteError prints the final error: a single-line JSON object on
 // stderr when a structured output format was requested, a human-readable log
 // line otherwise.
@@ -128,20 +151,7 @@ func reportExecuteError(err error) {
 		return
 	}
 
-	payload := struct {
-		Error string `json:"error"`
-		Code  string `json:"code"`
-		Hint  string `json:"hint,omitempty"`
-	}{Error: err.Error(), Code: "error"}
-
-	var cliErr *clierr.Error
-	if errors.As(err, &cliErr) {
-		payload.Error = cliErr.Message
-		payload.Code = string(cliErr.Category)
-		payload.Hint = cliErr.Hint
-	}
-
-	data, marshalErr := json.Marshal(payload)
+	data, marshalErr := json.Marshal(executeErrorPayload(err))
 	if marshalErr != nil {
 		log.Error(err)
 		return

--- a/apps/cli/main.go
+++ b/apps/cli/main.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/daytonaio/daytona/cli/cmd"
+	api "github.com/daytonaio/daytona/cli/cmd/api"
 	"github.com/daytonaio/daytona/cli/cmd/auth"
 	"github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/cmd/mcp"
@@ -54,6 +55,7 @@ func init() {
 	rootCmd.AddCommand(cmd.AutoCompleteCmd)
 	rootCmd.AddCommand(cmd.GenerateDocsCmd)
 	rootCmd.AddCommand(cmd.VersionCmd)
+	rootCmd.AddCommand(api.ApiCmd)
 
 	// Add sandbox subcommands as top-level shortcuts
 	rootCmd.AddCommand(createSandboxShortcut(sandbox.CreateCmd))
@@ -66,6 +68,8 @@ func init() {
 	rootCmd.AddCommand(createSandboxShortcut(sandbox.SSHCmd))
 	rootCmd.AddCommand(createSandboxShortcut(sandbox.ExecCmd))
 	rootCmd.AddCommand(createSandboxShortcut(sandbox.PreviewUrlCmd))
+	rootCmd.AddCommand(createSandboxShortcut(sandbox.CpCmd))
+	rootCmd.AddCommand(createSandboxShortcut(sandbox.LogsCmd))
 
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 	rootCmd.PersistentFlags().BoolP("help", "", false, "help for daytona")

--- a/apps/cli/main_test.go
+++ b/apps/cli/main_test.go
@@ -1,0 +1,89 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+)
+
+func TestExecuteErrorPayload(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantError string
+		wantCode  string
+		wantHint  string
+	}{
+		{
+			name:      "clierr maps message, category, and hint",
+			err:       clierr.New(clierr.CategoryAuth, "unauthorized").WithHint("run 'daytona login' to reauthenticate"),
+			wantError: "unauthorized",
+			wantCode:  "auth",
+			wantHint:  "run 'daytona login' to reauthenticate",
+		},
+		{
+			name:      "clierr without hint",
+			err:       clierr.New(clierr.CategoryNotFound, "sandbox not found"),
+			wantError: "sandbox not found",
+			wantCode:  "not_found",
+		},
+		{
+			name:      "wrapped clierr is unwrapped",
+			err:       fmt.Errorf("context: %w", clierr.New(clierr.CategoryUsage, "bad flag").WithHint("see --help")),
+			wantError: "bad flag",
+			wantCode:  "usage",
+			wantHint:  "see --help",
+		},
+		{
+			name:      "plain error maps to generic code",
+			err:       errors.New("boom"),
+			wantError: "boom",
+			wantCode:  "error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := executeErrorPayload(tt.err)
+			if payload.Error != tt.wantError {
+				t.Errorf("Error = %q, want %q", payload.Error, tt.wantError)
+			}
+			if payload.Code != tt.wantCode {
+				t.Errorf("Code = %q, want %q", payload.Code, tt.wantCode)
+			}
+			if payload.Hint != tt.wantHint {
+				t.Errorf("Hint = %q, want %q", payload.Hint, tt.wantHint)
+			}
+		})
+	}
+}
+
+func TestExecuteErrorPayloadJSONShape(t *testing.T) {
+	t.Run("hint key omitted when empty", func(t *testing.T) {
+		data, err := json.Marshal(executeErrorPayload(errors.New("boom")))
+		if err != nil {
+			t.Fatalf("json.Marshal: %v", err)
+		}
+		if got := string(data); got != `{"error":"boom","code":"error"}` {
+			t.Errorf("payload JSON = %s, want {\"error\":\"boom\",\"code\":\"error\"}", got)
+		}
+	})
+
+	t.Run("hint key present for clierr with hint", func(t *testing.T) {
+		payload := executeErrorPayload(clierr.New(clierr.CategoryAuth, "unauthorized").WithHint("log in"))
+		data, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("json.Marshal: %v", err)
+		}
+		if !strings.Contains(string(data), `"hint":"log in"`) {
+			t.Errorf("payload JSON = %s, missing hint key", data)
+		}
+	})
+}

--- a/apps/cli/views/common/confirm.go
+++ b/apps/cli/views/common/confirm.go
@@ -1,0 +1,33 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common
+
+import (
+	"github.com/charmbracelet/huh"
+	"github.com/daytonaio/daytona/cli/internal"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+)
+
+// Confirm shows an interactive yes/no confirmation prompt and returns the
+// user's choice. In non-interactive mode it fails instead of prompting.
+func Confirm(question string) (bool, error) {
+	if !internal.Interactive() {
+		return false, clierr.New(clierr.CategoryUsage, "confirmation required in non-interactive mode").WithHint("pass --yes to proceed")
+	}
+
+	var confirmed bool
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(question).
+				Value(&confirmed),
+		).WithTheme(GetCustomTheme()),
+	)
+
+	if err := form.Run(); err != nil {
+		return false, err
+	}
+
+	return confirmed, nil
+}

--- a/apps/cli/views/common/confirm_test.go
+++ b/apps/cli/views/common/confirm_test.go
@@ -1,0 +1,48 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/internal"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+	"github.com/daytonaio/daytona/cli/views/common"
+)
+
+// forceNonInteractive makes internal.Interactive() return false for the
+// duration of the test, regardless of the test process TTY.
+func forceNonInteractive(t *testing.T) {
+	t.Helper()
+	prev := internal.NoInput
+	internal.NoInput = true
+	t.Cleanup(func() { internal.NoInput = prev })
+}
+
+// assertUsageClierr fails the test unless err is a *clierr.Error with the
+// usage category and the expected hint.
+func assertUsageClierr(t *testing.T, err error, wantHint string) {
+	t.Helper()
+	var cliErr *clierr.Error
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *clierr.Error, got %T: %v", err, err)
+	}
+	if cliErr.Category != clierr.CategoryUsage {
+		t.Errorf("category = %q, want %q", cliErr.Category, clierr.CategoryUsage)
+	}
+	if cliErr.Hint != wantHint {
+		t.Errorf("hint = %q, want %q", cliErr.Hint, wantHint)
+	}
+}
+
+func TestConfirmNonInteractive(t *testing.T) {
+	forceNonInteractive(t)
+
+	confirmed, err := common.Confirm("Delete 2 sandboxes?")
+	if confirmed {
+		t.Error("Confirm() in non-interactive mode returned true, want false")
+	}
+	assertUsageClierr(t, err, "pass --yes to proceed")
+}

--- a/apps/cli/views/common/prompt.go
+++ b/apps/cli/views/common/prompt.go
@@ -10,6 +10,8 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/daytonaio/daytona/cli/internal"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 )
 
 type promptModel struct {
@@ -65,6 +67,10 @@ func (m promptModel) View() string {
 }
 
 func PromptForInput(prompt, title, desc string) (string, error) {
+	if !internal.Interactive() {
+		return "", clierr.New(clierr.CategoryUsage, "cannot prompt for input in non-interactive mode").WithHint("re-run interactively or provide the value via flags")
+	}
+
 	ti := textinput.New()
 	ti.Focus()
 	ti.CharLimit = 156

--- a/apps/cli/views/common/prompt_test.go
+++ b/apps/cli/views/common/prompt_test.go
@@ -1,0 +1,20 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common_test
+
+import (
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/views/common"
+)
+
+func TestPromptForInputNonInteractive(t *testing.T) {
+	forceNonInteractive(t)
+
+	value, err := common.PromptForInput("prompt", "Title", "Description")
+	if value != "" {
+		t.Errorf("PromptForInput() in non-interactive mode returned %q, want empty string", value)
+	}
+	assertUsageClierr(t, err, "re-run interactively or provide the value via flags")
+}

--- a/apps/cli/views/common/select.go
+++ b/apps/cli/views/common/select.go
@@ -6,6 +6,8 @@ package common
 import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/daytonaio/daytona/cli/internal"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 )
 
 // SelectItem represents an item in the selection list
@@ -94,6 +96,10 @@ func (m SelectModel) View() string {
 // Select displays a selection prompt with the given title and items
 // Returns the selected item's title and any error that occurred
 func Select(title string, items []SelectItem) (string, error) {
+	if !internal.Interactive() {
+		return "", clierr.New(clierr.CategoryUsage, "cannot prompt for input in non-interactive mode").WithHint("re-run interactively or provide the value via flags")
+	}
+
 	p := tea.NewProgram(NewSelectModel(title, items), tea.WithAltScreen())
 	m, err := p.Run()
 	if err != nil {

--- a/apps/cli/views/common/select_test.go
+++ b/apps/cli/views/common/select_test.go
@@ -1,0 +1,23 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common_test
+
+import (
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/views/common"
+)
+
+func TestSelectNonInteractive(t *testing.T) {
+	forceNonInteractive(t)
+
+	choice, err := common.Select("Choose an option", []common.SelectItem{
+		{Title: "first", Desc: "first option"},
+		{Title: "second", Desc: "second option"},
+	})
+	if choice != "" {
+		t.Errorf("Select() in non-interactive mode returned %q, want empty string", choice)
+	}
+	assertUsageClierr(t, err, "re-run interactively or provide the value via flags")
+}

--- a/apps/cli/views/organization/select.go
+++ b/apps/cli/views/organization/select.go
@@ -5,11 +5,17 @@ package organization
 
 import (
 	"github.com/charmbracelet/huh"
+	"github.com/daytonaio/daytona/cli/internal"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
 	"github.com/daytonaio/daytona/cli/views/common"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 )
 
 func GetOrganizationIdFromPrompt(organizationList []apiclient.Organization) (*apiclient.Organization, error) {
+	if !internal.Interactive() {
+		return nil, clierr.New(clierr.CategoryUsage, "cannot prompt for input in non-interactive mode").WithHint("pass the organization ID or name as an argument")
+	}
+
 	var chosenOrganizationId string
 	var organizationOptions []huh.Option[string]
 

--- a/apps/cli/views/organization/select_test.go
+++ b/apps/cli/views/organization/select_test.go
@@ -1,0 +1,39 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package organization_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/internal"
+	"github.com/daytonaio/daytona/cli/internal/clierr"
+	"github.com/daytonaio/daytona/cli/views/organization"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+)
+
+func TestGetOrganizationIdFromPromptNonInteractive(t *testing.T) {
+	prev := internal.NoInput
+	internal.NoInput = true
+	t.Cleanup(func() { internal.NoInput = prev })
+
+	org, err := organization.GetOrganizationIdFromPrompt([]apiclient.Organization{
+		{Id: "org-1", Name: "Org One"},
+		{Id: "org-2", Name: "Org Two"},
+	})
+	if org != nil {
+		t.Errorf("GetOrganizationIdFromPrompt() in non-interactive mode returned %v, want nil", org)
+	}
+
+	var cliErr *clierr.Error
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected *clierr.Error, got %T: %v", err, err)
+	}
+	if cliErr.Category != clierr.CategoryUsage {
+		t.Errorf("category = %q, want %q", cliErr.Category, clierr.CategoryUsage)
+	}
+	if cliErr.Hint != "pass the organization ID or name as an argument" {
+		t.Errorf("hint = %q, want %q", cliErr.Hint, "pass the organization ID or name as an argument")
+	}
+}

--- a/apps/docs/src/content/docs/en/tools/cli.mdx
+++ b/apps/docs/src/content/docs/en/tools/cli.mdx
@@ -76,20 +76,58 @@ __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 | `--version` | `-v` | Display the version of Daytona |
+
+
+## daytona api
+Make an authenticated request to the Daytona API
+
+```shell
+daytona api PATH [flags]
+```
+
+### Examples
+
+```shell
+  daytona api /sandbox
+  daytona api /sandbox/my-sandbox -X DELETE
+  daytona api /snapshots -X POST --input snapshot.json
+  cat body.json | daytona api /sandbox -X POST --input -
+```
+
+__Flags__
+| Long | Short | Description |
+| :--- | :---- | :---------- |
+| `--input` |  | Request body source: a file path or '-' for stdin (POST, PUT, and PATCH only) |
+| `--method` | `-X` | HTTP method (GET, POST, PUT, PATCH, DELETE, HEAD) |
+| `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona archive
 Archive a sandbox
 
 ```shell
-daytona archive [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+daytona archive [SANDBOX_ID | SANDBOX_NAME] [flags]
+```
+
+### Examples
+
+```shell
+  daytona archive my-sandbox
+  daytona archive my-sandbox --wait --timeout 10m
+  daytona archive my-sandbox --wait --format json
 ```
 
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
+| `--format` | `-f` | Output format. Must be one of (yaml, json) |
+| `--timeout` |  | Maximum time to wait with --wait (0 waits indefinitely) |
+| `--wait` |  | Wait until the sandbox is archived |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona autocomplete
@@ -103,6 +141,7 @@ __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 <Aside type="note">
 If using bash shell environment, make sure you have bash-completion installed in order to get full autocompletion functionality.
@@ -110,11 +149,42 @@ Linux Installation: ```sudo apt-get install bash-completion```
 macOS Installation: ```brew install bash-completion```
 </Aside>
 
+## daytona cp
+Copy files between the local machine and a sandbox
+
+```shell
+daytona cp SOURCE DESTINATION [flags]
+```
+
+### Examples
+
+```shell
+  daytona cp ./config.yaml my-sandbox:/workspace/config.yaml
+  daytona cp my-sandbox:/workspace/output ./output
+  daytona cp ./src my-sandbox:/workspace/src --format json
+```
+
+__Flags__
+| Long | Short | Description |
+| :--- | :---- | :---------- |
+| `--format` | `-f` | Output format. Must be one of (yaml, json) |
+| `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
+
+
 ## daytona create
 Create a new sandbox
 
 ```shell
 daytona create [flags]
+```
+
+### Examples
+
+```shell
+  daytona create --snapshot my-snapshot:1.0 --name my-sandbox
+  daytona create --name my-sandbox --env-file .env --if-exists reuse
+  daytona create --snapshot my-snapshot:1.0 --name my-sandbox --format json
 ```
 
 __Flags__
@@ -128,8 +198,12 @@ __Flags__
 | `--disk` |  | Disk space allocated to the sandbox in GB |
 | `--dockerfile` | `-f` | Path to Dockerfile for Sandbox snapshot |
 | `--env` | `-e` | Environment variables (format: KEY=VALUE) |
+| `--env-file` |  | Read environment variables from a dotenv-style file (entries from --env override file values) |
+| `--format` |  | Output format. Must be one of (yaml, json) |
 | `--gpu` |  | GPU units allocated to the sandbox |
+| `--if-exists` |  | Behavior when a sandbox with the same name already exists (error, reuse; reuse requires --name) |
 | `--label` | `-l` | Labels (format: KEY=VALUE) |
+| `--label-file` |  | Read labels from a dotenv-style file (entries from --label override file values) |
 | `--memory` |  | Memory allocated to the sandbox in MB |
 | `--name` |  | Name of the sandbox |
 | `--network-allow-list` |  | Comma-separated list of allowed CIDR network addresses for the sandbox |
@@ -137,23 +211,41 @@ __Flags__
 | `--public` |  | Make sandbox publicly accessible |
 | `--snapshot` |  | Snapshot to use for the sandbox |
 | `--target` |  | Target region (eu, us) |
+| `--timeout` |  | Maximum time to wait for the sandbox to start (0 means wait indefinitely) |
 | `--user` |  | User associated with the sandbox |
 | `--volume` | `-v` | Volumes to mount (format: VOLUME_ID_OR_NAME:MOUNT_PATH) |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona delete
 Delete a sandbox
 
 ```shell
-daytona delete [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+daytona delete [SANDBOX_ID | SANDBOX_NAME] [flags]
+```
+
+### Examples
+
+```shell
+  daytona delete my-sandbox
+  daytona delete my-sandbox --wait --format json
+  daytona delete --all --dry-run
+  daytona delete --all --yes
 ```
 
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--all` | `-a` | Delete all sandboxes |
+| `--dry-run` |  | Show what would be deleted without deleting anything |
+| `--format` | `-f` | Output format. Must be one of (yaml, json) |
+| `--ignore-not-found` |  | Treat a missing sandbox as a successful delete |
+| `--timeout` |  | Maximum time to wait with --wait (0 waits indefinitely) |
+| `--wait` |  | Wait until the sandbox is fully deleted |
+| `--yes` | `-y` | Skip the confirmation prompt for bulk deletes |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona docs
@@ -167,6 +259,7 @@ __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona exec
@@ -176,12 +269,22 @@ Execute a command in a sandbox
 daytona exec [SANDBOX_ID | SANDBOX_NAME] -- [COMMAND] [ARGS...] [flags]
 ```
 
+### Examples
+
+```shell
+  daytona exec my-sandbox -- ls -la /workspace
+  daytona exec my-sandbox -- python -c "print('hi')"
+  daytona exec my-sandbox --cwd /workspace --format json -- npm test
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--cwd` |  | Working directory for command execution |
+| `--format` | `-f` | Output format. Must be one of (yaml, json) |
 | `--timeout` |  | Command timeout in seconds (0 for no timeout) |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona info
@@ -191,11 +294,19 @@ Get sandbox info
 daytona info [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 ```
 
+### Examples
+
+```shell
+  daytona info my-sandbox
+  daytona info my-sandbox --format json
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--format` | `-f` | Output format. Must be one of (yaml, json) |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona list
@@ -205,6 +316,14 @@ List sandboxes
 daytona list [flags]
 ```
 
+### Examples
+
+```shell
+  daytona list
+  daytona list --limit 50
+  daytona list --format json
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
@@ -212,6 +331,7 @@ __Flags__
 | `--format` | `-f` | Output format. Must be one of (yaml, json) |
 | `--limit` | `-l` | Maximum number of items per page |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona login
@@ -221,11 +341,22 @@ Log in to Daytona
 daytona login [flags]
 ```
 
+### Examples
+
+```shell
+  daytona login
+  daytona login --api-key $DAYTONA_API_KEY
+  daytona login --api-key-stdin < ~/.daytona-api-key
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--api-key` |  | API key to use for authentication |
+| `--api-key-file` |  | Read the API key from a file |
+| `--api-key-stdin` |  | Read the API key from stdin |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona logout
@@ -239,6 +370,29 @@ __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
+
+
+## daytona logs
+View the build logs of a sandbox
+
+```shell
+daytona logs [SANDBOX_ID | SANDBOX_NAME] [flags]
+```
+
+### Examples
+
+```shell
+  daytona logs my-sandbox
+  daytona logs my-sandbox --follow
+```
+
+__Flags__
+| Long | Short | Description |
+| :--- | :---- | :---------- |
+| `--follow` | `-f` | Follow the logs until the sandbox build reaches a terminal state |
+| `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona mcp
@@ -252,19 +406,28 @@ __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona mcp config
 Outputs JSON configuration for Daytona MCP Server
 
 ```shell
-daytona mcp config [AGENT_NAME] [flags]
+daytona mcp config [flags]
+```
+
+### Examples
+
+```shell
+  daytona mcp config
+  daytona mcp config > daytona-mcp.json
 ```
 
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona mcp init
@@ -275,10 +438,18 @@ Initialize Daytona MCP Server with an agent (currently supported: claude, windsu
 daytona mcp init [AGENT_NAME] [flags]
 ```
 
+### Examples
+
+```shell
+  daytona mcp init claude
+  daytona mcp init cursor
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona mcp start
@@ -288,10 +459,18 @@ Start Daytona MCP Server
 daytona mcp start [flags]
 ```
 
+### Examples
+
+```shell
+  # Typically launched by an MCP client (see 'daytona mcp init')
+  daytona mcp start
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona organization
@@ -305,6 +484,7 @@ __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona organization create
@@ -314,10 +494,19 @@ Create a new organization and set it as active
 daytona organization create [ORGANIZATION_NAME] [flags]
 ```
 
+### Examples
+
+```shell
+  daytona organization create my-org
+  daytona organization create my-org --region us
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
+| `--region` | `-r` | Default region (id or name) for the organization |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona organization delete
@@ -327,10 +516,19 @@ Delete an organization
 daytona organization delete [ORGANIZATION] [flags]
 ```
 
+### Examples
+
+```shell
+  daytona organization delete my-org
+  # With no argument, pick from a list interactively
+  daytona organization delete
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona organization list
@@ -340,11 +538,19 @@ List all organizations
 daytona organization list [flags]
 ```
 
+### Examples
+
+```shell
+  daytona organization list
+  daytona organization list --format json
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--format` | `-f` | Output format. Must be one of (yaml, json) |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona organization use
@@ -354,10 +560,19 @@ Set active organization
 daytona organization use [ORGANIZATION] [flags]
 ```
 
+### Examples
+
+```shell
+  daytona organization use my-org
+  # With no argument, pick from a list interactively
+  daytona organization use
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona preview-url
@@ -367,12 +582,22 @@ Get signed preview URL for a sandbox port
 daytona preview-url [SANDBOX_ID | SANDBOX_NAME] [flags]
 ```
 
+### Examples
+
+```shell
+  daytona preview-url my-sandbox --port 3000
+  daytona preview-url my-sandbox --port 3000 --expires 7200
+  daytona preview-url my-sandbox --port 3000 --format json
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--expires` |  | URL expiration time in seconds |
+| `--format` | `-f` | Output format. Must be one of (yaml, json) |
 | `--port` | `-p` | Port number to get preview URL for (required) |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona snapshot
@@ -386,6 +611,7 @@ __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona snapshot create
@@ -393,6 +619,14 @@ Create a snapshot
 
 ```shell
 daytona snapshot create [SNAPSHOT] [flags]
+```
+
+### Examples
+
+```shell
+  daytona snapshot create my-snapshot:1.0 --image ubuntu:22.04 --entrypoint "sleep infinity"
+  daytona snapshot create my-snapshot:1.0 --dockerfile ./Dockerfile --context ./app
+  daytona snapshot create my-snapshot:1.0 --image ubuntu:22.04 --cpu 2 --memory 4 --disk 10
 ```
 
 __Flags__
@@ -407,6 +641,7 @@ __Flags__
 | `--memory` |  | Memory that will be allocated to the underlying sandboxes in GB (default: 1) |
 | `--region` |  | ID of the region where the snapshot will be available (defaults to organization default region) |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona snapshot delete
@@ -416,11 +651,24 @@ Delete a snapshot
 daytona snapshot delete [SNAPSHOT_ID | SNAPSHOT_NAME] [flags]
 ```
 
+### Examples
+
+```shell
+  daytona snapshot delete my-snapshot:1.0
+  daytona snapshot delete --all --dry-run
+  daytona snapshot delete --all --yes --format json
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--all` | `-a` | Delete all snapshots |
+| `--dry-run` |  | Show what would be deleted without deleting anything |
+| `--format` | `-f` | Output format. Must be one of (yaml, json) |
+| `--ignore-not-found` |  | Treat a missing snapshot as a successful delete |
+| `--yes` | `-y` | Skip the confirmation prompt for bulk deletes |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona snapshot list
@@ -430,6 +678,14 @@ List all snapshots
 daytona snapshot list [flags]
 ```
 
+### Examples
+
+```shell
+  daytona snapshot list
+  daytona snapshot list --limit 50
+  daytona snapshot list --format json
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
@@ -437,6 +693,29 @@ __Flags__
 | `--limit` | `-l` | Maximum number of items per page |
 | `--page` | `-p` | Page number for pagination (starting from 1) |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
+
+
+## daytona snapshot logs
+View the build logs of a snapshot
+
+```shell
+daytona snapshot logs [SNAPSHOT_ID | SNAPSHOT_NAME] [flags]
+```
+
+### Examples
+
+```shell
+  daytona snapshot logs my-snapshot:1.0
+  daytona snapshot logs my-snapshot:1.0 --follow
+```
+
+__Flags__
+| Long | Short | Description |
+| :--- | :---- | :---------- |
+| `--follow` | `-f` | Follow the logs until the snapshot build reaches a terminal state |
+| `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona snapshot push
@@ -444,6 +723,13 @@ Push local snapshot
 
 ```shell
 daytona snapshot push [SNAPSHOT] [flags]
+```
+
+### Examples
+
+```shell
+  daytona snapshot push my-image:latest --name my-snapshot:1.0
+  daytona snapshot push my-image:latest --name my-snapshot:1.0 --cpu 2 --memory 4
 ```
 
 __Flags__
@@ -456,6 +742,7 @@ __Flags__
 | `--name` | `-n` | Specify the Snapshot name |
 | `--region` |  | ID of the region where the snapshot will be available (defaults to organization default region) |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona ssh
@@ -465,38 +752,70 @@ SSH into a sandbox
 daytona ssh [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 ```
 
+### Examples
+
+```shell
+  daytona ssh my-sandbox
+  daytona ssh my-sandbox --expires 60
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--expires` |  | SSH access token expiration time in minutes (defaults to 24 hours) |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona start
 Start a sandbox
 
 ```shell
-daytona start [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+daytona start [SANDBOX_ID | SANDBOX_NAME] [flags]
+```
+
+### Examples
+
+```shell
+  daytona start my-sandbox
+  daytona start my-sandbox --wait --timeout 2m
+  daytona start my-sandbox --wait --format json
 ```
 
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
+| `--format` | `-f` | Output format. Must be one of (yaml, json) |
+| `--timeout` |  | Maximum time to wait with --wait (0 waits indefinitely) |
+| `--wait` |  | Wait until the sandbox is started |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona stop
 Stop a sandbox
 
 ```shell
-daytona stop [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+daytona stop [SANDBOX_ID | SANDBOX_NAME] [flags]
+```
+
+### Examples
+
+```shell
+  daytona stop my-sandbox
+  daytona stop my-sandbox --wait --timeout 2m
+  daytona stop my-sandbox --force --format json
 ```
 
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--force` | `-f` | Force stop the sandbox using SIGKILL |
+| `--format` |  | Output format. Must be one of (yaml, json) |
+| `--timeout` |  | Maximum time to wait with --wait (0 waits indefinitely) |
+| `--wait` |  | Wait until the sandbox is stopped |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona version
@@ -510,6 +829,7 @@ __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona volume
@@ -523,6 +843,7 @@ __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona volume create
@@ -532,11 +853,19 @@ Create a volume
 daytona volume create [NAME] [flags]
 ```
 
+### Examples
+
+```shell
+  daytona volume create my-volume
+  # Mount it when creating a sandbox
+  daytona create --snapshot my-snapshot:1.0 --volume my-volume:/data
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
-| `--size` | `-s` | Size of the volume in GB |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona volume delete
@@ -546,10 +875,18 @@ Delete a volume
 daytona volume delete [VOLUME_ID_OR_NAME] [flags]
 ```
 
+### Examples
+
+```shell
+  # Delete a volume by name or ID
+  daytona volume delete my-volume
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona volume get
@@ -559,11 +896,19 @@ Get volume details
 daytona volume get [VOLUME_ID_OR_NAME] [flags]
 ```
 
+### Examples
+
+```shell
+  daytona volume get my-volume
+  daytona volume get my-volume --format json
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--format` | `-f` | Output format. Must be one of (yaml, json) |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 
 ## daytona volume list
@@ -573,10 +918,18 @@ List all volumes
 daytona volume list [flags]
 ```
 
+### Examples
+
+```shell
+  daytona volume list
+  daytona volume list --format json
+```
+
 __Flags__
 | Long | Short | Description |
 | :--- | :---- | :---------- |
 | `--format` | `-f` | Output format. Must be one of (yaml, json) |
 | `--help` |  | help for daytona |
+| `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
 

--- a/apps/docs/src/content/docs/en/tools/cli.mdx
+++ b/apps/docs/src/content/docs/en/tools/cli.mdx
@@ -291,7 +291,7 @@ __Flags__
 Get sandbox info
 
 ```shell
-daytona info [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+daytona info [SANDBOX_ID | SANDBOX_NAME] [flags]
 ```
 
 ### Examples
@@ -640,6 +640,7 @@ __Flags__
 | `--image` | `-i` | The image name for the snapshot |
 | `--memory` |  | Memory that will be allocated to the underlying sandboxes in GB (default: 1) |
 | `--region` |  | ID of the region where the snapshot will be available (defaults to organization default region) |
+| `--timeout` |  | Maximum time to wait for the snapshot to become active (0 means wait indefinitely) |
 | `--help` |  | help for daytona |
 | `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
@@ -741,6 +742,7 @@ __Flags__
 | `--memory` |  | Memory that will be allocated to the underlying sandboxes in GB (default: 1) |
 | `--name` | `-n` | Specify the Snapshot name |
 | `--region` |  | ID of the region where the snapshot will be available (defaults to organization default region) |
+| `--timeout` |  | Maximum time to wait for the snapshot to be validated (0 means wait indefinitely) |
 | `--help` |  | help for daytona |
 | `--no-input` |  | Never prompt for input; fail instead when input would be required |
 
@@ -749,7 +751,7 @@ __Flags__
 SSH into a sandbox
 
 ```shell
-daytona ssh [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+daytona ssh [SANDBOX_ID | SANDBOX_NAME] [flags]
 ```
 
 ### Examples

--- a/apps/docs/tools/update-cli-reference.js
+++ b/apps/docs/tools/update-cli-reference.js
@@ -156,6 +156,20 @@ function yamlToMarkdown(files) {
     output += `${rawDoc.usage}\n`
     output += '```\n\n'
 
+    if (rawDoc.example) {
+      const example = rawDoc.example
+        .split('\n')
+        .map(line => line.replace(/\s+$/, ''))
+        .join('\n')
+        .replace(/\n+$/, '')
+      if (example) {
+        output += '### Examples\n\n'
+        output += '```shell\n'
+        output += `${example}\n`
+        output += '```\n\n'
+      }
+    }
+
     output += '__Flags__\n'
     output += '| Long | Short | Description |\n'
     output += '| :--- | :---- | :---------- |\n'


### PR DESCRIPTION
Addresses #4878.

Closes #4879, closes #4880, closes #4881, closes #4882, closes #4883, closes #4884, closes #4885, closes #4886, closes #4887, closes #4981, closes #4982, closes #4983, closes #4984, closes #4985, closes #4986.

## Before and after

### 1. Missing arguments: Go panic → clean usage error

```console
# before (main)
$ daytona start
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/daytonaio/daytona/cli/cmd/sandbox.init.func9(...)
	apps/cli/cmd/sandbox/start.go:27 +0x14c
...
[exit: 2, panic]

# after (this branch)
$ daytona start
error: missing required argument: sandbox ID or name
[exit: 2, documented usage error]
```

Same fix for `stop`, `archive`, `delete`, `logs`, `cp`, `exec`, and `api`.

### 2. `daytona exec` no longer corrupts quoted commands

```console
# before (main): argv joined with spaces, quoting destroyed
$ daytona exec my-sandbox -- python3 -c "print('hi there')"
zsh: unknown file attribute: h
[exit: 1, the sandbox ran a different command than written]

# after (this branch)
$ daytona exec my-sandbox -- python3 -c "print('hi there')"
hi there
[exit: 0]
```

The old behavior could also fail silently. `daytona exec my-sandbox -- sh -c 'echo from-stdout; exit 3'` on main printed **nothing** and exited 3, because the quoting loss turned it into a different command with empty output.

### 3. Structured output for exec, with the remote exit code

```console
# after (this branch)
$ daytona exec my-sandbox --format json -- sh -c 'echo from-stdout; echo from-stderr >&2; exit 3'
{
  "result": "from-stdout\nfrom-stderr\n",
  "exitCode": 3
}
[exit: 3, remote exit code passed through. 255 means the CLI itself failed]
```

### 4. Non-interactive environments fail fast and say the fix

```console
# before (main)
$ daytona login < /dev/null
FATA error running selection prompt: could not open a new TTY: open /dev/tty: device not configured
[exit: 1]

# after (this branch)
$ daytona login < /dev/null
error: cannot prompt for login method in non-interactive mode - provide --api-key, --api-key-stdin, or --api-key-file (or set DAYTONA_API_KEY and DAYTONA_API_URL)
[exit: 2]
```

A global `--no-input` flag forces this everywhere. `DAYTONA_API_KEY` now works without `DAYTONA_API_URL`, and `--api-key-stdin` / `--api-key-file` keep keys out of argv.

### 5. Invalid `--format` values fail loudly instead of silently picking JSON

```console
# before (main): "xml" silently fell back to JSON
$ daytona list --format xml
{ "items": [ ... ] }
[exit: 0]

# after (this branch)
$ daytona list --format xml
{"error":"invalid --format value \"xml\": must be one of json, yaml","code":"usage"}
[exit: 2]
```

With `--format` set, failures are one JSON object on stderr with a stable `code` (`usage`, `auth`, `not_found`, `conflict`, `rate_limit`, `server`, `network`, `timeout`). Retry logic reads a field instead of parsing prose.

### 6. Lifecycle commands are retry-safe and can wait for the target state

```console
# before (main): retrying a stop fails
$ daytona stop my-sandbox
FATA Bad Request: Sandbox is not started
[exit: 1]

# after (this branch)
$ daytona stop my-sandbox --wait
 Sandbox my-sandbox stopped        # returned only after state == STOPPED (~1.5s)
$ daytona stop my-sandbox
 Sandbox my-sandbox is already stopped
[exit: 0, safe to retry]
```

`start`, `stop`, `archive`, and `delete` gained `--wait` and `--timeout`. Every internal wait now takes a bound, including `create`'s build wait and `snapshot push`'s registry poll. Timeouts exit 124, distinct from ordinary failures.

### 7. Destructive commands: preview first, confirm explicitly

```console
# before (main)
$ daytona delete --all --dry-run
FATA unknown flag: --dry-run      # --all deleted everything immediately, no prompt
[exit: 1]

# after (this branch)
$ daytona delete --all --dry-run --format json
{
  "dryRun": true,
  "count": 2,
  "sandboxes": [
    { "id": "2feb0586-bd77-49ed-bbef-b03a3db361c7", "name": "agent-cli-itest", "state": "started" },
    { "id": "5d75021a-eb9f-4dff-967f-fe60f8425cb1", "name": "zo-mhashmi-c4ca8185", "state": "stopped" }
  ]
}
[exit: 0, nothing deleted. Real bulk deletes ask for confirmation unless --yes]
```

Deletes are also idempotent on demand:

```console
$ daytona delete agent-cli-itest --ignore-not-found
 Sandbox agent-cli-itest not found, nothing to delete
[exit: 0]

$ daytona delete agent-cli-itest --format json
{"error":"Not Found: Sandbox with ID or name agent-cli-itest not found","code":"not_found"}
[exit: 1]
```

### 8. Create, delete, start, stop, and preview-url are chainable

```console
# after (this branch): id/name/state come back as JSON from every mutating command
$ daytona create --name agent-cli-itest --format json
{ "id": "2feb0586-bd77-49ed-bbef-b03a3db361c7", "name": "agent-cli-itest", "state": "creating", ... }

$ daytona preview-url agent-cli-itest -p 3000 --format json
{
  "url": "https://<signed-host>.daytonaproxy01.net...",
  "port": 3000,
  "expiresInSeconds": 3600,
  "sandbox": "agent-cli-itest"
}
```

`create` also gained `--env-file`, `--label-file`, `--if-exists reuse`, and strict parsing. Malformed `--env`, `--label`, and `--volume` entries now fail instead of vanishing silently.

### 9. New commands: cp, logs, api

```console
# file transfer. New; agents used to improvise over ssh.
$ daytona cp ./report.txt agent-cli-itest:/tmp/report.txt
 Uploaded ./report.txt -> agent-cli-itest:/tmp/report.txt
 Copied 1 file(s)
$ daytona cp agent-cli-itest:/tmp/report.txt ./back.txt   # byte-identical roundtrip, dirs recurse

# build logs after the fact. A BUILD_FAILED sandbox used to be undebuggable from the CLI.
$ daytona logs my-sandbox --follow

# raw authenticated requests, gh api style, for anything the CLI doesn't wrap yet
$ daytona api /sandbox
{ "items": [ ... ], "total": 2 }
$ daytona api /no-such-route
{"path":"/api/no-such-route","statusCode":404,...}
[exit: 1, body still printed, error categorized]
```

### 10. Help teaches by example

Every common command now has an `Examples` section in `--help` and the docs site, and the root help documents exit codes:

```text
Exit codes: 0 success; 1 runtime failure; 2 invalid flags or arguments (where validated);
124 wait timeout. 'daytona exec' exits with the remote command's exit code; 255 indicates
a CLI-side failure.
```

---

**Testing.** Unit tests run against httptest servers behind the generated API client: exec success and failure, idempotent stop, `--if-exists reuse`, cp upload/download/empty files, logs follow termination, api auth headers and error propagation, wait timeouts, strict parsing, login key resolution. The before/after blocks above double as the live end-to-end pass. golangci-lint reports zero issues, `go work sync` is clean, and the regenerated CLI reference passes the docs check.
