### PR TITLE
fix(sdk-typescript): poll the snapshot record in _experimental_createSnapshot

### DIFF
--- a/apps/docs/src/content/docs/en/typescript-sdk/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/sandbox.mdx
@@ -67,7 +67,8 @@ new Sandbox(
    sandboxDto: SandboxListItem | Sandbox, 
    clientConfig: Configuration, 
    axiosInstance: AxiosInstance, 
-   sandboxApi: SandboxApi): Sandbox
+   sandboxApi: SandboxApi, 
+   snapshotsApi: SnapshotsApi): Sandbox
 ```
 
 Creates a new Sandbox instance
@@ -78,6 +79,7 @@ Creates a new Sandbox instance
 - `clientConfig` _Configuration_
 - `axiosInstance` _AxiosInstance_
 - `sandboxApi` _SandboxApi_
+- `snapshotsApi` _SnapshotsApi_
 
 
 **Returns**:
@@ -96,7 +98,9 @@ Creates a snapshot from the current state of the Sandbox.
 
 This captures the Sandbox's filesystem into a reusable snapshot that can be
 used to create new Sandboxes. The Sandbox will temporarily enter a
-'snapshotting' state and return to its previous state when complete.
+'snapshotting' state and return to its previous state when complete. The
+method waits until the snapshot record reaches the 'active' state and throws
+a DaytonaError carrying the snapshot's error reason if the capture fails.
 
 **Parameters**:
 

--- a/apps/docs/src/content/docs/en/typescript-sdk/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/sandbox.mdx
@@ -68,7 +68,7 @@ new Sandbox(
    clientConfig: Configuration, 
    axiosInstance: AxiosInstance, 
    sandboxApi: SandboxApi, 
-   snapshotsApi: SnapshotsApi): Sandbox
+   snapshotsApi?: SnapshotsApi): Sandbox
 ```
 
 Creates a new Sandbox instance
@@ -79,7 +79,7 @@ Creates a new Sandbox instance
 - `clientConfig` _Configuration_
 - `axiosInstance` _AxiosInstance_
 - `sandboxApi` _SandboxApi_
-- `snapshotsApi` _SnapshotsApi_
+- `snapshotsApi?` _SnapshotsApi_
 
 
 **Returns**:

