### PR TITLE
feat(runner): track per-sandbox host-side file descriptor usage

### DIFF
--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -17,56 +17,57 @@ import (
 )
 
 type Config struct {
-	DaytonaApiUrl                      string        `envconfig:"DAYTONA_API_URL"`
-	ApiToken                           string        `envconfig:"DAYTONA_RUNNER_TOKEN"`
-	ApiPort                            int           `envconfig:"API_PORT"`
-	ApiLogRequests                     bool          `envconfig:"API_LOG_REQUESTS" default:"false"`
-	TLSCertFile                        string        `envconfig:"TLS_CERT_FILE"`
-	TLSKeyFile                         string        `envconfig:"TLS_KEY_FILE"`
-	EnableTLS                          bool          `envconfig:"ENABLE_TLS"`
-	OtelLoggingEnabled                 bool          `envconfig:"OTEL_LOGGING_ENABLED"`
-	OtelTracingEnabled                 bool          `envconfig:"OTEL_TRACING_ENABLED"`
-	OtelEndpoint                       string        `envconfig:"OTEL_EXPORTER_OTLP_ENDPOINT"`
-	OtelHeaders                        string        `envconfig:"OTEL_EXPORTER_OTLP_HEADERS"`
-	BackupInfoCacheRetention           time.Duration `envconfig:"BACKUP_INFO_CACHE_RETENTION" default:"168h" validate:"min=5m"`
-	Environment                        string        `envconfig:"ENVIRONMENT"`
-	ContainerRuntime                   string        `envconfig:"CONTAINER_RUNTIME"`
-	ContainerNetwork                   string        `envconfig:"CONTAINER_NETWORK"`
-	InterSandboxNetworkEnabled         bool          `envconfig:"INTER_SANDBOX_NETWORK_ENABLED" default:"true"`
-	GpuEnabled                         bool          `envconfig:"GPU_ENABLED" default:"false"`
-	LogFilePath                        string        `envconfig:"LOG_FILE_PATH"`
-	AWSRegion                          string        `envconfig:"AWS_REGION"`
-	AWSEndpointUrl                     string        `envconfig:"AWS_ENDPOINT_URL"`
-	AWSAccessKeyId                     string        `envconfig:"AWS_ACCESS_KEY_ID"`
-	AWSSecretAccessKey                 string        `envconfig:"AWS_SECRET_ACCESS_KEY"`
-	AWSDefaultBucket                   string        `envconfig:"AWS_DEFAULT_BUCKET"`
-	ResourceLimitsDisabled             bool          `envconfig:"RESOURCE_LIMITS_DISABLED"`
-	DaemonStartTimeoutSec              int           `envconfig:"DAEMON_START_TIMEOUT_SEC"`
-	SandboxStartTimeoutSec             int           `envconfig:"SANDBOX_START_TIMEOUT_SEC"`
-	AndroidBootTimeoutSec              int           `envconfig:"ANDROID_BOOT_TIMEOUT_SEC"`
-	UseSnapshotEntrypoint              bool          `envconfig:"USE_SNAPSHOT_ENTRYPOINT"`
-	Domain                             string        `envconfig:"RUNNER_DOMAIN" validate:"omitempty,hostname|ip"`
-	VolumeCleanupInterval              time.Duration `envconfig:"VOLUME_CLEANUP_INTERVAL" default:"30s" validate:"min=10s"`
-	VolumeCleanupDryRun                bool          `envconfig:"VOLUME_CLEANUP_DRY_RUN" default:"true"`
-	VolumeCleanupExclusionPeriod       time.Duration `envconfig:"VOLUME_CLEANUP_EXCLUSION_PERIOD" default:"120s" validate:"min=0s"`
-	PollTimeout                        time.Duration `envconfig:"POLL_TIMEOUT" default:"30s"`
-	PollLimit                          int           `envconfig:"POLL_LIMIT" default:"10" validate:"min=1,max=100"`
-	CollectorWindowSize                int           `envconfig:"COLLECTOR_WINDOW_SIZE" default:"60" validate:"min=1"`
-	CPUUsageSnapshotInterval           time.Duration `envconfig:"CPU_USAGE_SNAPSHOT_INTERVAL" default:"5s" validate:"min=1s"`
-	AllocatedResourcesSnapshotInterval time.Duration `envconfig:"ALLOCATED_RESOURCES_SNAPSHOT_INTERVAL" default:"5s" validate:"min=1s"`
-	HealthcheckInterval                time.Duration `envconfig:"HEALTHCHECK_INTERVAL" default:"30s" validate:"min=10s"`
-	HealthcheckTimeout                 time.Duration `envconfig:"HEALTHCHECK_TIMEOUT" default:"10s"`
-	BackupTimeoutMin                   int           `envconfig:"BACKUP_TIMEOUT_MIN" default:"60" validate:"min=1"`
-	SnapshotPullTimeout                time.Duration `envconfig:"SNAPSHOT_PULL_TIMEOUT" default:"60m" validate:"min=1m"`
-	BuildTimeoutMin                    int           `envconfig:"BUILD_TIMEOUT_MIN" default:"120" validate:"min=1"`
-	BuildCPUCores                      int64         `envconfig:"BUILD_CPU_CORES" default:"4" validate:"min=1"`
-	BuildMemoryGB                      int64         `envconfig:"BUILD_MEMORY_GB" default:"8" validate:"min=1"`
-	ApiVersion                         int           `envconfig:"API_VERSION" default:"2"`
-	InitializeDaemonTelemetry          bool          `envconfig:"INITIALIZE_DAEMON_TELEMETRY" default:"true"`
-	SnapshotErrorCacheRetention        time.Duration `envconfig:"SNAPSHOT_ERROR_CACHE_RETENTION" default:"10m" validate:"min=5m"`
-	BuildEngine                        string        `envconfig:"BUILD_ENGINE" default:"buildkit" validate:"oneof=buildkit legacy"`
-	ForceSnapshotRemoval               bool          `envconfig:"FORCE_SNAPSHOT_REMOVAL" default:"true"`
-	MountKvmToAndroidSandbox           bool          `envconfig:"MOUNT_KVM_TO_ANDROID_SANDBOX" default:"false"`
+	DaytonaApiUrl                         string        `envconfig:"DAYTONA_API_URL"`
+	ApiToken                              string        `envconfig:"DAYTONA_RUNNER_TOKEN"`
+	ApiPort                               int           `envconfig:"API_PORT"`
+	ApiLogRequests                        bool          `envconfig:"API_LOG_REQUESTS" default:"false"`
+	TLSCertFile                           string        `envconfig:"TLS_CERT_FILE"`
+	TLSKeyFile                            string        `envconfig:"TLS_KEY_FILE"`
+	EnableTLS                             bool          `envconfig:"ENABLE_TLS"`
+	OtelLoggingEnabled                    bool          `envconfig:"OTEL_LOGGING_ENABLED"`
+	OtelTracingEnabled                    bool          `envconfig:"OTEL_TRACING_ENABLED"`
+	OtelEndpoint                          string        `envconfig:"OTEL_EXPORTER_OTLP_ENDPOINT"`
+	OtelHeaders                           string        `envconfig:"OTEL_EXPORTER_OTLP_HEADERS"`
+	BackupInfoCacheRetention              time.Duration `envconfig:"BACKUP_INFO_CACHE_RETENTION" default:"168h" validate:"min=5m"`
+	Environment                           string        `envconfig:"ENVIRONMENT"`
+	ContainerRuntime                      string        `envconfig:"CONTAINER_RUNTIME"`
+	ContainerNetwork                      string        `envconfig:"CONTAINER_NETWORK"`
+	InterSandboxNetworkEnabled            bool          `envconfig:"INTER_SANDBOX_NETWORK_ENABLED" default:"true"`
+	GpuEnabled                            bool          `envconfig:"GPU_ENABLED" default:"false"`
+	LogFilePath                           string        `envconfig:"LOG_FILE_PATH"`
+	AWSRegion                             string        `envconfig:"AWS_REGION"`
+	AWSEndpointUrl                        string        `envconfig:"AWS_ENDPOINT_URL"`
+	AWSAccessKeyId                        string        `envconfig:"AWS_ACCESS_KEY_ID"`
+	AWSSecretAccessKey                    string        `envconfig:"AWS_SECRET_ACCESS_KEY"`
+	AWSDefaultBucket                      string        `envconfig:"AWS_DEFAULT_BUCKET"`
+	ResourceLimitsDisabled                bool          `envconfig:"RESOURCE_LIMITS_DISABLED"`
+	DaemonStartTimeoutSec                 int           `envconfig:"DAEMON_START_TIMEOUT_SEC"`
+	SandboxStartTimeoutSec                int           `envconfig:"SANDBOX_START_TIMEOUT_SEC"`
+	AndroidBootTimeoutSec                 int           `envconfig:"ANDROID_BOOT_TIMEOUT_SEC"`
+	UseSnapshotEntrypoint                 bool          `envconfig:"USE_SNAPSHOT_ENTRYPOINT"`
+	Domain                                string        `envconfig:"RUNNER_DOMAIN" validate:"omitempty,hostname|ip"`
+	VolumeCleanupInterval                 time.Duration `envconfig:"VOLUME_CLEANUP_INTERVAL" default:"30s" validate:"min=10s"`
+	VolumeCleanupDryRun                   bool          `envconfig:"VOLUME_CLEANUP_DRY_RUN" default:"true"`
+	VolumeCleanupExclusionPeriod          time.Duration `envconfig:"VOLUME_CLEANUP_EXCLUSION_PERIOD" default:"120s" validate:"min=0s"`
+	PollTimeout                           time.Duration `envconfig:"POLL_TIMEOUT" default:"30s"`
+	PollLimit                             int           `envconfig:"POLL_LIMIT" default:"10" validate:"min=1,max=100"`
+	CollectorWindowSize                   int           `envconfig:"COLLECTOR_WINDOW_SIZE" default:"60" validate:"min=1"`
+	CPUUsageSnapshotInterval              time.Duration `envconfig:"CPU_USAGE_SNAPSHOT_INTERVAL" default:"5s" validate:"min=1s"`
+	AllocatedResourcesSnapshotInterval    time.Duration `envconfig:"ALLOCATED_RESOURCES_SNAPSHOT_INTERVAL" default:"5s" validate:"min=1s"`
+	SandboxFdUsageWarningThresholdPercent int           `envconfig:"SANDBOX_FD_USAGE_WARNING_THRESHOLD_PERCENT" default:"70" validate:"min=1,max=100"`
+	HealthcheckInterval                   time.Duration `envconfig:"HEALTHCHECK_INTERVAL" default:"30s" validate:"min=10s"`
+	HealthcheckTimeout                    time.Duration `envconfig:"HEALTHCHECK_TIMEOUT" default:"10s"`
+	BackupTimeoutMin                      int           `envconfig:"BACKUP_TIMEOUT_MIN" default:"60" validate:"min=1"`
+	SnapshotPullTimeout                   time.Duration `envconfig:"SNAPSHOT_PULL_TIMEOUT" default:"60m" validate:"min=1m"`
+	BuildTimeoutMin                       int           `envconfig:"BUILD_TIMEOUT_MIN" default:"120" validate:"min=1"`
+	BuildCPUCores                         int64         `envconfig:"BUILD_CPU_CORES" default:"4" validate:"min=1"`
+	BuildMemoryGB                         int64         `envconfig:"BUILD_MEMORY_GB" default:"8" validate:"min=1"`
+	ApiVersion                            int           `envconfig:"API_VERSION" default:"2"`
+	InitializeDaemonTelemetry             bool          `envconfig:"INITIALIZE_DAEMON_TELEMETRY" default:"true"`
+	SnapshotErrorCacheRetention           time.Duration `envconfig:"SNAPSHOT_ERROR_CACHE_RETENTION" default:"10m" validate:"min=5m"`
+	BuildEngine                           string        `envconfig:"BUILD_ENGINE" default:"buildkit" validate:"oneof=buildkit legacy"`
+	ForceSnapshotRemoval                  bool          `envconfig:"FORCE_SNAPSHOT_REMOVAL" default:"true"`
+	MountKvmToAndroidSandbox              bool          `envconfig:"MOUNT_KVM_TO_ANDROID_SANDBOX" default:"false"`
 }
 
 var DEFAULT_API_PORT int = 8080

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -219,11 +219,12 @@ func run() int {
 
 	// Create metrics collector
 	metricsCollector := metrics.NewCollector(metrics.CollectorConfig{
-		Logger:                             logger,
-		Docker:                             dockerClient,
-		WindowSize:                         cfg.CollectorWindowSize,
-		CPUUsageSnapshotInterval:           cfg.CPUUsageSnapshotInterval,
-		AllocatedResourcesSnapshotInterval: cfg.AllocatedResourcesSnapshotInterval,
+		Logger:                                logger,
+		Docker:                                dockerClient,
+		WindowSize:                            cfg.CollectorWindowSize,
+		CPUUsageSnapshotInterval:              cfg.CPUUsageSnapshotInterval,
+		AllocatedResourcesSnapshotInterval:    cfg.AllocatedResourcesSnapshotInterval,
+		SandboxFdUsageWarningThresholdPercent: float64(cfg.SandboxFdUsageWarningThresholdPercent),
 	})
 	metricsCollector.Start(ctx)
 

--- a/apps/runner/go.mod
+++ b/apps/runner/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/procfs v0.20.1
 	github.com/samber/slog-gin v1.20.1
 	github.com/shirou/gopsutil/v4 v4.25.12
 	github.com/swaggo/files v1.0.1
@@ -120,7 +121,6 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
-	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.10.0 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect

--- a/apps/runner/internal/metrics/collector.go
+++ b/apps/runner/internal/metrics/collector.go
@@ -32,6 +32,9 @@ type CollectorConfig struct {
 	WindowSize                         int
 	CPUUsageSnapshotInterval           time.Duration
 	AllocatedResourcesSnapshotInterval time.Duration
+	// SandboxFdUsageWarningThresholdPercent is the worst-process fd usage
+	// percentage at or above which a sandbox is warned about.
+	SandboxFdUsageWarningThresholdPercent float64
 }
 
 // Collector collects system metrics
@@ -52,6 +55,7 @@ type Collector struct {
 	// Per-sandbox host-side fd usage sampling (Linux only)
 	fdSamplingEnabled bool
 	lastFdSandboxIds  map[string]struct{}
+	fdWarn            *fdWarnTracker
 
 	// Intervals for snapshotting metrics in seconds
 	cpuUsageSnapshotInterval           time.Duration
@@ -90,6 +94,7 @@ func NewCollector(cfg CollectorConfig) *Collector {
 		allocatedResourcesSnapshotInterval: cfg.AllocatedResourcesSnapshotInterval,
 		fdSamplingEnabled:                  runtime.GOOS == "linux",
 		lastFdSandboxIds:                   make(map[string]struct{}),
+		fdWarn:                             newFdWarnTracker(cfg.SandboxFdUsageWarningThresholdPercent),
 	}
 }
 
@@ -301,6 +306,7 @@ func (c *Collector) snapshotAllocatedResources(ctx context.Context) {
 
 			if c.fdSamplingEnabled {
 				c.cleanupFdMetrics(seenFdSandboxIds)
+				c.fdWarn.prune(seenFdSandboxIds)
 				c.lastFdSandboxIds = seenFdSandboxIds
 			}
 
@@ -331,6 +337,24 @@ func (c *Collector) sampleContainerFdUsage(ctx context.Context, containerJSON *c
 	common.SandboxOpenFds.WithLabelValues(sandboxId).Set(float64(usage.OpenFds))
 	common.SandboxFdLimit.WithLabelValues(sandboxId).Set(float64(usage.WorstFdLimit))
 	common.SandboxFdUsagePercent.WithLabelValues(sandboxId).Set(usage.UsagePercent)
+
+	switch c.fdWarn.observe(sandboxId, usage.UsagePercent, time.Now()) {
+	case fdWarnEventWarn:
+		c.log.WarnContext(ctx, "Sandbox file descriptor usage above threshold",
+			"sandbox_id", sandboxId,
+			"open_fds", usage.OpenFds,
+			"worst_pid", usage.WorstPid,
+			"worst_open_fds", usage.WorstOpenFds,
+			"fd_limit", usage.WorstFdLimit,
+			"usage_percent", usage.UsagePercent,
+			"threshold_percent", c.fdWarn.thresholdPercent)
+	case fdWarnEventClear:
+		c.log.InfoContext(ctx, "Sandbox file descriptor usage recovered",
+			"sandbox_id", sandboxId,
+			"usage_percent", usage.UsagePercent,
+			"threshold_percent", c.fdWarn.thresholdPercent)
+	case fdWarnEventNone:
+	}
 }
 
 // cleanupFdMetrics deletes gauge label sets for sandboxes that disappeared

--- a/apps/runner/internal/metrics/collector.go
+++ b/apps/runner/internal/metrics/collector.go
@@ -355,6 +355,22 @@ func (c *Collector) sampleContainerFdUsage(ctx context.Context, containerJSON *c
 			"threshold_percent", c.fdWarn.thresholdPercent)
 	case fdWarnEventNone:
 	}
+
+	// Best-effort fd attribution for runtime helper processes (shim and
+	// friends) whenever a runtime name is present in HostConfig. dockerd
+	// backfills the default runtime name ("runc") at create, so this also
+	// runs for default-runtime containers; attribution is best-effort for
+	// any runtime. Never feeds the warning/percentage path; on failure the
+	// metric is simply absent.
+	if containerJSON.HostConfig != nil && containerJSON.HostConfig.Runtime != "" {
+		helperFds, err := sampleRuntimeHelperFds(procRoot, containerJSON.State.Pid, usage.memberPids)
+		if err != nil {
+			c.log.DebugContext(ctx, "Failed to sample runtime helper fd usage", "sandbox_id", sandboxId, "error", err)
+			common.SandboxRuntimeHelperOpenFds.DeleteLabelValues(sandboxId)
+		} else {
+			common.SandboxRuntimeHelperOpenFds.WithLabelValues(sandboxId).Set(float64(helperFds))
+		}
+	}
 }
 
 // cleanupFdMetrics deletes gauge label sets for sandboxes that disappeared
