### PR TITLE
feat(api): create the snapshot record at capture start and mark it error on failure

### DIFF
--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -719,6 +719,7 @@ export class SandboxController {
     description: 'Snapshot creation has been initiated',
     type: SandboxDto,
   })
+  @ApiResponse({ status: 409, description: 'A snapshot with this name already exists for the organization' })
   @UseGuards(OrganizationAuthContextGuard, SandboxAccessGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_SANDBOXES])
   @Audit({

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -38,6 +38,7 @@ import { SnapshotService } from '../services/snapshot.service'
 import { OnAsyncEvent } from '../../common/decorators/on-async-event.decorator'
 import { parseDockerImage } from '../../common/utils/docker-image.util'
 import { getRunnerSandboxClass, isRegistryBasedSandboxClass } from '../utils/sandbox-class.util'
+import { isPendingCaptureSnapshot } from '../utils/persist-snapshot-from-sandbox.util'
 import { SandboxClass } from '../enums/sandbox-class.enum'
 import { SandboxState } from '../enums/sandbox-state.enum'
 import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
@@ -1176,6 +1177,20 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
   }
 
   async handleSnapshotStatePending(snapshot: Snapshot): Promise<SyncState> {
+    // Capture records (snapshot-from-sandbox) have no imageName/buildInfo and
+    // are driven by the v0 background promise or the SNAPSHOT_SANDBOX job, not
+    // by the pull/build flow below — which would otherwise error them via
+    // parseDockerImage(''). Leave them alone until they exceed the capture
+    // timeout, then mark them ERROR (covers v0 promises lost to process
+    // restarts and vanished v2 jobs).
+    if (isPendingCaptureSnapshot(snapshot)) {
+      const timeoutMs = this.configService.getOrThrow('sandboxSnapshottingTimeoutMin') * 60 * 1000
+      if (Date.now() - snapshot.createdAt.getTime() > timeoutMs) {
+        await this.updateSnapshotState(snapshot, SnapshotState.ERROR, 'Timeout creating snapshot from sandbox')
+      }
+      return DONT_SYNC_AGAIN
+    }
+
     let initialRunner: Runner | undefined = undefined
 
     if (!snapshot.initialRunnerId) {

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -27,7 +27,7 @@ import { ResourceType } from '../enums/resource-type.enum'
 import { getStateChangeLockKey } from '../utils/lock-key.util'
 import { SandboxEvents } from '../constants/sandbox-events.constants'
 import { SandboxStartedEvent } from '../events/sandbox-started.event'
-import { persistSnapshotFromSandbox } from '../utils/persist-snapshot-from-sandbox.util'
+import { activateSnapshotFromSandbox, failSnapshotFromSandbox } from '../utils/persist-snapshot-from-sandbox.util'
 import { Runner } from '../entities/runner.entity'
 
 /**
@@ -802,8 +802,9 @@ export class JobStateHandlerService {
         entity: sandbox,
       })
 
+      const payload = job.getPayload<{ name?: string; registry?: { url?: string; project?: string } }>()
+
       if (job.status === JobStatus.COMPLETED) {
-        const payload = job.getPayload<{ name?: string; registry?: { url?: string; project?: string } }>()
         const metadata = job.getResultMetadata()
         const snapshotName = payload?.name
         const hash =
@@ -850,7 +851,7 @@ export class JobStateHandlerService {
                 : undefined
 
           try {
-            await persistSnapshotFromSandbox(
+            await activateSnapshotFromSandbox(
               {
                 snapshotRepository: this.snapshotRepository,
                 snapshotRunnerRepository: this.snapshotRunnerRepository,
@@ -873,6 +874,25 @@ export class JobStateHandlerService {
             )
           } catch (error) {
             this.logger.error(`Failed to persist snapshot from SNAPSHOT_SANDBOX job ${job.id}:`, error)
+          }
+        }
+      } else if (job.status === JobStatus.FAILED) {
+        if (payload?.name) {
+          try {
+            await failSnapshotFromSandbox(
+              {
+                snapshotRepository: this.snapshotRepository,
+                snapshotRunnerRepository: this.snapshotRunnerRepository,
+                eventEmitter: this.eventEmitter,
+              },
+              {
+                organizationId: sandbox.organizationId,
+                name: payload.name,
+                errorReason: job.errorMessage || 'Failed to create snapshot from sandbox',
+              },
+            )
+          } catch (error) {
+            this.logger.error(`Failed to mark snapshot as errored for SNAPSHOT_SANDBOX job ${job.id}:`, error)
           }
         }
       }

--- a/apps/api/src/sandbox/services/sandbox.service.spec.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.spec.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Organization } from '../../organization/entities/organization.entity'
+import { Runner } from '../entities/runner.entity'
+import { Sandbox } from '../entities/sandbox.entity'
+import { SandboxClass } from '../enums/sandbox-class.enum'
+import { SandboxState } from '../enums/sandbox-state.enum'
+import { SandboxService } from './sandbox.service'
+
+interface StubDeps {
+  sandboxRepository: {
+    updateWhere: jest.Mock
+  }
+  runnerService: {
+    findOneOrFail: jest.Mock
+  }
+  organizationService: {
+    assertOrganizationIsNotSuspended: jest.Mock
+  }
+  runnerAdapterFactory: {
+    create: jest.Mock
+  }
+  regionService: {
+    findOne: jest.Mock
+  }
+  snapshotService: {
+    validateOrganizationQuotas: jest.Mock
+    createPendingSnapshotFromSandbox: jest.Mock
+    failSnapshotFromSandbox: jest.Mock
+    rollbackPendingUsage: jest.Mock
+  }
+  dockerRegistryService: {
+    getAvailableInternalRegistry: jest.Mock
+  }
+}
+
+const organization = { id: 'org-1' } as Organization
+const runner = { id: 'runner-1', apiVersion: '2' } as Runner
+
+function makeSandbox(): Sandbox {
+  return {
+    id: 'sandbox-1',
+    organizationId: 'org-1',
+    state: SandboxState.STARTED,
+    pending: false,
+    runnerId: 'runner-1',
+    region: 'region-1',
+    sandboxClass: SandboxClass.CONTAINER,
+    cpu: 2,
+    gpu: 0,
+    mem: 4,
+    disk: 10,
+  } as Sandbox
+}
+
+function createService(): { service: SandboxService; stub: StubDeps } {
+  const stub: StubDeps = {
+    sandboxRepository: {
+      updateWhere: jest.fn(async (_id: string, params: { updateData: Partial<Sandbox> }) => ({
+        ...makeSandbox(),
+        ...params.updateData,
+      })),
+    },
+    runnerService: {
+      findOneOrFail: jest.fn(async () => runner),
+    },
+    organizationService: {
+      assertOrganizationIsNotSuspended: jest.fn(),
+    },
+    runnerAdapterFactory: {
+      create: jest.fn(),
+    },
+    regionService: {
+      findOne: jest.fn(async () => ({ id: 'region-1' })),
+    },
+    snapshotService: {
+      validateOrganizationQuotas: jest.fn(async () => ({ pendingSnapshotCountIncremented: true })),
+      createPendingSnapshotFromSandbox: jest.fn(async () => ({})),
+      failSnapshotFromSandbox: jest.fn(async () => undefined),
+      rollbackPendingUsage: jest.fn(async () => undefined),
+    },
+    dockerRegistryService: {
+      getAvailableInternalRegistry: jest.fn(async () => ({ id: 'registry-1' })),
+    },
+  }
+
+  // Test-only construction: createSnapshotFromSandbox exercises a small
+  // subset of the 22 constructor dependencies; the rest stay undefined.
+  const ServiceCtor = SandboxService as unknown as new (...args: unknown[]) => SandboxService
+  const service = new ServiceCtor(
+    stub.sandboxRepository, // sandboxRepository
+    undefined, // snapshotRepository
+    undefined, // runnerRepository
+    undefined, // buildInfoRepository
+    undefined, // sshAccessRepository
+    stub.runnerService, // runnerService
+    undefined, // volumeService
+    undefined, // configService
+    undefined, // warmPoolService
+    undefined, // eventEmitter
+    stub.organizationService, // organizationService
+    stub.runnerAdapterFactory, // runnerAdapterFactory
+    undefined, // organizationUsageService
+    undefined, // redisLockProvider
+    undefined, // redis
+    stub.regionService, // regionService
+    stub.snapshotService, // snapshotService
+    undefined, // sandboxLookupCacheInvalidationService
+    undefined, // sandboxActivityService
+    stub.dockerRegistryService, // dockerRegistryService
+    undefined, // sandboxForkRepository
+    undefined, // sandboxSearchAdapter
+  )
+
+  return { service, stub }
+}
+
+describe('SandboxService.createSnapshotFromSandbox', () => {
+  it.each([
+    [
+      'runner adapter creation throws',
+      (stub: StubDeps) => {
+        stub.runnerAdapterFactory.create.mockRejectedValue(new Error('adapter exploded'))
+      },
+      'adapter exploded',
+    ],
+    [
+      'v2 snapshot job dispatch throws',
+      (stub: StubDeps) => {
+        stub.runnerAdapterFactory.create.mockResolvedValue({
+          createSnapshotFromSandbox: jest.fn().mockRejectedValue(new Error('dispatch exploded')),
+        })
+      },
+      'dispatch exploded',
+    ],
+  ])('restores sandbox state and fails the capture record when %s', async (_label, arrange, message) => {
+    const { service, stub } = createService()
+    jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue(makeSandbox())
+    arrange(stub)
+
+    await expect(service.createSnapshotFromSandbox('sandbox-1', organization, { name: 'my-snap' })).rejects.toThrow(
+      message,
+    )
+
+    // First call transitions to SNAPSHOTTING; second restores the previous state.
+    expect(stub.sandboxRepository.updateWhere).toHaveBeenCalledTimes(2)
+    expect(stub.sandboxRepository.updateWhere).toHaveBeenNthCalledWith(2, 'sandbox-1', {
+      updateData: { state: SandboxState.STARTED, pending: false },
+      whereCondition: { state: SandboxState.SNAPSHOTTING },
+    })
+    expect(stub.snapshotService.failSnapshotFromSandbox).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      name: 'my-snap',
+      errorReason: message,
+    })
+    // The pending quota counter already transferred to the record lifecycle,
+    // so the outer rollback must be a no-op.
+    expect(stub.snapshotService.rollbackPendingUsage).toHaveBeenCalledWith('org-1', undefined)
+  })
+
+  it('returns the SNAPSHOTTING sandbox without touching the record when dispatch succeeds', async () => {
+    const { service, stub } = createService()
+    jest.spyOn(service, 'findOneByIdOrName').mockResolvedValue(makeSandbox())
+    stub.runnerAdapterFactory.create.mockResolvedValue({
+      createSnapshotFromSandbox: jest.fn(async () => undefined),
+    })
+
+    const result = await service.createSnapshotFromSandbox('sandbox-1', organization, { name: 'my-snap' })
+
+    expect(result.state).toBe(SandboxState.SNAPSHOTTING)
+    expect(stub.sandboxRepository.updateWhere).toHaveBeenCalledTimes(1)
+    expect(stub.snapshotService.failSnapshotFromSandbox).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1392,8 +1392,6 @@ export class SandboxService {
       // ACTIVE/ERROR), so the outer catch's rollback must not fire.
       pendingSnapshotCountIncrement = undefined
 
-      const runnerAdapter = await this.runnerAdapterFactory.create(runner)
-
       // v2 runners enqueue a SNAPSHOT_SANDBOX job and resolve immediately
       // with `undefined`; the job state handler will persist the resulting
       // Snapshot on completion.
@@ -1405,40 +1403,46 @@ export class SandboxService {
       // background and immediately return the SNAPSHOTTING sandbox to the
       // caller. The background promise persists the snapshot or reverts
       // sandbox state on failure.
-      if (runner.apiVersion === '0') {
-        void this.runV0SnapshotFromSandbox({
-          sandbox,
-          previousState: sandbox.state,
-          snapshotName: dto.name,
-          organizationId: organization.id,
-          registry,
-          runner,
-          runnerAdapter,
-        })
-      } else {
-        try {
-          await runnerAdapter.createSnapshotFromSandbox(sandbox.id, dto.name, organization.id, registry, includeMemory)
-        } catch (error) {
-          await this.sandboxRepository.updateWhere(sandbox.id, {
-            updateData: {
-              state: sandbox.state,
-              pending: false,
-            },
-            whereCondition: { state: SandboxState.SNAPSHOTTING },
+      //
+      // Any synchronous initiation failure (adapter creation or v2 job
+      // dispatch) must restore the sandbox state and fail the pending
+      // capture record; otherwise both would linger until the cron timeout.
+      try {
+        const runnerAdapter = await this.runnerAdapterFactory.create(runner)
+
+        if (runner.apiVersion === '0') {
+          void this.runV0SnapshotFromSandbox({
+            sandbox,
+            previousState: sandbox.state,
+            snapshotName: dto.name,
+            organizationId: organization.id,
+            registry,
+            runner,
+            runnerAdapter,
           })
-
-          await this.snapshotService
-            .failSnapshotFromSandbox({
-              organizationId: organization.id,
-              name: dto.name,
-              errorReason: error?.message || 'Failed to dispatch snapshot job',
-            })
-            .catch((err) =>
-              this.logger.error(`Failed to mark snapshot ${dto.name} as errored for org ${organization.id}:`, err),
-            )
-
-          throw error
+        } else {
+          await runnerAdapter.createSnapshotFromSandbox(sandbox.id, dto.name, organization.id, registry, includeMemory)
         }
+      } catch (error) {
+        await this.sandboxRepository.updateWhere(sandbox.id, {
+          updateData: {
+            state: sandbox.state,
+            pending: false,
+          },
+          whereCondition: { state: SandboxState.SNAPSHOTTING },
+        })
+
+        await this.snapshotService
+          .failSnapshotFromSandbox({
+            organizationId: organization.id,
+            name: dto.name,
+            errorReason: error?.message || 'Failed to initiate snapshot from sandbox',
+          })
+          .catch((err) =>
+            this.logger.error(`Failed to mark snapshot ${dto.name} as errored for org ${organization.id}:`, err),
+          )
+
+        throw error
       }
 
       return updatedSandbox

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1360,6 +1360,38 @@ export class SandboxService {
         },
       })
 
+      // Create the snapshot record up front (state=PENDING): duplicate names
+      // 409 here, before any capture runs, and failures/timeouts are recorded
+      // on the snapshot itself.
+      try {
+        await this.snapshotService.createPendingSnapshotFromSandbox({
+          organizationId: organization.id,
+          name: dto.name,
+          regionId: sandbox.region,
+          sandboxClass: sandbox.sandboxClass,
+          cpu: sandbox.cpu,
+          gpu: sandbox.gpu,
+          gpuType: sandbox.gpuType ?? null,
+          mem: sandbox.mem,
+          disk: sandbox.disk,
+        })
+      } catch (error) {
+        await this.sandboxRepository.updateWhere(sandbox.id, {
+          updateData: {
+            state: sandbox.state,
+            pending: false,
+          },
+          whereCondition: { state: SandboxState.SNAPSHOTTING },
+        })
+
+        throw error
+      }
+
+      // The CREATED event transferred the pending quota counter to current
+      // usage; settlement now follows the record lifecycle (PENDING ->
+      // ACTIVE/ERROR), so the outer catch's rollback must not fire.
+      pendingSnapshotCountIncrement = undefined
+
       const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
       // v2 runners enqueue a SNAPSHOT_SANDBOX job and resolve immediately
@@ -1374,12 +1406,6 @@ export class SandboxService {
       // caller. The background promise persists the snapshot or reverts
       // sandbox state on failure.
       if (runner.apiVersion === '0') {
-        // Hand off pending-quota ownership to the background driver - it must
-        // roll back on failure since the outer try/catch returns successfully
-        // here.
-        const inheritedPendingIncrement = pendingSnapshotCountIncrement
-        pendingSnapshotCountIncrement = undefined
-
         void this.runV0SnapshotFromSandbox({
           sandbox,
           previousState: sandbox.state,
@@ -1388,7 +1414,6 @@ export class SandboxService {
           registry,
           runner,
           runnerAdapter,
-          pendingSnapshotCountIncrement: inheritedPendingIncrement,
         })
       } else {
         try {
@@ -1401,6 +1426,16 @@ export class SandboxService {
             },
             whereCondition: { state: SandboxState.SNAPSHOTTING },
           })
+
+          await this.snapshotService
+            .failSnapshotFromSandbox({
+              organizationId: organization.id,
+              name: dto.name,
+              errorReason: error?.message || 'Failed to dispatch snapshot job',
+            })
+            .catch((err) =>
+              this.logger.error(`Failed to mark snapshot ${dto.name} as errored for org ${organization.id}:`, err),
+            )
 
           throw error
         }
@@ -1421,8 +1456,9 @@ export class SandboxService {
    * user-facing API request can return immediately with state=SNAPSHOTTING,
    * mirroring the v2 (job-driven) UX.
    *
-   * Errors are intentionally swallowed - sandbox state is the source of
-   * truth. On any failure we restore state and refund the pending quota.
+   * Errors are recorded on the pending snapshot record (state=ERROR with
+   * errorReason); the PENDING -> ERROR transition settles quota usage via the
+   * snapshot state-updated event. The sandbox state is always restored.
    */
   private async runV0SnapshotFromSandbox(params: {
     sandbox: Sandbox
@@ -1432,27 +1468,16 @@ export class SandboxService {
     registry?: DockerRegistry
     runner: Runner
     runnerAdapter: RunnerAdapter
-    pendingSnapshotCountIncrement?: number
   }): Promise<void> {
-    const {
-      sandbox,
-      previousState,
-      snapshotName,
-      organizationId,
-      registry,
-      runner,
-      runnerAdapter,
-      pendingSnapshotCountIncrement,
-    } = params
+    const { sandbox, previousState, snapshotName, organizationId, registry, runner, runnerAdapter } = params
 
-    let succeeded = false
     try {
       const result = await runnerAdapter.createSnapshotFromSandbox(sandbox.id, snapshotName, organizationId, registry)
       if (!result) {
         throw new Error('runner returned no snapshot result')
       }
 
-      await this.snapshotService.persistSnapshotFromSandbox({
+      await this.snapshotService.activateSnapshotFromSandbox({
         organizationId,
         name: snapshotName,
         ref: result.ref,
@@ -1466,9 +1491,18 @@ export class SandboxService {
         disk: sandbox.disk,
         sizeGB: result.sizeGB,
       })
-      succeeded = true
     } catch (error) {
       this.logger.error(`v0 snapshotFromSandbox failed for sandbox ${sandbox.id}:`, error)
+
+      await this.snapshotService
+        .failSnapshotFromSandbox({
+          organizationId,
+          name: snapshotName,
+          errorReason: error?.message || 'Failed to create snapshot from sandbox',
+        })
+        .catch((err) =>
+          this.logger.error(`Failed to mark snapshot ${snapshotName} as errored for org ${organizationId}:`, err),
+        )
     }
 
     // Always clear SNAPSHOTTING - whether the snapshot was persisted or not,
@@ -1479,12 +1513,6 @@ export class SandboxService {
         whereCondition: { state: SandboxState.SNAPSHOTTING },
       })
       .catch((err) => this.logger.error(`Failed to clear SNAPSHOTTING state for sandbox ${sandbox.id}:`, err))
-
-    if (!succeeded) {
-      await this.snapshotService
-        .rollbackPendingUsage(organizationId, pendingSnapshotCountIncrement)
-        .catch((err) => this.logger.error(`Failed to roll back pending snapshot quota for org ${organizationId}:`, err))
-    }
   }
 
   async findAllPaginatedDeprecated(
@@ -2926,14 +2954,9 @@ export class SandboxService {
             whereCondition: { state: SandboxState.SNAPSHOTTING, desiredState: sandbox.desiredState },
           })
 
-          await this.snapshotService
-            .rollbackPendingUsage(sandbox.organizationId, 1)
-            .catch((err) =>
-              this.logger.error(
-                `Failed to roll back pending snapshot quota for org ${sandbox.organizationId} during stale recovery:`,
-                err,
-              ),
-            )
+          // Quota settlement is owned by the capture record: SnapshotManager
+          // times the PENDING record out to ERROR, and that state transition
+          // decrements current snapshot usage.
 
           this.logger.warn(
             `Recovered stale SNAPSHOTTING sandbox ${sandbox.id} (v0 runner ${sandbox.runnerId}), restored to ${restoredState}`,

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -59,7 +59,10 @@ import { SnapshotActivatedEvent } from '../events/snapshot-activated.event'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import {
-  persistSnapshotFromSandbox,
+  activateSnapshotFromSandbox,
+  createPendingSnapshotFromSandbox,
+  CreatePendingSnapshotFromSandboxParams,
+  failSnapshotFromSandbox,
   PersistSnapshotFromSandboxParams,
 } from '../utils/persist-snapshot-from-sandbox.util'
 import { getRunnerSandboxClass } from '../utils/sandbox-class.util'
@@ -405,8 +408,30 @@ export class SnapshotService {
     }
   }
 
-  async persistSnapshotFromSandbox(params: PersistSnapshotFromSandboxParams): Promise<Snapshot> {
-    return persistSnapshotFromSandbox(
+  async createPendingSnapshotFromSandbox(params: CreatePendingSnapshotFromSandboxParams): Promise<Snapshot> {
+    return createPendingSnapshotFromSandbox(
+      {
+        snapshotRepository: this.snapshotRepository,
+        snapshotRunnerRepository: this.snapshotRunnerRepository,
+        eventEmitter: this.eventEmitter,
+      },
+      params,
+    )
+  }
+
+  async activateSnapshotFromSandbox(params: PersistSnapshotFromSandboxParams): Promise<Snapshot | null> {
+    return activateSnapshotFromSandbox(
+      {
+        snapshotRepository: this.snapshotRepository,
+        snapshotRunnerRepository: this.snapshotRunnerRepository,
+        eventEmitter: this.eventEmitter,
+      },
+      params,
+    )
+  }
+
+  async failSnapshotFromSandbox(params: { organizationId: string; name: string; errorReason: string }): Promise<void> {
+    return failSnapshotFromSandbox(
       {
         snapshotRepository: this.snapshotRepository,
         snapshotRunnerRepository: this.snapshotRunnerRepository,

--- a/apps/api/src/sandbox/utils/persist-snapshot-from-sandbox.util.spec.ts
+++ b/apps/api/src/sandbox/utils/persist-snapshot-from-sandbox.util.spec.ts
@@ -1,0 +1,315 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ConflictException } from '@nestjs/common'
+import { Snapshot } from '../entities/snapshot.entity'
+import { SnapshotState } from '../enums/snapshot-state.enum'
+import { SnapshotRunnerState } from '../enums/snapshot-runner-state.enum'
+import { SnapshotEvents } from '../constants/snapshot-events'
+import { SnapshotCreatedEvent } from '../events/snapshot-created.event'
+import { SandboxClass } from '../enums/sandbox-class.enum'
+import { BuildInfo } from '../entities/build-info.entity'
+import {
+  activateSnapshotFromSandbox,
+  createPendingSnapshotFromSandbox,
+  failSnapshotFromSandbox,
+  isPendingCaptureSnapshot,
+  PersistSnapshotFromSandboxDeps,
+} from './persist-snapshot-from-sandbox.util'
+
+interface DepsStub {
+  snapshotRepository: {
+    create: jest.Mock
+    insert: jest.Mock
+    update: jest.Mock
+    findOne: jest.Mock
+  }
+  snapshotRunnerRepository: {
+    create: jest.Mock
+    save: jest.Mock
+  }
+  eventEmitter: {
+    emit: jest.Mock
+  }
+}
+
+function createDeps(): { stub: DepsStub; deps: PersistSnapshotFromSandboxDeps } {
+  const stub: DepsStub = {
+    snapshotRepository: {
+      create: jest.fn((data: Partial<Snapshot>) => data as Snapshot),
+      insert: jest.fn(async (snapshot: Snapshot) => snapshot),
+      update: jest.fn(async (_id: string, params: { updateData: Partial<Snapshot>; entity?: Snapshot }) => ({
+        ...params.entity,
+        ...params.updateData,
+      })),
+      findOne: jest.fn(async () => null),
+    },
+    snapshotRunnerRepository: {
+      create: jest.fn((data: unknown) => data),
+      save: jest.fn(async (runner: unknown) => runner),
+    },
+    eventEmitter: {
+      emit: jest.fn(),
+    },
+  }
+  return { stub, deps: stub as unknown as PersistSnapshotFromSandboxDeps }
+}
+
+const pendingParams = {
+  organizationId: 'org-1',
+  name: 'my-snap',
+  regionId: 'region-1',
+  sandboxClass: SandboxClass.CONTAINER,
+  cpu: 2,
+  gpu: 0,
+  gpuType: null,
+  mem: 4,
+  disk: 10,
+}
+
+const activateParams = {
+  ...pendingParams,
+  ref: 'registry.example.com/daytona/daytona-abc:daytona',
+  runnerId: 'runner-1',
+  sizeGB: 4.2,
+}
+
+function captureRecord(overrides: Partial<Snapshot> = {}): Snapshot {
+  return {
+    id: 'snap-1',
+    organizationId: 'org-1',
+    name: 'my-snap',
+    imageName: '',
+    state: SnapshotState.PENDING,
+    buildInfo: undefined,
+    ...overrides,
+  } as Snapshot
+}
+
+describe('isPendingCaptureSnapshot', () => {
+  it('is true only for pending records with empty imageName and no buildInfo', () => {
+    expect(isPendingCaptureSnapshot(captureRecord())).toBe(true)
+  })
+
+  it.each([
+    ['pending with imageName', captureRecord({ imageName: 'ubuntu:22.04' })],
+    ['pending with buildInfo', captureRecord({ buildInfo: { snapshotRef: 'ref' } as BuildInfo })],
+    ['active capture-shaped record', captureRecord({ state: SnapshotState.ACTIVE })],
+    ['errored capture-shaped record', captureRecord({ state: SnapshotState.ERROR })],
+  ])('is false for %s', (_label, snapshot) => {
+    expect(isPendingCaptureSnapshot(snapshot)).toBe(false)
+  })
+})
+
+describe('createPendingSnapshotFromSandbox', () => {
+  it('inserts a PENDING record with capture fields and no result fields', async () => {
+    const { stub, deps } = createDeps()
+
+    const inserted = await createPendingSnapshotFromSandbox(deps, pendingParams)
+
+    expect(stub.snapshotRepository.insert).toHaveBeenCalledTimes(1)
+    const entity = stub.snapshotRepository.insert.mock.calls[0][0]
+    expect(entity).toMatchObject({
+      organizationId: 'org-1',
+      name: 'my-snap',
+      state: SnapshotState.PENDING,
+      sandboxClass: SandboxClass.CONTAINER,
+      cpu: 2,
+      gpu: 0,
+      gpuType: null,
+      mem: 4,
+      disk: 10,
+    })
+    expect(entity.snapshotRegions).toEqual([{ snapshotId: entity.id, regionId: 'region-1' }])
+    expect(entity).not.toHaveProperty('ref')
+    expect(entity).not.toHaveProperty('size')
+    expect(entity).not.toHaveProperty('lastUsedAt')
+    expect(entity).not.toHaveProperty('initialRunnerId')
+    expect(inserted).toBe(entity)
+  })
+
+  it('emits the CREATED event with the inserted snapshot', async () => {
+    const { stub, deps } = createDeps()
+
+    const inserted = await createPendingSnapshotFromSandbox(deps, pendingParams)
+
+    expect(stub.eventEmitter.emit).toHaveBeenCalledTimes(1)
+    const [event, payload] = stub.eventEmitter.emit.mock.calls[0]
+    expect(event).toBe(SnapshotEvents.CREATED)
+    expect(payload).toBeInstanceOf(SnapshotCreatedEvent)
+    expect(payload.snapshot).toBe(inserted)
+  })
+
+  it('creates no SnapshotRunner', async () => {
+    const { stub, deps } = createDeps()
+
+    await createPendingSnapshotFromSandbox(deps, pendingParams)
+
+    expect(stub.snapshotRunnerRepository.create).not.toHaveBeenCalled()
+    expect(stub.snapshotRunnerRepository.save).not.toHaveBeenCalled()
+  })
+
+  it('maps a unique-violation insert error to ConflictException naming the snapshot', async () => {
+    const { stub, deps } = createDeps()
+    stub.snapshotRepository.insert.mockRejectedValue(Object.assign(new Error('duplicate'), { code: '23505' }))
+
+    await expect(createPendingSnapshotFromSandbox(deps, pendingParams)).rejects.toThrow(ConflictException)
+    await expect(createPendingSnapshotFromSandbox(deps, pendingParams)).rejects.toThrow('my-snap')
+    expect(stub.eventEmitter.emit).not.toHaveBeenCalled()
+  })
+
+  it('rethrows other insert errors unchanged', async () => {
+    const { stub, deps } = createDeps()
+    const failure = new Error('connection lost')
+    stub.snapshotRepository.insert.mockRejectedValue(failure)
+
+    await expect(createPendingSnapshotFromSandbox(deps, pendingParams)).rejects.toBe(failure)
+    expect(stub.eventEmitter.emit).not.toHaveBeenCalled()
+  })
+})
+
+describe('activateSnapshotFromSandbox', () => {
+  it('updates a pending capture record to ACTIVE and wires up the SnapshotRunner', async () => {
+    const { stub, deps } = createDeps()
+    const record = captureRecord()
+    stub.snapshotRepository.findOne.mockResolvedValue(record)
+
+    const updated = await activateSnapshotFromSandbox(deps, activateParams)
+
+    expect(stub.snapshotRepository.update).toHaveBeenCalledTimes(1)
+    const [id, params] = stub.snapshotRepository.update.mock.calls[0]
+    expect(id).toBe('snap-1')
+    expect(params.entity).toBe(record)
+    expect(params.updateData).toMatchObject({
+      state: SnapshotState.ACTIVE,
+      ref: activateParams.ref,
+      size: 4.2,
+      initialRunnerId: 'runner-1',
+      errorReason: null,
+    })
+    expect(params.updateData.lastUsedAt).toBeInstanceOf(Date)
+
+    expect(stub.snapshotRunnerRepository.create).toHaveBeenCalledWith({
+      snapshotRef: activateParams.ref,
+      runnerId: 'runner-1',
+      state: SnapshotRunnerState.READY,
+    })
+    expect(stub.snapshotRunnerRepository.save).toHaveBeenCalledTimes(1)
+    expect(stub.snapshotRepository.insert).not.toHaveBeenCalled()
+    expect(updated).toMatchObject({ state: SnapshotState.ACTIVE, ref: activateParams.ref })
+  })
+
+  it('omits size from the update when sizeGB is not finite', async () => {
+    const { stub, deps } = createDeps()
+    stub.snapshotRepository.findOne.mockResolvedValue(captureRecord())
+
+    await activateSnapshotFromSandbox(deps, { ...activateParams, sizeGB: Number.NaN })
+
+    const [, params] = stub.snapshotRepository.update.mock.calls[0]
+    expect(params.updateData).not.toHaveProperty('size')
+  })
+
+  it('falls back to inserting an ACTIVE record when no record exists', async () => {
+    const { stub, deps } = createDeps()
+
+    const inserted = await activateSnapshotFromSandbox(deps, activateParams)
+
+    expect(stub.snapshotRepository.update).not.toHaveBeenCalled()
+    expect(stub.snapshotRepository.insert).toHaveBeenCalledTimes(1)
+    const entity = stub.snapshotRepository.insert.mock.calls[0][0]
+    expect(entity).toMatchObject({
+      organizationId: 'org-1',
+      name: 'my-snap',
+      ref: activateParams.ref,
+      state: SnapshotState.ACTIVE,
+      size: 4.2,
+      initialRunnerId: 'runner-1',
+    })
+    expect(entity.lastUsedAt).toBeInstanceOf(Date)
+    expect(entity.snapshotRegions).toEqual([{ snapshotId: entity.id, regionId: 'region-1' }])
+
+    const [event, payload] = stub.eventEmitter.emit.mock.calls[0]
+    expect(event).toBe(SnapshotEvents.CREATED)
+    expect(payload.snapshot).toBe(inserted)
+    expect(stub.snapshotRunnerRepository.save).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null without writing when the record is no longer a pending capture', async () => {
+    const { stub, deps } = createDeps()
+    stub.snapshotRepository.findOne.mockResolvedValue(captureRecord({ state: SnapshotState.ERROR }))
+
+    const result = await activateSnapshotFromSandbox(deps, activateParams)
+
+    expect(result).toBeNull()
+    expect(stub.snapshotRepository.update).not.toHaveBeenCalled()
+    expect(stub.snapshotRepository.insert).not.toHaveBeenCalled()
+    expect(stub.snapshotRunnerRepository.save).not.toHaveBeenCalled()
+    expect(stub.eventEmitter.emit).not.toHaveBeenCalled()
+  })
+
+  it('returns null for a pending record that belongs to the pull flow (imageName set)', async () => {
+    const { stub, deps } = createDeps()
+    stub.snapshotRepository.findOne.mockResolvedValue(captureRecord({ imageName: 'ubuntu:22.04' }))
+
+    const result = await activateSnapshotFromSandbox(deps, activateParams)
+
+    expect(result).toBeNull()
+    expect(stub.snapshotRepository.update).not.toHaveBeenCalled()
+    expect(stub.snapshotRepository.insert).not.toHaveBeenCalled()
+  })
+
+  it('skips the SnapshotRunner when no runnerId is given', async () => {
+    const { stub, deps } = createDeps()
+    stub.snapshotRepository.findOne.mockResolvedValue(captureRecord())
+
+    await activateSnapshotFromSandbox(deps, { ...activateParams, runnerId: null })
+
+    expect(stub.snapshotRepository.update).toHaveBeenCalledTimes(1)
+    expect(stub.snapshotRunnerRepository.create).not.toHaveBeenCalled()
+    expect(stub.snapshotRunnerRepository.save).not.toHaveBeenCalled()
+  })
+})
+
+describe('failSnapshotFromSandbox', () => {
+  const failParams = { organizationId: 'org-1', name: 'my-snap', errorReason: 'runner exploded' }
+
+  it('marks a pending capture record as ERROR with the reason', async () => {
+    const { stub, deps } = createDeps()
+    const record = captureRecord()
+    stub.snapshotRepository.findOne.mockResolvedValue(record)
+
+    await failSnapshotFromSandbox(deps, failParams)
+
+    expect(stub.snapshotRepository.update).toHaveBeenCalledTimes(1)
+    const [id, params] = stub.snapshotRepository.update.mock.calls[0]
+    expect(id).toBe('snap-1')
+    expect(params.entity).toBe(record)
+    expect(params.updateData).toEqual({
+      state: SnapshotState.ERROR,
+      errorReason: 'runner exploded',
+    })
+  })
+
+  it('does nothing when the record is missing', async () => {
+    const { stub, deps } = createDeps()
+
+    await failSnapshotFromSandbox(deps, failParams)
+
+    expect(stub.snapshotRepository.update).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['a pull snapshot sharing the name', captureRecord({ imageName: 'ubuntu:22.04' })],
+    ['a build snapshot sharing the name', captureRecord({ buildInfo: { snapshotRef: 'ref' } as BuildInfo })],
+    ['an already-active record', captureRecord({ state: SnapshotState.ACTIVE })],
+  ])('leaves %s untouched', async (_label, record) => {
+    const { stub, deps } = createDeps()
+    stub.snapshotRepository.findOne.mockResolvedValue(record)
+
+    await failSnapshotFromSandbox(deps, failParams)
+
+    expect(stub.snapshotRepository.update).not.toHaveBeenCalled()
+  })
+})

--- a/apps/api/src/sandbox/utils/persist-snapshot-from-sandbox.util.spec.ts
+++ b/apps/api/src/sandbox/utils/persist-snapshot-from-sandbox.util.spec.ts
@@ -89,7 +89,7 @@ function captureRecord(overrides: Partial<Snapshot> = {}): Snapshot {
 }
 
 describe('isPendingCaptureSnapshot', () => {
-  it('is true only for pending records with empty imageName and no buildInfo', () => {
+  it('is true only for pending records with empty imageName, no buildInfo and no ref', () => {
     expect(isPendingCaptureSnapshot(captureRecord())).toBe(true)
   })
 
@@ -98,6 +98,7 @@ describe('isPendingCaptureSnapshot', () => {
     ['pending with buildInfo', captureRecord({ buildInfo: { snapshotRef: 'ref' } as BuildInfo })],
     ['active capture-shaped record', captureRecord({ state: SnapshotState.ACTIVE })],
     ['errored capture-shaped record', captureRecord({ state: SnapshotState.ERROR })],
+    ['reactivated capture record with ref', captureRecord({ ref: 'registry.example.com/daytona/daytona-abc:daytona' })],
   ])('is false for %s', (_label, snapshot) => {
     expect(isPendingCaptureSnapshot(snapshot)).toBe(false)
   })

--- a/apps/api/src/sandbox/utils/persist-snapshot-from-sandbox.util.ts
+++ b/apps/api/src/sandbox/utils/persist-snapshot-from-sandbox.util.ts
@@ -48,12 +48,16 @@ export type CreatePendingSnapshotFromSandboxParams = Omit<
 /**
  * Identifies a snapshot-from-sandbox capture record awaiting its result.
  *
- * Capture records are the only PENDING rows with an empty imageName and no
- * buildInfo: createFromPull rejects empty image names and createFromBuildInfo
- * always sets buildInfo.
+ * Capture records are the only PENDING rows with an empty imageName, no
+ * buildInfo and no ref: createFromPull rejects empty image names,
+ * createFromBuildInfo always sets buildInfo, and activateSnapshotFromSandbox
+ * sets ref. The ref check excludes previously-captured snapshots that were
+ * deactivated and reactivated (INACTIVE -> PENDING): those keep their empty
+ * imageName but carry the ref written at activation, and must go through the
+ * regular pull-by-ref flow instead of the capture timeout.
  */
 export function isPendingCaptureSnapshot(snapshot: Snapshot): boolean {
-  return snapshot.state === SnapshotState.PENDING && !snapshot.buildInfo && !snapshot.imageName
+  return snapshot.state === SnapshotState.PENDING && !snapshot.buildInfo && !snapshot.imageName && !snapshot.ref
 }
 
 /**

--- a/apps/api/src/sandbox/utils/persist-snapshot-from-sandbox.util.ts
+++ b/apps/api/src/sandbox/utils/persist-snapshot-from-sandbox.util.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { ConflictException } from '@nestjs/common'
+import { ConflictException, Logger } from '@nestjs/common'
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { Repository } from 'typeorm'
 import { v4 as uuidv4 } from 'uuid'
@@ -16,6 +16,8 @@ import { SnapshotCreatedEvent } from '../events/snapshot-created.event'
 import { SnapshotRepository } from '../repositories/snapshot.repository'
 import { SandboxClass } from '../enums/sandbox-class.enum'
 import { GpuType } from '../enums/gpu-type.enum'
+
+const logger = new Logger('PersistSnapshotFromSandbox')
 
 export interface PersistSnapshotFromSandboxDeps {
   snapshotRepository: SnapshotRepository
@@ -38,26 +40,131 @@ export interface PersistSnapshotFromSandboxParams {
   sizeGB?: number
 }
 
+export type CreatePendingSnapshotFromSandboxParams = Omit<
+  PersistSnapshotFromSandboxParams,
+  'ref' | 'runnerId' | 'sizeGB'
+>
+
 /**
- * Inserts a Snapshot row in the ACTIVE state for an image that a runner has
- * already produced (snapshot-from-sandbox), wires up the matching
- * SnapshotRunner record, and emits the CREATED event.
+ * Identifies a snapshot-from-sandbox capture record awaiting its result.
+ *
+ * Capture records are the only PENDING rows with an empty imageName and no
+ * buildInfo: createFromPull rejects empty image names and createFromBuildInfo
+ * always sets buildInfo.
+ */
+export function isPendingCaptureSnapshot(snapshot: Snapshot): boolean {
+  return snapshot.state === SnapshotState.PENDING && !snapshot.buildInfo && !snapshot.imageName
+}
+
+/**
+ * Inserts the Snapshot record (state=PENDING) when a snapshot-from-sandbox
+ * capture is accepted, before the capture is dispatched. A duplicate
+ * (organizationId, name) surfaces as ConflictException (HTTP 409) here,
+ * before any capture work runs. Emits the CREATED event, which transfers the
+ * pending quota counter to current usage — from this point quota settlement
+ * follows the record lifecycle (PENDING -> ACTIVE/ERROR state transitions).
  *
  * Extracted to a free function to avoid a NestJS DI cycle between
  * SnapshotService and JobStateHandlerService: both can call this without
  * importing each other.
  */
-export async function persistSnapshotFromSandbox(
+export async function createPendingSnapshotFromSandbox(
+  deps: PersistSnapshotFromSandboxDeps,
+  params: CreatePendingSnapshotFromSandboxParams,
+): Promise<Snapshot> {
+  const { snapshotRepository, eventEmitter } = deps
+
+  const snapshotId = uuidv4()
+  const snapshot = snapshotRepository.create({
+    id: snapshotId,
+    organizationId: params.organizationId,
+    name: params.name,
+    state: SnapshotState.PENDING,
+    sandboxClass: params.sandboxClass,
+    cpu: params.cpu,
+    gpu: params.gpu,
+    gpuType: params.gpuType ?? null,
+    mem: params.mem,
+    disk: params.disk,
+    snapshotRegions: [{ snapshotId, regionId: params.regionId }],
+  })
+
+  let inserted: Snapshot
+  try {
+    inserted = await snapshotRepository.insert(snapshot)
+  } catch (error) {
+    if ((error as { code?: string }).code === '23505') {
+      throw new ConflictException(`Snapshot with name "${params.name}" already exists for this organization`)
+    }
+    throw error
+  }
+
+  eventEmitter.emit(SnapshotEvents.CREATED, new SnapshotCreatedEvent(inserted))
+  return inserted
+}
+
+/**
+ * Marks the capture record ACTIVE once the runner has produced the image,
+ * filling in ref/size/initialRunnerId and wiring up the matching
+ * SnapshotRunner record. The PENDING -> ACTIVE transition emits STATE_UPDATED
+ * via the repository.
+ *
+ * If no record exists (SNAPSHOT_SANDBOX jobs enqueued before the accept-time
+ * insert was deployed), falls back to inserting an ACTIVE record directly. If
+ * the record exists but is no longer a pending capture (e.g. already ERROR
+ * after a timeout), returns null without touching it.
+ */
+export async function activateSnapshotFromSandbox(
   deps: PersistSnapshotFromSandboxDeps,
   params: PersistSnapshotFromSandboxParams,
-): Promise<Snapshot> {
+): Promise<Snapshot | null> {
   const { snapshotRepository, snapshotRunnerRepository, eventEmitter } = deps
 
   const size = typeof params.sizeGB === 'number' && Number.isFinite(params.sizeGB) ? params.sizeGB : undefined
   const runnerId = params.runnerId || undefined
-  const snapshotId = uuidv4()
 
-  // We should set to active only after a number of snapshot runners had been propagated, leaving as is for now
+  const existing = await snapshotRepository.findOne({
+    where: { organizationId: params.organizationId, name: params.name },
+  })
+
+  if (existing) {
+    if (!isPendingCaptureSnapshot(existing)) {
+      logger.warn(
+        `Snapshot "${params.name}" (org ${params.organizationId}) is not a pending capture record (state: ${existing.state}); skipping activation`,
+      )
+      return null
+    }
+
+    const updated = await snapshotRepository.update(existing.id, {
+      updateData: {
+        state: SnapshotState.ACTIVE,
+        ref: params.ref,
+        ...(size !== undefined && { size }),
+        initialRunnerId: runnerId,
+        lastUsedAt: new Date(),
+        errorReason: null,
+      },
+      entity: existing,
+    })
+
+    // SnapshotRunner is created only after the Snapshot row is updated so a
+    // failure above doesn't leave an orphan SnapshotRunner record pointing at
+    // a ref no Snapshot owns.
+    if (runnerId) {
+      const snapshotRunner = snapshotRunnerRepository.create({
+        snapshotRef: params.ref,
+        runnerId,
+        state: SnapshotRunnerState.READY,
+      })
+      await snapshotRunnerRepository.save(snapshotRunner)
+    }
+
+    return updated
+  }
+
+  // Legacy fallback: jobs enqueued before the accept-time record existed have
+  // no row to update — insert the ACTIVE record directly.
+  const snapshotId = uuidv4()
   const snapshot = snapshotRepository.create({
     id: snapshotId,
     organizationId: params.organizationId,
@@ -100,4 +207,40 @@ export async function persistSnapshotFromSandbox(
 
   eventEmitter.emit(SnapshotEvents.CREATED, new SnapshotCreatedEvent(inserted))
   return inserted
+}
+
+/**
+ * Marks the capture record ERROR when the capture fails. The PENDING -> ERROR
+ * transition emits STATE_UPDATED, which decrements current snapshot usage in
+ * OrganizationUsageService — the same settlement path pull/build snapshot
+ * failures use. No-ops (with a warning) when the record is missing or is not
+ * a pending capture, making it idempotent against late or duplicate failure
+ * signals.
+ */
+export async function failSnapshotFromSandbox(
+  deps: PersistSnapshotFromSandboxDeps,
+  params: { organizationId: string; name: string; errorReason: string },
+): Promise<void> {
+  const { snapshotRepository } = deps
+
+  const existing = await snapshotRepository.findOne({
+    where: { organizationId: params.organizationId, name: params.name },
+  })
+
+  if (!existing || !isPendingCaptureSnapshot(existing)) {
+    logger.warn(
+      `Snapshot "${params.name}" (org ${params.organizationId}) is ${
+        existing ? `not a pending capture record (state: ${existing.state})` : 'missing'
+      }; skipping failure marking`,
+    )
+    return
+  }
+
+  await snapshotRepository.update(existing.id, {
+    updateData: {
+      state: SnapshotState.ERROR,
+      errorReason: params.errorReason,
+    },
+    entity: existing,
+  })
 }

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -2538,6 +2538,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/Sandbox"
           description: Snapshot creation has been initiated
+        "409":
+          description: A snapshot with this name already exists for the organization
       security:
       - bearer: []
       - oauth2:

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/api/SandboxApi.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/api/SandboxApi.java
@@ -520,6 +520,7 @@ public class SandboxApi {
        <caption>Response Details</caption>
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> A snapshot with this name already exists for the organization </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createSandboxSnapshotCall(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback _callback) throws ApiException {
@@ -602,6 +603,7 @@ public class SandboxApi {
        <caption>Response Details</caption>
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> A snapshot with this name already exists for the organization </td><td>  -  </td></tr>
      </table>
      */
     public Sandbox createSandboxSnapshot(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
@@ -622,6 +624,7 @@ public class SandboxApi {
        <caption>Response Details</caption>
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> A snapshot with this name already exists for the organization </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<Sandbox> createSandboxSnapshotWithHttpInfo(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
@@ -644,6 +647,7 @@ public class SandboxApi {
        <caption>Response Details</caption>
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> Snapshot creation has been initiated </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> A snapshot with this name already exists for the organization </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createSandboxSnapshotAsync(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nonnull CreateSandboxSnapshot createSandboxSnapshot, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback<Sandbox> _callback) throws ApiException {

--- a/libs/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
+++ b/libs/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
@@ -962,6 +962,7 @@ class SandboxApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Sandbox",
+            '409': None,
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -1036,6 +1037,7 @@ class SandboxApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Sandbox",
+            '409': None,
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -1110,6 +1112,7 @@ class SandboxApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Sandbox",
+            '409': None,
         }
         response_data = await self.api_client.call_api(
             *_param,

--- a/libs/api-client-python/daytona_api_client/api/sandbox_api.py
+++ b/libs/api-client-python/daytona_api_client/api/sandbox_api.py
@@ -962,6 +962,7 @@ class SandboxApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Sandbox",
+            '409': None,
         }
         response_data = self.api_client.call_api(
             *_param,
@@ -1036,6 +1037,7 @@ class SandboxApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Sandbox",
+            '409': None,
         }
         response_data = self.api_client.call_api(
             *_param,
@@ -1110,6 +1112,7 @@ class SandboxApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Sandbox",
+            '409': None,
         }
         response_data = self.api_client.call_api(
             *_param,


### PR DESCRIPTION
**TL;DR:** snapshot-from-sandbox captures now create the snapshot record at accept time and mark it `error` (+`errorReason`) on every failure path, so failed captures are visible instead of silently vanishing.

## Description

Capture previously inserted the Snapshot record only AFTER success. Any failure (error, timeout, transport abort) left zero evidence: sandbox state silently reverted, the SDK reported success, the snapshot 404'd forever (#4990).

After this PR:

- The record is created `pending` when the capture is accepted (v0 and v2), so duplicate names 409 before any capture work runs.
- Success transitions it to `active` (existing propagation preserved); failures (v0 background error, v2 FAILED job, cron timeout, initiation throw) mark it `error` with a real `errorReason` while the sandbox still reverts to its previous state.
- v2 FAILED jobs settle pending snapshot quota via the `pending -> error` state event (closes a quota leak).
- `sizeGB` is persisted for v0 records; deploy-window fallback keeps jobs from pre-rollout APIs working (legacy insert-ACTIVE).

**Design decision:** capture records reuse `SnapshotState.PENDING`, discriminated by `isPendingCaptureSnapshot` (`pending` + no `buildInfo` + empty `imageName` + **empty `ref`**), instead of a new enum value - avoids a Postgres `ALTER TYPE` migration and an OpenAPI enum change regenerating six client libraries. The `!ref` term exists because activation sets `ref` but never `imageName`, so reactivated rows (INACTIVE -> PENDING) would otherwise match the signature - found by review, fixed in 194a03a58.

Behavior notes for reviewers:
- A failed capture now holds the unique (org, name) with an `error` record until deleted - consistent with pull/build failures, but previously failures left no trace. Release-note worthy.
- A v2 FAILED job arriving after the sandbox already left `SNAPSHOTTING` resolves via the cron timeout (generic reason) instead of the job's message - rare corner, accepted.

## Review guide

Suggested order:
1. `apps/api/src/sandbox/utils/persist-snapshot-from-sandbox.util.ts` - the record lifecycle helpers and the capture signature (risk center: the `isPendingCaptureSnapshot` predicate gates everything).
2. `apps/api/src/sandbox/services/sandbox.service.ts` - accept-time insert + v0 failure path + initiation try/catch.
3. `apps/api/src/sandbox/services/job-state-handler.service.ts` - v2 FAILED handling + quota settle.
4. `apps/api/src/sandbox/managers/snapshot.manager.ts` - cron guard (risk center: interaction with the pull flow).
5. Specs.

Generated files: one additive client regen documenting the 409 (response-map and doc entries across the go/java/python clients); guarded by the CI regen-drift gate.

## Commit map

| Commit | What | Why it exists |
|---|---|---|
| 3e7f645e5 | persist pending record at accept | implementation (plan) |
| c18906924 | mark record from v2 job completion | implementation (plan) |
| 1421ab94f | record lifecycle specs | implementation (plan) |
| 3465daec5 | restore state + fail record when initiation throws | Copilot review finding (valid) |
| 194a03a58 | exclude reactivated snapshots from capture guard | cubic review P1 (valid) |
| 4a0bf0e9e | document the 409 duplicate-name response on the capture route | review follow-up (spec completeness) |
| 369e6df05 | client regen for the 409 response | generated |

## Related PRs

Part of #4990. Merge order: this PR first; #5004 (v0 async capture) is stacked on this branch and gets retargeted to main after merge; #5000 (SDK record polling) pairs with this and merges independently.

## Validation

- `persist-snapshot-from-sandbox.util.spec.ts` (21 assertions: insert fields/event/409 mapping, activation incl. legacy fallback and non-capture refusal, failure idempotency, signature predicate incl. reactivated rows) + new `sandbox.service.spec.ts` (3 tests on the initiation-throw path).
- Full `nx test api`: 52 suites / 571 tests green; `nx build api` + lint green.
- Spec: the 409 duplicate-name contract is annotated on the capture route and regenerated into the clients (additive-only: 12 insertions, 0 deletions, 4 files); regen built fresh with `--skip-nx-cache` and verified by the CI drift gate.
- All CI checks green on 194a03a58 (incl. E2E).

Closes #4991