--- a/libs/sdk-typescript/src/Daytona.ts
+++ b/libs/sdk-typescript/src/Daytona.ts
@@ -228,6 +228,7 @@ export type CreateSandboxFromSnapshotParams = CreateSandboxBaseParams & {
 export class Daytona implements AsyncDisposable {
   private readonly clientConfig: Configuration
   private readonly sandboxApi: SandboxApi
+  private readonly snapshotsApi: SnapshotsApi
   private readonly objectStorageApi: ObjectStorageApi
   private readonly configApi: ConfigApi
   private readonly target?: string
@@ -323,15 +324,11 @@ export class Daytona implements AsyncDisposable {
     const axiosInstance = Daytona.createAxiosInstance()
 
     this.sandboxApi = new SandboxApi(configuration, '', axiosInstance)
+    this.snapshotsApi = new SnapshotsApi(configuration, '', axiosInstance)
     this.objectStorageApi = new ObjectStorageApi(configuration, '', axiosInstance)
     this.configApi = new ConfigApi(configuration, '', axiosInstance)
     this.volume = new VolumeService(new VolumesApi(configuration, '', axiosInstance))
-    this.snapshot = new SnapshotService(
-      configuration,
-      new SnapshotsApi(configuration, '', axiosInstance),
-      this.objectStorageApi,
-      this.target,
-    )
+    this.snapshot = new SnapshotService(configuration, this.snapshotsApi, this.objectStorageApi, this.target)
     this.clientConfig = configuration
 
     const env = envReader()
@@ -620,6 +617,7 @@ export class Daytona implements AsyncDisposable {
         new Configuration(structuredClone(this.clientConfig)),
         Daytona.createAxiosInstance(),
         this.sandboxApi,
+        this.snapshotsApi,
       )
 
       if (sandbox.state !== 'started') {
@@ -660,6 +658,7 @@ export class Daytona implements AsyncDisposable {
       structuredClone(this.clientConfig),
       Daytona.createAxiosInstance(),
       this.sandboxApi,
+      this.snapshotsApi,
     )
   }
 
@@ -675,7 +674,7 @@ export class Daytona implements AsyncDisposable {
    * }
    */
   public list(query?: ListSandboxesQuery): AsyncIterableIterator<Sandbox> {
-    const { sandboxApi, clientConfig } = this
+    const { sandboxApi, snapshotsApi, clientConfig } = this
     const tracer = trace.getTracer('')
 
     async function* generator(): AsyncGenerator<Sandbox> {
@@ -746,7 +745,13 @@ export class Daytona implements AsyncDisposable {
 
         for (const sandbox of response.data.items) {
           // Sandbox ctor mutates clientConfig.basePath — clone per item.
-          yield new Sandbox(sandbox, structuredClone(clientConfig), Daytona.createAxiosInstance(), sandboxApi)
+          yield new Sandbox(
+            sandbox,
+            structuredClone(clientConfig),
+            Daytona.createAxiosInstance(),
+            sandboxApi,
+            snapshotsApi,
+          )
         }
 
         cursor = response.data.nextCursor ?? undefined

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -470,7 +470,8 @@ export class Sandbox {
         if (snapshot.state === SnapshotState.ACTIVE) {
           // Record polling bypasses the sandbox, so sync local data
           // (state would otherwise stay SNAPSHOTTING) before resolving.
-          await this.refreshData()
+          // Best-effort: a refresh failure must never reject a successful capture.
+          await this.refreshDataSafe()
           return
         }
         if (snapshot.state === SnapshotState.ERROR || snapshot.state === SnapshotState.BUILD_FAILED) {

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SandboxState, SandboxApi, SandboxBackupStateEnum, Configuration } from '@daytona/api-client'
+import {
+  SandboxState,
+  SandboxApi,
+  SandboxBackupStateEnum,
+  Configuration,
+  SnapshotsApi,
+  SnapshotState,
+} from '@daytona/api-client'
 import type {
   Sandbox as SandboxDto,
   SandboxListItem as SandboxListItemDto,
@@ -18,6 +25,7 @@ import type {
   UpdateSandboxNetworkSettings,
   SandboxListSortField,
   SandboxListSortDirection,
+  SnapshotDto,
 } from '@daytona/api-client'
 import { Daytona } from './Daytona'
 import type { Resources } from './Daytona'
@@ -138,6 +146,7 @@ export class Sandbox {
     private readonly clientConfig: Configuration,
     private readonly axiosInstance: AxiosInstance,
     private readonly sandboxApi: SandboxApi,
+    private readonly snapshotsApi: SnapshotsApi,
   ) {
     this.processSandboxDto(sandboxDto)
 
@@ -369,6 +378,7 @@ export class Sandbox {
       structuredClone(this.clientConfig),
       Daytona.createAxiosInstance(),
       this.sandboxApi,
+      this.snapshotsApi,
     )
 
     const timeElapsed = Date.now() - startTime
@@ -382,7 +392,9 @@ export class Sandbox {
    *
    * This captures the Sandbox's filesystem into a reusable snapshot that can be
    * used to create new Sandboxes. The Sandbox will temporarily enter a
-   * 'snapshotting' state and return to its previous state when complete.
+   * 'snapshotting' state and return to its previous state when complete. The
+   * method waits until the snapshot record reaches the 'active' state and throws
+   * a DaytonaError carrying the snapshot's error reason if the capture fails.
    *
    * @param {string} name - Name for the new snapshot
    * @param {number} [timeout] - Maximum time to wait in seconds. 0 means no timeout.
@@ -412,25 +424,50 @@ export class Sandbox {
 
     const timeElapsed = Date.now() - startTime
     const remainingTimeout = timeout ? Math.max(0.001, timeout - timeElapsed / 1000) : timeout
-    await this.waitForSnapshotComplete(remainingTimeout)
+    await this.waitForSnapshotComplete(name, remainingTimeout)
   }
 
-  private async waitForSnapshotComplete(timeout: number) {
+  private async waitForSnapshotComplete(name: string, timeout: number) {
     let checkInterval = 100
     const startTime = Date.now()
 
-    while (this.state === SandboxState.SNAPSHOTTING) {
-      await this.refreshData()
-
-      // @ts-expect-error this.refreshData() can modify this.state so this check is fine
-      if (this.state === SandboxState.ERROR || this.state === SandboxState.BUILD_FAILED) {
-        throw new DaytonaError(
-          `Sandbox ${this.id} snapshot failed with state: ${this.state}, error reason: ${this.errorReason}`,
-        )
+    while (true) {
+      let snapshot: SnapshotDto | undefined
+      try {
+        snapshot = (await this.snapshotsApi.getSnapshot(name)).data
+      } catch (error) {
+        if (!(error instanceof DaytonaNotFoundError)) {
+          throw error
+        }
+        // Legacy APIs create the snapshot record only after a successful capture.
+        // Tolerate the missing record while the sandbox is still snapshotting.
+        await this.refreshData()
+        if (this.state !== SandboxState.SNAPSHOTTING) {
+          // Pre-#4991 APIs persist the record and restore the sandbox state in separate steps,
+          // so a poll can observe the reverted sandbox before the record lands. Re-read once
+          // before declaring the capture failed.
+          try {
+            snapshot = (await this.snapshotsApi.getSnapshot(name)).data
+          } catch (graceError) {
+            if (!(graceError instanceof DaytonaNotFoundError)) {
+              throw graceError
+            }
+            throw new DaytonaError(
+              `Sandbox ${this.id} snapshot '${name}' failed: no snapshot record exists and sandbox is no longer snapshotting (state: ${this.state}, error reason: ${this.errorReason})`,
+            )
+          }
+        }
       }
 
-      if (this.state !== SandboxState.SNAPSHOTTING) {
-        return
+      if (snapshot) {
+        if (snapshot.state === SnapshotState.ACTIVE) {
+          return
+        }
+        if (snapshot.state === SnapshotState.ERROR || snapshot.state === SnapshotState.BUILD_FAILED) {
+          throw new DaytonaError(
+            `Snapshot ${name} failed with state: ${snapshot.state}, error reason: ${snapshot.errorReason}`,
+          )
+        }
       }
 
       if (timeout !== 0 && Date.now() - startTime > timeout * 1000) {

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -135,6 +135,7 @@ export class Sandbox {
   public toolboxProxyUrl: string
 
   private infoApi: InfoApi
+  private readonly snapshotsApi: SnapshotsApi
 
   /**
    * Creates a new Sandbox instance
@@ -146,8 +147,14 @@ export class Sandbox {
     private readonly clientConfig: Configuration,
     private readonly axiosInstance: AxiosInstance,
     private readonly sandboxApi: SandboxApi,
-    private readonly snapshotsApi: SnapshotsApi,
+    snapshotsApi?: SnapshotsApi,
   ) {
+    // clientConfig still targets the Daytona API at this point (it is repurposed
+    // for the toolbox below), so a default SnapshotsApi built from a copy of it
+    // polls the correct host when the caller does not provide one.
+    this.snapshotsApi =
+      snapshotsApi ?? new SnapshotsApi(new Configuration({ ...clientConfig }), '', Daytona.createAxiosInstance())
+
     this.processSandboxDto(sandboxDto)
 
     // Set the toolbox base URL
@@ -461,9 +468,13 @@ export class Sandbox {
 
       if (snapshot) {
         if (snapshot.state === SnapshotState.ACTIVE) {
+          // Record polling bypasses the sandbox, so sync local data
+          // (state would otherwise stay SNAPSHOTTING) before resolving.
+          await this.refreshData()
           return
         }
         if (snapshot.state === SnapshotState.ERROR || snapshot.state === SnapshotState.BUILD_FAILED) {
+          await this.refreshDataSafe()
           throw new DaytonaError(
             `Snapshot ${name} failed with state: ${snapshot.state}, error reason: ${snapshot.errorReason}`,
           )

--- a/libs/sdk-typescript/src/__tests__/Sandbox.test.ts
+++ b/libs/sdk-typescript/src/__tests__/Sandbox.test.ts
@@ -1,7 +1,12 @@
 // Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Configuration, Sandbox as SandboxDto } from '@daytona/api-client'
+import {
+  Configuration as MockedConfiguration,
+  SnapshotsApi as MockedSnapshotsApi,
+  type Configuration,
+  type Sandbox as SandboxDto,
+} from '@daytona/api-client'
 import { createApiResponse } from './helpers'
 import { DaytonaNotFoundError } from '../errors/DaytonaError'
 
@@ -360,7 +365,10 @@ describe('Sandbox', () => {
 
   it('defaults snapshotsApi to an API-targeted client when omitted', async () => {
     const { Sandbox } = require('../Sandbox') as typeof import('../Sandbox')
-    const apiClient = require('@daytona/api-client') as { SnapshotsApi: jest.Mock; Configuration: jest.Mock }
+    const apiClient = {
+      SnapshotsApi: MockedSnapshotsApi as unknown as jest.Mock,
+      Configuration: MockedConfiguration as unknown as jest.Mock,
+    }
     apiClient.SnapshotsApi.mockClear()
     apiClient.Configuration.mockClear()
 

--- a/libs/sdk-typescript/src/__tests__/Sandbox.test.ts
+++ b/libs/sdk-typescript/src/__tests__/Sandbox.test.ts
@@ -22,6 +22,8 @@ jest.mock(
       ERROR: 'error',
       BUILD_FAILED: 'build_failed',
     },
+    Configuration: jest.fn((params: Record<string, unknown> = {}) => ({ ...params })),
+    SnapshotsApi: jest.fn(() => ({ getSnapshot: jest.fn() })),
   }),
   { virtual: true },
 )
@@ -261,7 +263,9 @@ describe('Sandbox', () => {
   it('creates sandbox snapshots and waits for completion', async () => {
     const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
     sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
-    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+    sandboxApi.getSandbox
+      .mockResolvedValueOnce(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+      .mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
     snapshotsApi.getSnapshot
       .mockResolvedValueOnce(createApiResponse({ state: 'pending' }))
       .mockResolvedValueOnce(createApiResponse({ state: 'active' }))
@@ -273,17 +277,23 @@ describe('Sandbox', () => {
     })
     expect(snapshotsApi.getSnapshot).toHaveBeenCalledWith('snap-1')
     expect(snapshotsApi.getSnapshot.mock.calls.length).toBeGreaterThanOrEqual(2)
+    // The success path refreshes local sandbox data once the record turns active.
+    expect(sandbox.state).toBe('started')
   })
 
   it('throws when snapshot record reports a failed capture', async () => {
     const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
     sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
-    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+    sandboxApi.getSandbox
+      .mockResolvedValueOnce(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+      .mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
     snapshotsApi.getSnapshot.mockResolvedValue(createApiResponse({ state: 'error', errorReason: 'capture failed' }))
 
     await expect(sandbox._experimental_createSnapshot('snap-1', 1)).rejects.toThrow(
       'Snapshot snap-1 failed with state: error, error reason: capture failed',
     )
+    // The failure path refreshes local sandbox data before throwing.
+    expect(sandbox.state).toBe('started')
   })
 
   it('throws when snapshot record reports a failed build', async () => {
@@ -333,6 +343,37 @@ describe('Sandbox', () => {
       "Sandbox sb-1 snapshot 'snap-1' failed: no snapshot record exists and sandbox is no longer snapshotting (state: started",
     )
     expect(snapshotsApi.getSnapshot).toHaveBeenCalledTimes(2)
+  })
+
+  it('defaults snapshotsApi to an API-targeted client when omitted', async () => {
+    const { Sandbox } = require('../Sandbox') as typeof import('../Sandbox')
+    const apiClient = require('@daytona/api-client') as { SnapshotsApi: jest.Mock; Configuration: jest.Mock }
+    apiClient.SnapshotsApi.mockClear()
+    apiClient.Configuration.mockClear()
+
+    const cfg = { basePath: 'http://api', baseOptions: { headers: {} } } as unknown as Configuration
+    const sandboxApi = {
+      createSandboxSnapshot: jest.fn().mockResolvedValue(createApiResponse(undefined)),
+      getSandbox: jest.fn().mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' })),
+    }
+
+    const sandbox = new Sandbox(
+      { ...baseDto, state: 'snapshotting' },
+      cfg,
+      { defaults: { baseURL: '' } } as unknown as never,
+      sandboxApi as unknown as never,
+    )
+
+    // The default SnapshotsApi must be built from the API base path captured
+    // before the constructor repoints clientConfig at the toolbox proxy.
+    expect(apiClient.Configuration).toHaveBeenCalledWith(expect.objectContaining({ basePath: 'http://api' }))
+    expect(cfg.basePath).toBe('http://proxy/sb-1')
+
+    const snapshotsApi = apiClient.SnapshotsApi.mock.results[0].value as { getSnapshot: jest.Mock }
+    snapshotsApi.getSnapshot.mockResolvedValue(createApiResponse({ state: 'active' }))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).resolves.toBeUndefined()
+    expect(snapshotsApi.getSnapshot).toHaveBeenCalledWith('snap-1')
   })
 
   it('waitUntilStarted throws when sandbox enters an error state', async () => {

--- a/libs/sdk-typescript/src/__tests__/Sandbox.test.ts
+++ b/libs/sdk-typescript/src/__tests__/Sandbox.test.ts
@@ -13,6 +13,14 @@ jest.mock(
       ERROR: 'error',
       BUILD_FAILED: 'build_failed',
       DESTROYED: 'destroyed',
+      SNAPSHOTTING: 'snapshotting',
+      STARTED: 'started',
+    },
+    SnapshotState: {
+      PENDING: 'pending',
+      ACTIVE: 'active',
+      ERROR: 'error',
+      BUILD_FAILED: 'build_failed',
     },
   }),
   { virtual: true },
@@ -52,7 +60,11 @@ const baseDto: SandboxDto = {
 
 const makeSandbox = (
   overrides: Partial<SandboxDto> = {},
-): { sandbox: import('../Sandbox').Sandbox; sandboxApi: Record<string, jest.Mock> } => {
+): {
+  sandbox: import('../Sandbox').Sandbox
+  sandboxApi: Record<string, jest.Mock>
+  snapshotsApi: Record<string, jest.Mock>
+} => {
   const { Sandbox } = require('../Sandbox') as typeof import('../Sandbox')
   const sandboxApi = {
     startSandbox: jest.fn(),
@@ -76,6 +88,10 @@ const makeSandbox = (
     validateSshAccess: jest.fn(),
   }
 
+  const snapshotsApi = {
+    getSnapshot: jest.fn(),
+  }
+
   const cfg: Configuration = {
     basePath: 'http://proxy',
     baseOptions: { headers: {} },
@@ -90,9 +106,10 @@ const makeSandbox = (
     cfg,
     axiosInstance as unknown as never,
     sandboxApi as unknown as never,
+    snapshotsApi as unknown as never,
   )
 
-  return { sandbox, sandboxApi }
+  return { sandbox, sandboxApi, snapshotsApi }
 }
 
 describe('Sandbox', () => {
@@ -242,15 +259,80 @@ describe('Sandbox', () => {
   })
 
   it('creates sandbox snapshots and waits for completion', async () => {
-    const { sandbox, sandboxApi } = makeSandbox({ state: 'snapshotting' })
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
     sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
-    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
+    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+    snapshotsApi.getSnapshot
+      .mockResolvedValueOnce(createApiResponse({ state: 'pending' }))
+      .mockResolvedValueOnce(createApiResponse({ state: 'active' }))
 
     await sandbox._experimental_createSnapshot('snap-1', 1)
 
     expect(sandboxApi.createSandboxSnapshot).toHaveBeenCalledWith('sb-1', { name: 'snap-1' }, undefined, {
       timeout: 1000,
     })
+    expect(snapshotsApi.getSnapshot).toHaveBeenCalledWith('snap-1')
+    expect(snapshotsApi.getSnapshot.mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('throws when snapshot record reports a failed capture', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+    snapshotsApi.getSnapshot.mockResolvedValue(createApiResponse({ state: 'error', errorReason: 'capture failed' }))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).rejects.toThrow(
+      'Snapshot snap-1 failed with state: error, error reason: capture failed',
+    )
+  })
+
+  it('throws when snapshot record reports a failed build', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+    snapshotsApi.getSnapshot.mockResolvedValue(
+      createApiResponse({ state: 'build_failed', errorReason: 'build failed' }),
+    )
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).rejects.toThrow(
+      'Snapshot snap-1 failed with state: build_failed, error reason: build failed',
+    )
+  })
+
+  it('tolerates missing snapshot record while sandbox is still snapshotting (legacy API)', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+    snapshotsApi.getSnapshot
+      .mockRejectedValueOnce(new DaytonaNotFoundError('not found'))
+      .mockResolvedValueOnce(createApiResponse({ state: 'active' }))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).resolves.toBeUndefined()
+    expect(snapshotsApi.getSnapshot.mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('recovers when the snapshot record appears on the grace re-read after the sandbox reverted', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
+    snapshotsApi.getSnapshot
+      .mockRejectedValueOnce(new DaytonaNotFoundError('not found'))
+      .mockResolvedValueOnce(createApiResponse({ state: 'active' }))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).resolves.toBeUndefined()
+    expect(snapshotsApi.getSnapshot).toHaveBeenCalledTimes(2)
+  })
+
+  it('fails when sandbox reverted and no snapshot record exists (legacy failure)', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox.mockResolvedValue(createApiResponse({ ...baseDto, state: 'started' }))
+    snapshotsApi.getSnapshot.mockRejectedValue(new DaytonaNotFoundError('not found'))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).rejects.toThrow(
+      "Sandbox sb-1 snapshot 'snap-1' failed: no snapshot record exists and sandbox is no longer snapshotting (state: started",
+    )
+    expect(snapshotsApi.getSnapshot).toHaveBeenCalledTimes(2)
   })
 
   it('waitUntilStarted throws when sandbox enters an error state', async () => {

--- a/libs/sdk-typescript/src/__tests__/Sandbox.test.ts
+++ b/libs/sdk-typescript/src/__tests__/Sandbox.test.ts
@@ -281,6 +281,19 @@ describe('Sandbox', () => {
     expect(sandbox.state).toBe('started')
   })
 
+  it('resolves a successful capture even when the success-path refresh fails', async () => {
+    const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
+    sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))
+    sandboxApi.getSandbox
+      .mockResolvedValueOnce(createApiResponse({ ...baseDto, state: 'snapshotting' }))
+      .mockRejectedValue(new Error('transient network failure'))
+    snapshotsApi.getSnapshot.mockResolvedValue(createApiResponse({ state: 'active' }))
+
+    await expect(sandbox._experimental_createSnapshot('snap-1', 1)).resolves.toBeUndefined()
+    // The refresh failure is swallowed; local state simply stays stale.
+    expect(sandbox.state).toBe('snapshotting')
+  })
+
   it('throws when snapshot record reports a failed capture', async () => {
     const { sandbox, sandboxApi, snapshotsApi } = makeSandbox({ state: 'snapshotting' })
     sandboxApi.createSandboxSnapshot.mockResolvedValue(createApiResponse(undefined))


### PR DESCRIPTION
**TL;DR:** `_experimental_createSnapshot` now polls the snapshot record (not sandbox state), so failed captures throw with the record's `errorReason` instead of reporting success for a snapshot that doesn't exist.

## Description

The helper previously polled sandbox state and treated any exit from `SNAPSHOTTING` as success. A silently failed capture (#4990) therefore RESOLVED with a snapshot name that 404s forever.

Now it polls the record by name until terminal: `active` resolves; `error`/`build_failed` throw a `DaytonaError` carrying the record's `errorReason`. Terminal-state handling mirrors `SnapshotService.create`.

- **Legacy-server compatibility** (pre-#4999 APIs create no record until success): a 404 is tolerated while the sandbox is still `SNAPSHOTTING`; once the sandbox reverts with no record, ONE grace re-read closes the server-side persist/revert straddle before reporting the legacy silent revert as a failure.
- **Constructor:** `Sandbox` gains an **optional** `snapshotsApi` parameter. When omitted (direct constructors in the wild), it is default-instantiated from the same pre-proxy `Configuration` the other APIs use - captured before the constructor repoints `clientConfig` to the toolbox proxy. No breaking change; everyone gets record polling.
- **Refresh semantics:** after a successful capture the local sandbox data is refreshed best-effort - a refresh failure logs and is swallowed, never rejecting a successful snapshot.

Known, labeled limitation: against PRE-#4999 servers, a pre-existing ACTIVE record with the same name yields a false success - pre-existing failure class, fixed server-side by #4999's accept-time 409.

## Review guide

Suggested order:
1. `libs/sdk-typescript/src/Sandbox.ts` - `waitForSnapshotComplete` loop (risk center: terminal mapping + legacy fallback), then the constructor default.
2. `libs/sdk-typescript/src/Daytona.ts` - wiring of the new param at construction sites.
3. `__tests__/Sandbox.test.ts` - the six snapshot-wait specs document the contract.
Mechanical: `apps/docs` typedoc regen (generated; CI diffs it), test-file import fix (nx module-boundary rule counts CJS `require` of a buildable lib as lazy-loading).

## Commit map

| Commit | What | Why it exists |
|---|---|---|
| bf500c96d | poll the record in _experimental_createSnapshot | implementation (plan) |
| 1fc4ca90b | typedoc regen | implementation (generated) |
| cfc34c4fe | snapshotsApi optional + success-path refresh | Copilot + cubic review (valid) |
| 679c2997b | never reject a successful capture on refresh failure | cubic review (valid) |
| 91cdee1bb | static api-client import in test | CI module-boundary failure fix |

## Related PRs

Part of #4990. Pairs with #4999 (record exists from accept time); mergeable independently thanks to the legacy fallback. Python SDK has the same bug plus an unenforced-timeout defect - deliberately out of scope, follow-up issue to come.

## Validation

- `nx test sdk-typescript`: 15 suites / 202 tests green, incl.: success gated on the record (polled twice), `error` rejects with errorReason, `build_failed` rejects, 404-tolerance while snapshotting, grace re-read recovery, legacy hard-fail once reverted with no record, default `SnapshotsApi` instantiation, success + refresh-throws still resolves.
- CI typecheck mirror (`tsc --verbatimModuleSyntax`) clean; prettier clean; typedoc regenerated in-PR.
- All CI checks green on 91cdee1bb. (One E2E run failed on the nuxt runtime harness's silent `npm install` - infra flake, passed on rerun, tracked in #5008.)

Closes #4992