@@ -365,6 +381,7 @@ func (c *Collector) cleanupFdMetrics(seen map[string]struct{}) {
 			common.SandboxOpenFds.DeleteLabelValues(sandboxId)
 			common.SandboxFdLimit.DeleteLabelValues(sandboxId)
 			common.SandboxFdUsagePercent.DeleteLabelValues(sandboxId)
+			common.SandboxRuntimeHelperOpenFds.DeleteLabelValues(sandboxId)
 		}
 	}
 }

--- a/apps/runner/internal/metrics/collector.go
+++ b/apps/runner/internal/metrics/collector.go
@@ -11,6 +11,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -47,6 +49,10 @@ type Collector struct {
 	allocatedDiskGiB    float32
 	startedSandboxCount float32
 
+	// Per-sandbox host-side fd usage sampling (Linux only)
+	fdSamplingEnabled bool
+	lastFdSandboxIds  map[string]struct{}
+
 	// Intervals for snapshotting metrics in seconds
 	cpuUsageSnapshotInterval           time.Duration
 	allocatedResourcesSnapshotInterval time.Duration
@@ -82,11 +88,17 @@ func NewCollector(cfg CollectorConfig) *Collector {
 		cpuRing:                            ring.New(cfg.WindowSize),
 		cpuUsageSnapshotInterval:           cfg.CPUUsageSnapshotInterval,
 		allocatedResourcesSnapshotInterval: cfg.AllocatedResourcesSnapshotInterval,
+		fdSamplingEnabled:                  runtime.GOOS == "linux",
+		lastFdSandboxIds:                   make(map[string]struct{}),
 	}
 }
 
 // Start begins needed metrics collection processes
 func (c *Collector) Start(ctx context.Context) {
+	if !c.fdSamplingEnabled {
+		c.log.InfoContext(ctx, "Per-sandbox file descriptor sampling disabled", "goos", runtime.GOOS)
+	}
+
 	go c.snapshotCPUUsage(ctx)
 	go c.snapshotAllocatedResources(ctx)
 }
@@ -254,8 +266,19 @@ func (c *Collector) snapshotAllocatedResources(ctx context.Context) {
 			var totalAllocatedDiskGB float32 = 0          // Disk in GB
 			var startedSandboxCount float32 = 0           // Count of running containers
 
+			var seenFdSandboxIds map[string]struct{}
+			if c.fdSamplingEnabled {
+				seenFdSandboxIds = make(map[string]struct{})
+			}
+
 			for _, ctr := range containers {
-				cpu, memory, disk, err := c.getContainerAllocatedResources(ctx, ctr.ID)
+				containerJSON, err := c.docker.ContainerInspect(ctx, ctr.ID)
+				if err != nil {
+					c.log.WarnContext(ctx, "Failed to get allocated resources for container", "container_id", ctr.ID, "error", err)
+					continue
+				}
+
+				cpu, memory, disk, err := getContainerAllocatedResources(containerJSON)
 				if err != nil {
 					c.log.WarnContext(ctx, "Failed to get allocated resources for container", "container_id", ctr.ID, "error", err)
 					continue
@@ -270,6 +293,15 @@ func (c *Collector) snapshotAllocatedResources(ctx context.Context) {
 
 				// For disk: count all containers (running and stopped)
 				totalAllocatedDiskGB += disk
+
+				if c.fdSamplingEnabled && ctr.State == "running" && containerJSON.State != nil && containerJSON.State.Pid > 0 {
+					c.sampleContainerFdUsage(ctx, containerJSON, seenFdSandboxIds)
+				}
+			}
+
+			if c.fdSamplingEnabled {
+				c.cleanupFdMetrics(seenFdSandboxIds)
+				c.lastFdSandboxIds = seenFdSandboxIds
 			}
 
 			// Convert to original API units
@@ -283,13 +315,37 @@ func (c *Collector) snapshotAllocatedResources(ctx context.Context) {
 	}
 }
 
-func (c *Collector) getContainerAllocatedResources(ctx context.Context, containerId string) (float32, float32, float32, error) {
-	// Inspect the container to get its resource configuration
-	containerJSON, err := c.docker.ContainerInspect(ctx, containerId)
+// sampleContainerFdUsage samples host-side fd usage of a running sandbox
+// container and updates the per-sandbox Prometheus gauges. The container name
+// is the sandbox ID.
+func (c *Collector) sampleContainerFdUsage(ctx context.Context, containerJSON *container.InspectResponse, seen map[string]struct{}) {
+	sandboxId := strings.TrimPrefix(containerJSON.Name, "/")
+
+	usage, err := sampleSandboxFdUsage(procRoot, cgroupRoot, containerJSON.State.Pid)
 	if err != nil {
-		return 0, 0, 0, err
+		c.log.DebugContext(ctx, "Failed to sample sandbox fd usage", "sandbox_id", sandboxId, "error", err)
+		return
 	}
 
+	seen[sandboxId] = struct{}{}
+	common.SandboxOpenFds.WithLabelValues(sandboxId).Set(float64(usage.OpenFds))
+	common.SandboxFdLimit.WithLabelValues(sandboxId).Set(float64(usage.WorstFdLimit))
+	common.SandboxFdUsagePercent.WithLabelValues(sandboxId).Set(usage.UsagePercent)
+}
+
+// cleanupFdMetrics deletes gauge label sets for sandboxes that disappeared
+// since the previous snapshot so no stale series linger.
+func (c *Collector) cleanupFdMetrics(seen map[string]struct{}) {
+	for sandboxId := range c.lastFdSandboxIds {
+		if _, ok := seen[sandboxId]; !ok {
+			common.SandboxOpenFds.DeleteLabelValues(sandboxId)
+			common.SandboxFdLimit.DeleteLabelValues(sandboxId)
+			common.SandboxFdUsagePercent.DeleteLabelValues(sandboxId)
+		}
+	}
+}
+
+func getContainerAllocatedResources(containerJSON *container.InspectResponse) (float32, float32, float32, error) {
 	if containerJSON.HostConfig == nil {
 		return 0, 0, 0, nil
 	}
@@ -313,7 +369,7 @@ func (c *Collector) getContainerAllocatedResources(ctx context.Context, containe
 	// Disk allocation from StorageOpt (assuming xfs filesystem)
 	storageGB, err := common.ParseStorageOptSizeGB(containerJSON.HostConfig.StorageOpt)
 	if err != nil {
-		return allocatedCpu, allocatedMemory, 0, fmt.Errorf("error parsing storage quota for container %s: %v", containerId, err)
+		return allocatedCpu, allocatedMemory, 0, fmt.Errorf("error parsing storage quota for container %s: %v", containerJSON.ID, err)
 	}
 
 	if storageGB > 0 {

--- a/apps/runner/internal/metrics/collector.go
+++ b/apps/runner/internal/metrics/collector.go
@@ -327,13 +327,21 @@ func (c *Collector) snapshotAllocatedResources(ctx context.Context) {
 func (c *Collector) sampleContainerFdUsage(ctx context.Context, containerJSON *container.InspectResponse, seen map[string]struct{}) {
 	sandboxId := strings.TrimPrefix(containerJSON.Name, "/")
 
+	// The sandbox is present whether or not sampling succeeds below:
+	// recording it in seen up front keeps the warn tracker's rate-limit
+	// state across transient sampling failures, so recovery does not
+	// immediately re-warn.
+	seen[sandboxId] = struct{}{}
+
 	usage, err := sampleSandboxFdUsage(procRoot, cgroupRoot, containerJSON.State.Pid)
 	if err != nil {
 		c.log.DebugContext(ctx, "Failed to sample sandbox fd usage", "sandbox_id", sandboxId, "error", err)
+		// cleanupFdMetrics skips seen sandboxes, so drop this sandbox's
+		// gauges explicitly: no stale values for the failed tick.
+		deleteSandboxFdMetrics(sandboxId)
 		return
 	}
 
-	seen[sandboxId] = struct{}{}
 	common.SandboxOpenFds.WithLabelValues(sandboxId).Set(float64(usage.OpenFds))
 	common.SandboxFdLimit.WithLabelValues(sandboxId).Set(float64(usage.WorstFdLimit))
 	common.SandboxFdUsagePercent.WithLabelValues(sandboxId).Set(usage.UsagePercent)
@@ -378,12 +386,17 @@ func (c *Collector) sampleContainerFdUsage(ctx context.Context, containerJSON *c
 func (c *Collector) cleanupFdMetrics(seen map[string]struct{}) {
 	for sandboxId := range c.lastFdSandboxIds {
 		if _, ok := seen[sandboxId]; !ok {
-			common.SandboxOpenFds.DeleteLabelValues(sandboxId)
-			common.SandboxFdLimit.DeleteLabelValues(sandboxId)
-			common.SandboxFdUsagePercent.DeleteLabelValues(sandboxId)
-			common.SandboxRuntimeHelperOpenFds.DeleteLabelValues(sandboxId)
+			deleteSandboxFdMetrics(sandboxId)
 		}
 	}
+}
+
+// deleteSandboxFdMetrics drops every fd gauge label set of a sandbox.
+func deleteSandboxFdMetrics(sandboxId string) {
+	common.SandboxOpenFds.DeleteLabelValues(sandboxId)
+	common.SandboxFdLimit.DeleteLabelValues(sandboxId)
+	common.SandboxFdUsagePercent.DeleteLabelValues(sandboxId)
+	common.SandboxRuntimeHelperOpenFds.DeleteLabelValues(sandboxId)
 }
 
 func getContainerAllocatedResources(containerJSON *container.InspectResponse) (float32, float32, float32, error) {

--- a/apps/runner/internal/metrics/fd.go
+++ b/apps/runner/internal/metrics/fd.go
@@ -51,6 +51,9 @@ type SandboxFdUsage struct {
 	// percent. Processes with an unlimited RLIMIT_NOFILE contribute to OpenFds
 	// but not here, since they cannot hit EMFILE.
 	UsagePercent float64
+	// memberPids is the set of PIDs listed in cgroup.procs, used to exclude
+	// already-attributed processes from runtime-helper fd attribution.
+	memberPids map[int]struct{}
 }
 
 // sampleSandboxFdUsage samples file descriptor usage of every process in the
@@ -85,8 +88,10 @@ func sampleSandboxFdUsage(procfsRoot, cgroupfsRoot string, initPid int) (*Sandbo
 		return nil, err
 	}
 
-	usage := &SandboxFdUsage{}
+	usage := &SandboxFdUsage{memberPids: make(map[int]struct{}, len(pids))}
 	for _, pid := range pids {
+		usage.memberPids[pid] = struct{}{}
+
 		proc, err := fs.Proc(pid)
 		if err != nil {
 			continue
@@ -118,6 +123,94 @@ func sampleSandboxFdUsage(procfsRoot, cgroupfsRoot string, initPid int) (*Sandbo
 	}
 
 	return usage, nil
+}
+
+// sampleRuntimeHelperFds best-effort sums the open file descriptors of the
+// runtime helper processes (containerd-shim, conmon and friends) serving the
+// container whose init process is initPid: the helper tree is init's parent
+// and that parent's descendants, minus the processes already attributed
+// through the container cgroup. Descendants are discovered via
+// /proc/<pid>/task/<tid>/children, which requires CONFIG_PROC_CHILDREN.
+func sampleRuntimeHelperFds(procfsRoot string, initPid int, cgroupMembers map[int]struct{}) (uint64, error) {
+	fs, err := procfs.NewFS(procfsRoot)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open procfs at %s: %w", procfsRoot, err)
+	}
+
+	initProc, err := fs.Proc(initPid)
+	if err != nil {
+		return 0, fmt.Errorf("failed to access init process %d: %w", initPid, err)
+	}
+
+	stat, err := initProc.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("failed to read stat of pid %d: %w", initPid, err)
+	}
+
+	if stat.PPID <= 1 {
+		return 0, fmt.Errorf("init process %d has no runtime helper parent", initPid)
+	}
+
+	var total uint64
+	visited := make(map[int]struct{})
+	queue := []int{stat.PPID}
+	for len(queue) > 0 {
+		pid := queue[0]
+		queue = queue[1:]
+
+		if _, ok := visited[pid]; ok {
+			continue
+		}
+		visited[pid] = struct{}{}
+
+		// Cgroup members (and their descendants, which share the cgroup) are
+		// already attributed through sampleSandboxFdUsage.
+		if _, member := cgroupMembers[pid]; member {
+			continue
+		}
+
+		if proc, err := fs.Proc(pid); err == nil {
+			if openFds, err := countOpenFds(procfsRoot, proc); err == nil {
+				total += openFds
+			}
+		}
+
+		children, err := readProcChildren(procfsRoot, pid)
+		if err != nil {
+			continue
+		}
+		queue = append(queue, children...)
+	}
+
+	return total, nil
+}
+
+// readProcChildren collects the child PIDs of a process from its
+// /proc/<pid>/task/<tid>/children files.
+func readProcChildren(procfsRoot string, pid int) ([]int, error) {
+	taskDir := filepath.Join(procfsRoot, strconv.Itoa(pid), "task")
+	tids, err := os.ReadDir(taskDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var children []int
+	for _, tid := range tids {
+		data, err := os.ReadFile(filepath.Join(taskDir, tid.Name(), "children"))
+		if err != nil {
+			continue
+		}
+
+		for _, field := range strings.Fields(string(data)) {
+			child, err := strconv.Atoi(field)
+			if err != nil {
+				continue
+			}
+			children = append(children, child)
+		}
+	}
+
+	return children, nil
 }
 
 // countOpenFds returns the number of open file descriptors of proc. On Linux

--- a/apps/runner/internal/metrics/fd.go
+++ b/apps/runner/internal/metrics/fd.go
@@ -1,0 +1,189 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package metrics
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/procfs"
+)
+
+const (
+	// procRoot and cgroupRoot are the host mount points of procfs and cgroupfs.
+	procRoot   = "/proc"
+	cgroupRoot = "/sys/fs/cgroup"
+)
+
+// fdLimitUnlimited is the value procfs reports for an "unlimited" soft RLIMIT_NOFILE.
+const fdLimitUnlimited uint64 = math.MaxUint64
+
+// SandboxFdUsage aggregates host-side file descriptor usage across all
+// processes inside a sandbox container's cgroup.
+type SandboxFdUsage struct {
+	// OpenFds is the total number of open file descriptors summed across all
+	// cgroup member processes.
+	OpenFds uint64
+	// WorstPid is the PID of the member process closest to its soft RLIMIT_NOFILE.
+	WorstPid int
+	// WorstOpenFds is the number of open file descriptors of the worst process.
+	WorstOpenFds uint64
+	// WorstFdLimit is the soft RLIMIT_NOFILE of the worst process.
+	WorstFdLimit uint64
+	// UsagePercent is the highest open/limit ratio among member processes, in
+	// percent. Processes with an unlimited RLIMIT_NOFILE contribute to OpenFds
+	// but not here, since they cannot hit EMFILE.
+	UsagePercent float64
+}
+
+// sampleSandboxFdUsage samples file descriptor usage of every process in the
+// cgroup of the container whose init process is initPid: the init's cgroup is
+// resolved from /proc/<pid>/cgroup, member PIDs are read from cgroup.procs,
+// and each member contributes its open fd count and soft RLIMIT_NOFILE.
+// Member PIDs that disappear between the cgroup.procs read and per-process
+// sampling are skipped (benign race).
+func sampleSandboxFdUsage(procfsRoot, cgroupfsRoot string, initPid int) (*SandboxFdUsage, error) {
+	fs, err := procfs.NewFS(procfsRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open procfs at %s: %w", procfsRoot, err)
+	}
+
+	initProc, err := fs.Proc(initPid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to access init process %d: %w", initPid, err)
+	}
+
+	cgroups, err := initProc.Cgroups()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cgroups of pid %d: %w", initPid, err)
+	}
+
+	cgroupDir, err := resolveCgroupDir(cgroups, cgroupfsRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	pids, err := readCgroupProcs(filepath.Join(cgroupDir, "cgroup.procs"))
+	if err != nil {
+		return nil, err
+	}
+
+	usage := &SandboxFdUsage{}
+	for _, pid := range pids {
+		proc, err := fs.Proc(pid)
+		if err != nil {
+			continue
+		}
+
+		openFds, err := countOpenFds(procfsRoot, proc)
+		if err != nil {
+			continue
+		}
+
+		limits, err := proc.Limits()
+		if err != nil {
+			continue
+		}
+
+		usage.OpenFds += openFds
+
+		if limits.OpenFiles == 0 || limits.OpenFiles == fdLimitUnlimited {
+			continue
+		}
+
+		percent := float64(openFds) / float64(limits.OpenFiles) * 100
+		if usage.WorstPid == 0 || percent > usage.UsagePercent {
+			usage.WorstPid = pid
+			usage.WorstOpenFds = openFds
+			usage.WorstFdLimit = limits.OpenFiles
+			usage.UsagePercent = percent
+		}
+	}
+
+	return usage, nil
+}
+
+// countOpenFds returns the number of open file descriptors of proc. On Linux
+// it delegates to procfs, which stats /proc/<pid>/fd (the kernel reports the
+// entry count as the directory size since v6.2) and otherwise falls back to a
+// single Readdirnames pass. On other platforms (unit tests over fake /proc
+// trees) procfs mistakes the fake tree for a real procfs and would return the
+// directory byte size, so the entries are counted directly.
+func countOpenFds(procfsRoot string, proc procfs.Proc) (uint64, error) {
+	if runtime.GOOS == "linux" {
+		openFds, err := proc.FileDescriptorsLen()
+		if err != nil {
+			return 0, err
+		}
+		return uint64(openFds), nil
+	}
+
+	dir, err := os.Open(filepath.Join(procfsRoot, strconv.Itoa(proc.PID), "fd"))
+	if err != nil {
+		return 0, err
+	}
+	defer dir.Close()
+
+	names, err := dir.Readdirnames(-1)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(len(names)), nil
+}
+
+// resolveCgroupDir maps /proc/<pid>/cgroup entries to the cgroupfs directory
+// holding the process. The cgroup v2 unified hierarchy (HierarchyID 0) is
+// preferred; on cgroup v1 the hierarchy holding the pids controller is used.
+func resolveCgroupDir(cgroups []procfs.Cgroup, cgroupfsRoot string) (string, error) {
+	for _, cg := range cgroups {
+		if cg.HierarchyID == 0 {
+			return filepath.Join(cgroupfsRoot, cg.Path), nil
+		}
+	}
+
+	for _, cg := range cgroups {
+		for _, controller := range cg.Controllers {
+			if controller == "pids" {
+				return filepath.Join(cgroupfsRoot, "pids", cg.Path), nil
+			}
+		}
+	}
+
+	return "", errors.New("no unified or pids cgroup hierarchy found")
+}
+
+// readCgroupProcs parses a cgroup.procs file into its member PIDs.
+func readCgroupProcs(path string) ([]int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var pids []int
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		pid, err := strconv.Atoi(line)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse pid %q in %s: %w", line, path, err)
+		}
+
+		pids = append(pids, pid)
+	}
+
+	return pids, scanner.Err()
+}

--- a/apps/runner/internal/metrics/fd.go
+++ b/apps/runner/internal/metrics/fd.go
@@ -25,7 +25,8 @@ const (
 
 	// fdWarnClearMarginPercent is the hysteresis band below the warning
 	// threshold: a warned sandbox must drop more than this many percentage
-	// points below the threshold before its warning state clears.
+	// points below the threshold before its warning state clears (see
+	// fdWarnTracker.clearFloor for thresholds at or below the margin).
 	fdWarnClearMarginPercent = 5.0
 	// fdRewarnInterval is how long a sandbox staying above the threshold is
 	// kept silent after a warning before it is warned about again.
@@ -102,12 +103,15 @@ func sampleSandboxFdUsage(procfsRoot, cgroupfsRoot string, initPid int) (*Sandbo
 			continue
 		}
 
+		// The fd count is valid on its own: it always feeds the sum, and
+		// only the limit/percentage update below depends on a readable
+		// limits file.
+		usage.OpenFds += openFds
+
 		limits, err := proc.Limits()
 		if err != nil {
 			continue
 		}
-
-		usage.OpenFds += openFds
 
 		if limits.OpenFiles == 0 || limits.OpenFiles == fdLimitUnlimited {
 			continue
@@ -311,8 +315,8 @@ type fdWarnState struct {
 // fdWarnTracker rate-limits per-sandbox fd usage warnings: a sandbox is
 // warned about when its usage crosses thresholdPercent, re-warned at most
 // every fdRewarnInterval while it stays above, and re-armed only after usage
-// drops below thresholdPercent-fdWarnClearMarginPercent (hysteresis), so
-// usage oscillating around the threshold cannot spam the log.
+// drops below the clearFloor hysteresis band, so usage oscillating around
+// the threshold cannot spam the log.
 type fdWarnTracker struct {
 	thresholdPercent float64
 	states           map[string]*fdWarnState
@@ -343,12 +347,25 @@ func (t *fdWarnTracker) observe(sandboxId string, percent float64, now time.Time
 		return fdWarnEventNone
 	}
 
-	if state != nil && state.active && percent < t.thresholdPercent-fdWarnClearMarginPercent {
+	if state != nil && state.active && percent < t.clearFloor() {
 		state.active = false
 		return fdWarnEventClear
 	}
 
 	return fdWarnEventNone
+}
+
+// clearFloor is the usage percentage below which a warned sandbox re-arms.
+// Normally thresholdPercent-fdWarnClearMarginPercent; for thresholds at or
+// below the margin that floor would be <= 0 and unreachable (usage is never
+// negative), so half the threshold is used instead, keeping the floor
+// reachable for every valid threshold (1-100).
+func (t *fdWarnTracker) clearFloor() float64 {
+	floor := t.thresholdPercent - fdWarnClearMarginPercent
+	if floor <= 0 {
+		floor = t.thresholdPercent / 2
+	}
+	return floor
 }
 
 // prune drops state for sandboxes absent from seen so a recreated sandbox

--- a/apps/runner/internal/metrics/fd.go
+++ b/apps/runner/internal/metrics/fd.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/prometheus/procfs"
 )
@@ -21,6 +22,14 @@ const (
 	// procRoot and cgroupRoot are the host mount points of procfs and cgroupfs.
 	procRoot   = "/proc"
 	cgroupRoot = "/sys/fs/cgroup"
+
+	// fdWarnClearMarginPercent is the hysteresis band below the warning
+	// threshold: a warned sandbox must drop more than this many percentage
+	// points below the threshold before its warning state clears.
+	fdWarnClearMarginPercent = 5.0
+	// fdRewarnInterval is how long a sandbox staying above the threshold is
+	// kept silent after a warning before it is warned about again.
+	fdRewarnInterval = 10 * time.Minute
 )
 
 // fdLimitUnlimited is the value procfs reports for an "unlimited" soft RLIMIT_NOFILE.
@@ -186,4 +195,75 @@ func readCgroupProcs(path string) ([]int, error) {
 	}
 
 	return pids, scanner.Err()
+}
+
+// fdWarnEvent is the outcome of observing a sandbox fd usage sample.
+type fdWarnEvent int
+
+const (
+	fdWarnEventNone fdWarnEvent = iota
+	// fdWarnEventWarn fires when usage crosses the threshold, or stays above
+	// it for longer than fdRewarnInterval since the last warning.
+	fdWarnEventWarn
+	// fdWarnEventClear fires once when usage of a warned sandbox drops below
+	// the hysteresis band.
+	fdWarnEventClear
+)
+
+type fdWarnState struct {
+	active     bool
+	lastWarnAt time.Time
+}
+
+// fdWarnTracker rate-limits per-sandbox fd usage warnings: a sandbox is
+// warned about when its usage crosses thresholdPercent, re-warned at most
+// every fdRewarnInterval while it stays above, and re-armed only after usage
+// drops below thresholdPercent-fdWarnClearMarginPercent (hysteresis), so
+// usage oscillating around the threshold cannot spam the log.
+type fdWarnTracker struct {
+	thresholdPercent float64
+	states           map[string]*fdWarnState
+}
+
+func newFdWarnTracker(thresholdPercent float64) *fdWarnTracker {
+	return &fdWarnTracker{
+		thresholdPercent: thresholdPercent,
+		states:           make(map[string]*fdWarnState),
+	}
+}
+
+// observe records a usage sample for a sandbox and reports whether the caller
+// should emit a warning or a recovery notice. The clock is injected via now.
+func (t *fdWarnTracker) observe(sandboxId string, percent float64, now time.Time) fdWarnEvent {
+	state := t.states[sandboxId]
+
+	if percent >= t.thresholdPercent {
+		if state == nil {
+			t.states[sandboxId] = &fdWarnState{active: true, lastWarnAt: now}
+			return fdWarnEventWarn
+		}
+		if !state.active || now.Sub(state.lastWarnAt) >= fdRewarnInterval {
+			state.active = true
+			state.lastWarnAt = now
+			return fdWarnEventWarn
+		}
+		return fdWarnEventNone
+	}
+
+	if state != nil && state.active && percent < t.thresholdPercent-fdWarnClearMarginPercent {
+		state.active = false
+		return fdWarnEventClear
+	}
+
+	return fdWarnEventNone
+}
+
+// prune drops state for sandboxes absent from seen so a recreated sandbox
+// warns fresh.
+func (t *fdWarnTracker) prune(seen map[string]struct{}) {
+	for sandboxId := range t.states {
+		if _, ok := seen[sandboxId]; !ok {
+			delete(t.states, sandboxId)
+		}
+	}
 }

--- a/apps/runner/internal/metrics/fd_test.go
+++ b/apps/runner/internal/metrics/fd_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -213,5 +214,48 @@ func TestFdWarnTrackerPrune(t *testing.T) {
 	// A surviving sandbox keeps its rate-limit state.
 	if got := tracker.observe("kept", 80, now.Add(time.Second)); got != fdWarnEventNone {
 		t.Errorf("kept sandbox inside re-warn window: got %v, want none", got)
+	}
+}
+
+func TestSampleRuntimeHelperFds(t *testing.T) {
+	root := t.TempDir()
+	procDir := filepath.Join(root, "proc")
+
+	// Container init (pid 100) is a child of the runtime helper (pid 50) and
+	// a cgroup member: its fds must not be attributed to the helper.
+	writeFile(t, filepath.Join(procDir, "100", "stat"), "100 (init) S 50"+strings.Repeat(" 0", 40)+"\n")
+	for i := range 9 {
+		writeFile(t, filepath.Join(procDir, "100", "fd", strconv.Itoa(i)), "")
+	}
+
+	// Helper (pid 50) with 7 fds; its children are the init and a sidecar.
+	for i := range 7 {
+		writeFile(t, filepath.Join(procDir, "50", "fd", strconv.Itoa(i)), "")
+	}
+	writeFile(t, filepath.Join(procDir, "50", "task", "50", "children"), "100 51 ")
+
+	// Sidecar helper (pid 51) with 4 fds and no children file.
+	for i := range 4 {
+		writeFile(t, filepath.Join(procDir, "51", "fd", strconv.Itoa(i)), "")
+	}
+
+	total, err := sampleRuntimeHelperFds(procDir, 100, map[int]struct{}{100: {}})
+	if err != nil {
+		t.Fatalf("sampleRuntimeHelperFds: %v", err)
+	}
+	if total != 11 {
+		t.Errorf("total = %d, want 11 (7 helper + 4 sidecar, cgroup member excluded)", total)
+	}
+}
+
+func TestSampleRuntimeHelperFdsNoParent(t *testing.T) {
+	root := t.TempDir()
+	procDir := filepath.Join(root, "proc")
+
+	// Init reparented to pid 1: no helper to attribute to.
+	writeFile(t, filepath.Join(procDir, "100", "stat"), "100 (init) S 1"+strings.Repeat(" 0", 40)+"\n")
+
+	if _, err := sampleRuntimeHelperFds(procDir, 100, nil); err == nil {
+		t.Error("expected error when init has no runtime helper parent")
 	}
 }

--- a/apps/runner/internal/metrics/fd_test.go
+++ b/apps/runner/internal/metrics/fd_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/prometheus/procfs"
 )
@@ -138,4 +139,79 @@ func TestResolveCgroupDir(t *testing.T) {
 			t.Error("expected error for entries without unified or pids hierarchy")
 		}
 	})
+}
+
+func TestFdWarnTrackerHysteresis(t *testing.T) {
+	tracker := newFdWarnTracker(70)
+	now := time.Now()
+
+	if got := tracker.observe("sb", 70, now); got != fdWarnEventWarn {
+		t.Fatalf("crossing threshold: got %v, want warn", got)
+	}
+	if got := tracker.observe("sb", 67, now.Add(time.Second)); got != fdWarnEventNone {
+		t.Errorf("inside hysteresis band (65-70): got %v, want none", got)
+	}
+	if got := tracker.observe("sb", 71, now.Add(2*time.Second)); got != fdWarnEventNone {
+		t.Errorf("re-crossing threshold while active inside re-warn window: got %v, want none", got)
+	}
+	if got := tracker.observe("sb", 64, now.Add(3*time.Second)); got != fdWarnEventClear {
+		t.Errorf("dropping below band: got %v, want clear", got)
+	}
+	if got := tracker.observe("sb", 64, now.Add(4*time.Second)); got != fdWarnEventNone {
+		t.Errorf("staying below band after clear: got %v, want none", got)
+	}
+	if got := tracker.observe("sb", 70, now.Add(5*time.Second)); got != fdWarnEventWarn {
+		t.Errorf("re-crossing threshold after clear: got %v, want warn", got)
+	}
+}
+
+func TestFdWarnTrackerRewarnInterval(t *testing.T) {
+	tracker := newFdWarnTracker(70)
+	start := time.Now()
+
+	if got := tracker.observe("sb", 80, start); got != fdWarnEventWarn {
+		t.Fatalf("initial cross: got %v, want warn", got)
+	}
+
+	// Sustained usage above threshold: silent until the re-warn interval elapses.
+	for _, elapsed := range []time.Duration{time.Minute, 5 * time.Minute, fdRewarnInterval - time.Second} {
+		if got := tracker.observe("sb", 80, start.Add(elapsed)); got != fdWarnEventNone {
+			t.Errorf("at %v: got %v, want none", elapsed, got)
+		}
+	}
+
+	if got := tracker.observe("sb", 80, start.Add(fdRewarnInterval)); got != fdWarnEventWarn {
+		t.Errorf("after re-warn interval: got %v, want warn", got)
+	}
+
+	// The window restarts from the second warning: exactly one warn per window.
+	if got := tracker.observe("sb", 80, start.Add(fdRewarnInterval+9*time.Minute)); got != fdWarnEventNone {
+		t.Errorf("inside second window: got %v, want none", got)
+	}
+	if got := tracker.observe("sb", 80, start.Add(2*fdRewarnInterval)); got != fdWarnEventWarn {
+		t.Errorf("after second window: got %v, want warn", got)
+	}
+}
+
+func TestFdWarnTrackerPrune(t *testing.T) {
+	tracker := newFdWarnTracker(70)
+	now := time.Now()
+
+	if got := tracker.observe("gone", 80, now); got != fdWarnEventWarn {
+		t.Fatalf("initial cross: got %v, want warn", got)
+	}
+	if got := tracker.observe("kept", 80, now); got != fdWarnEventWarn {
+		t.Fatalf("initial cross: got %v, want warn", got)
+	}
+
+	tracker.prune(map[string]struct{}{"kept": {}})
+
+	// A recreated sandbox with the same ID warns fresh.
+	if got := tracker.observe("gone", 80, now.Add(time.Second)); got != fdWarnEventWarn {
+		t.Errorf("pruned sandbox: got %v, want warn", got)
+	}
+	// A surviving sandbox keeps its rate-limit state.
+	if got := tracker.observe("kept", 80, now.Add(time.Second)); got != fdWarnEventNone {
+		t.Errorf("kept sandbox inside re-warn window: got %v, want none", got)
+	}
 }

--- a/apps/runner/internal/metrics/fd_test.go
+++ b/apps/runner/internal/metrics/fd_test.go
@@ -1,0 +1,141 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package metrics
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/prometheus/procfs"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeProcEntry fakes /proc/<pid> with a cgroup file, a procfs-format limits
+// file, and openFds dummy entries under fd/.
+func writeProcEntry(t *testing.T, procDir string, pid int, cgroupLine string, openFds int, softFdLimit string) {
+	t.Helper()
+
+	pidDir := filepath.Join(procDir, strconv.Itoa(pid))
+	writeFile(t, filepath.Join(pidDir, "cgroup"), cgroupLine+"\n")
+	writeFile(t, filepath.Join(pidDir, "limits"),
+		"Limit                     Soft Limit           Hard Limit           Units\n"+
+			fmt.Sprintf("Max open files            %-21s%-21sfiles\n", softFdLimit, softFdLimit))
+
+	for i := range openFds {
+		writeFile(t, filepath.Join(pidDir, "fd", strconv.Itoa(i)), "")
+	}
+	if openFds == 0 {
+		if err := os.MkdirAll(filepath.Join(pidDir, "fd"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestSampleSandboxFdUsage(t *testing.T) {
+	root := t.TempDir()
+	procDir := filepath.Join(root, "proc")
+	cgroupDir := filepath.Join(root, "cgroup")
+
+	writeProcEntry(t, procDir, 100, "0::/sandbox-test", 3, "100")
+	writeProcEntry(t, procDir, 101, "0::/sandbox-test", 8, "10")
+	writeProcEntry(t, procDir, 102, "0::/sandbox-test", 5, "unlimited")
+	// PID 999 is listed in cgroup.procs but missing from /proc: exited
+	// between the cgroup.procs read and sampling, must be skipped.
+	writeFile(t, filepath.Join(cgroupDir, "sandbox-test", "cgroup.procs"), "100\n101\n102\n999\n")
+
+	usage, err := sampleSandboxFdUsage(procDir, cgroupDir, 100)
+	if err != nil {
+		t.Fatalf("sampleSandboxFdUsage: %v", err)
+	}
+
+	if usage.OpenFds != 16 {
+		t.Errorf("OpenFds = %d, want 16 (3+8+5, unlimited counts toward the sum)", usage.OpenFds)
+	}
+	if usage.UsagePercent != 80 {
+		t.Errorf("UsagePercent = %v, want 80 (worst process 101: 8/10)", usage.UsagePercent)
+	}
+	if usage.WorstPid != 101 {
+		t.Errorf("WorstPid = %d, want 101", usage.WorstPid)
+	}
+	if usage.WorstOpenFds != 8 {
+		t.Errorf("WorstOpenFds = %d, want 8", usage.WorstOpenFds)
+	}
+	if usage.WorstFdLimit != 10 {
+		t.Errorf("WorstFdLimit = %d, want 10", usage.WorstFdLimit)
+	}
+}
+
+func TestSampleSandboxFdUsageAllUnlimited(t *testing.T) {
+	root := t.TempDir()
+	procDir := filepath.Join(root, "proc")
+	cgroupDir := filepath.Join(root, "cgroup")
+
+	writeProcEntry(t, procDir, 100, "0::/sandbox-test", 4, "unlimited")
+	writeFile(t, filepath.Join(cgroupDir, "sandbox-test", "cgroup.procs"), "100\n")
+
+	usage, err := sampleSandboxFdUsage(procDir, cgroupDir, 100)
+	if err != nil {
+		t.Fatalf("sampleSandboxFdUsage: %v", err)
+	}
+
+	if usage.OpenFds != 4 {
+		t.Errorf("OpenFds = %d, want 4", usage.OpenFds)
+	}
+	if usage.UsagePercent != 0 {
+		t.Errorf("UsagePercent = %v, want 0 for unlimited-only processes", usage.UsagePercent)
+	}
+	if usage.WorstPid != 0 {
+		t.Errorf("WorstPid = %d, want 0 when no process has a finite limit", usage.WorstPid)
+	}
+}
+
+func TestResolveCgroupDir(t *testing.T) {
+	cgroupRoot := "/sys/fs/cgroup"
+
+	t.Run("v2 unified", func(t *testing.T) {
+		dir, err := resolveCgroupDir([]procfs.Cgroup{
+			{HierarchyID: 0, Path: "/system.slice/docker-x.scope"},
+		}, cgroupRoot)
+		if err != nil {
+			t.Fatalf("resolveCgroupDir: %v", err)
+		}
+		if want := "/sys/fs/cgroup/system.slice/docker-x.scope"; dir != want {
+			t.Errorf("dir = %q, want %q", dir, want)
+		}
+	})
+
+	t.Run("v1 pids controller", func(t *testing.T) {
+		dir, err := resolveCgroupDir([]procfs.Cgroup{
+			{HierarchyID: 3, Controllers: []string{"cpu", "cpuacct"}, Path: "/docker/abc"},
+			{HierarchyID: 5, Controllers: []string{"pids"}, Path: "/docker/abc"},
+		}, cgroupRoot)
+		if err != nil {
+			t.Fatalf("resolveCgroupDir: %v", err)
+		}
+		if want := "/sys/fs/cgroup/pids/docker/abc"; dir != want {
+			t.Errorf("dir = %q, want %q", dir, want)
+		}
+	})
+
+	t.Run("no usable hierarchy", func(t *testing.T) {
+		if _, err := resolveCgroupDir([]procfs.Cgroup{
+			{HierarchyID: 3, Controllers: []string{"cpu"}, Path: "/docker/abc"},
+		}, cgroupRoot); err == nil {
+			t.Error("expected error for entries without unified or pids hierarchy")
+		}
+	})
+}

--- a/apps/runner/internal/metrics/fd_test.go
+++ b/apps/runner/internal/metrics/fd_test.go
@@ -55,17 +55,23 @@ func TestSampleSandboxFdUsage(t *testing.T) {
 	writeProcEntry(t, procDir, 100, "0::/sandbox-test", 3, "100")
 	writeProcEntry(t, procDir, 101, "0::/sandbox-test", 8, "10")
 	writeProcEntry(t, procDir, 102, "0::/sandbox-test", 5, "unlimited")
+	// PID 103 has open fds but no limits file (e.g. it exited between the
+	// fd count and the limits read): the fds still count toward the sum,
+	// only the limit/percentage update is skipped.
+	for i := range 2 {
+		writeFile(t, filepath.Join(procDir, "103", "fd", strconv.Itoa(i)), "")
+	}
 	// PID 999 is listed in cgroup.procs but missing from /proc: exited
 	// between the cgroup.procs read and sampling, must be skipped.
-	writeFile(t, filepath.Join(cgroupDir, "sandbox-test", "cgroup.procs"), "100\n101\n102\n999\n")
+	writeFile(t, filepath.Join(cgroupDir, "sandbox-test", "cgroup.procs"), "100\n101\n102\n103\n999\n")
 
 	usage, err := sampleSandboxFdUsage(procDir, cgroupDir, 100)
 	if err != nil {
 		t.Fatalf("sampleSandboxFdUsage: %v", err)
 	}
 
-	if usage.OpenFds != 16 {
-		t.Errorf("OpenFds = %d, want 16 (3+8+5, unlimited counts toward the sum)", usage.OpenFds)
+	if usage.OpenFds != 18 {
+		t.Errorf("OpenFds = %d, want 18 (3+8+5+2, unlimited and missing-limits both count toward the sum)", usage.OpenFds)
 	}
 	if usage.UsagePercent != 80 {
 		t.Errorf("UsagePercent = %v, want 80 (worst process 101: 8/10)", usage.UsagePercent)
@@ -162,6 +168,27 @@ func TestFdWarnTrackerHysteresis(t *testing.T) {
 		t.Errorf("staying below band after clear: got %v, want none", got)
 	}
 	if got := tracker.observe("sb", 70, now.Add(5*time.Second)); got != fdWarnEventWarn {
+		t.Errorf("re-crossing threshold after clear: got %v, want warn", got)
+	}
+}
+
+// TestFdWarnTrackerLowThresholdClear covers thresholds at or below the clear
+// margin, where the floor falls back to threshold/2 so warnings can still
+// clear (threshold-5 would be negative and unreachable).
+func TestFdWarnTrackerLowThresholdClear(t *testing.T) {
+	tracker := newFdWarnTracker(3)
+	now := time.Now()
+
+	if got := tracker.observe("sb", 3, now); got != fdWarnEventWarn {
+		t.Fatalf("crossing threshold: got %v, want warn", got)
+	}
+	if got := tracker.observe("sb", 2, now.Add(time.Second)); got != fdWarnEventNone {
+		t.Errorf("inside hysteresis band (1.5-3): got %v, want none", got)
+	}
+	if got := tracker.observe("sb", 1, now.Add(2*time.Second)); got != fdWarnEventClear {
+		t.Errorf("dropping below band: got %v, want clear", got)
+	}
+	if got := tracker.observe("sb", 3, now.Add(3*time.Second)); got != fdWarnEventWarn {
 		t.Errorf("re-crossing threshold after clear: got %v, want warn", got)
 	}
 }

--- a/apps/runner/pkg/common/metrics.go
+++ b/apps/runner/pkg/common/metrics.go
@@ -36,4 +36,29 @@ var (
 		},
 		[]string{"operation", "status"},
 	)
+
+	// Gauges tracking per-sandbox host-side file descriptor usage
+	SandboxOpenFds = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sandbox_open_fds",
+			Help: "Total open file descriptors across the sandbox's host-side processes",
+		},
+		[]string{"sandbox_id"},
+	)
+
+	SandboxFdLimit = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sandbox_fd_limit",
+			Help: "Effective soft RLIMIT_NOFILE of the sandbox host-side process closest to its limit; 0 means every sampled process reports unlimited RLIMIT_NOFILE (dashboards must guard division by zero)",
+		},
+		[]string{"sandbox_id"},
+	)
+
+	SandboxFdUsagePercent = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sandbox_fd_usage_percent",
+			Help: "Highest per-process fd usage percentage (open/RLIMIT_NOFILE*100) among the sandbox's host-side processes",
+		},
+		[]string{"sandbox_id"},
+	)
 )

--- a/apps/runner/pkg/common/metrics.go
+++ b/apps/runner/pkg/common/metrics.go
@@ -61,4 +61,12 @@ var (
 		},
 		[]string{"sandbox_id"},
 	)
+
+	SandboxRuntimeHelperOpenFds = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sandbox_runtime_helper_open_fds",
+			Help: "Open file descriptors of the sandbox's runtime helper processes (shim and friends) outside the container cgroup",
+		},
+		[]string{"sandbox_id"},
+	)
 )


### PR DESCRIPTION
**TL;DR:** the runner now samples per-sandbox host-side file-descriptor usage on its existing 5s tick and exposes Prometheus gauges plus a rate-limited operator warning - zero API surface change.

## Description

During the fd-exhaustion incident, host-side fd budgets were exhausted while guest-side indicators looked fine; operators had no per-sandbox visibility. This PR adds it:

- Sampling rides the existing allocated-resources tick: docker init PID -> cgroup members (v1/v2) -> per-process fd counts (dirent count, no per-fd reads) + soft `RLIMIT_NOFILE`.
- Gauges on the runner's existing protected `/metrics` endpoint: `sandbox_open_fds`, `sandbox_fd_limit` (0 = every sampled process unlimited; dashboards must guard division), `sandbox_fd_usage_percent` (worst-process ratio - RLIMIT_NOFILE is per-process, so the worst process is what actually hits EMFILE), labeled by `sandbox_id`.
- Warning log when worst-process usage crosses `SANDBOX_FD_USAGE_WARNING_THRESHOLD_PERCENT` (default 70, validated 1-100), with a hysteresis band and 10m re-warn interval; recovery logs once; label sets and tracker state are pruned when sandboxes disappear.
- Transient sampling failures are NOT treated as disappearance: warn-tracker state survives error ticks (no series flapping or re-warn spam); gauges are absent for the failed tick only.
- Best-effort attribution of runtime helper processes (shim descendants outside the container cgroup) into a separate `sandbox_runtime_helper_open_fds` gauge; failures degrade to absent metrics, never errors.
- Deliberately no OpenAPI change: both spec-typed metrics consumers are untouched, so no client regen. Promoting fd data into the runner healthcheck is a follow-up decision.

Known limits: nested-cgroup sandboxes undercount (members enumerated non-recursively); reading `/proc/<pid>/fd` requires the privileges the runner already runs with.

## Review guide

Suggested order:
1. `apps/runner/internal/metrics/fd.go` - sampling math, limit parsing, worst-process computation, warn tracker (risk center: warn-state lifecycle across failure ticks and the hysteresis floor, reachable across the full 1-100 threshold range).
2. `apps/runner/internal/metrics/collector.go` - tick integration, presence-before-sampling, helper attribution gate.
3. Tests (fake /proc + cgroup trees).

No generated files.

## Commit map

| Commit | What | Why it exists |
|---|---|---|
| b988909d4 | sample per-sandbox fd usage in collector | implementation (plan) |
| b197e0a76 | threshold warning with hysteresis | implementation (plan) |
| c5aa13141 | best-effort helper-process attribution | implementation (plan) |
| 2df2ffe3e | warn state survives transient failures; hysteresis floor; undercount fix | Copilot + cubic review (3 valid findings) |

## Related PRs

Independent. Sibling fd-incident PRs: #5002 (degradedReason surfacing), #5003 (daemon shell resolution).

## Validation

- 11 unit tests against fake /proc + cgroup trees (sum/worst-process math, unlimited handling, cgroup v1/v2 resolution, hysteresis incl. threshold=3 clear, re-warn interval, prune, transient-failure survival, undercount case, helper attribution) - run on linux in a container (apps/runner does not build on darwin; netlink dependency).
- `GOOS=linux go build ./...`, `gofmt` clean, `golangci-lint` v2.6.2 zero issues, `go work sync` no drift.
- All CI checks green on 2df2ffe3e. (Earlier red runs on this PR were the golangci schema-download flake, tracked in #5007 - never a lint finding.)

Closes #4995
