### PR TITLE
fix(daemon): resolve the shell in-process and cache successful resolution

### DIFF
--- a/apps/daemon/pkg/common/get_shell.go
+++ b/apps/daemon/pkg/common/get_shell.go
@@ -42,7 +42,7 @@ func GetShell() string {
 
 // resolveShell reads the shells file at path and picks a shell by preference
 // order: /usr/bin/zsh > /bin/zsh > /usr/bin/bash > /bin/bash > $SHELL (if
-// set) > sh. The boolean reports whether the file was read successfully.
+// non-empty) > sh. The boolean reports whether the file was read successfully.
 func resolveShell(path string) (string, bool) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -69,7 +69,7 @@ func resolveShell(path string) (string, bool) {
 }
 
 func shellFallback() string {
-	if shellEnv, shellSet := os.LookupEnv("SHELL"); shellSet {
+	if shellEnv := os.Getenv("SHELL"); shellEnv != "" {
 		return shellEnv
 	}
 

--- a/apps/daemon/pkg/common/get_shell.go
+++ b/apps/daemon/pkg/common/get_shell.go
@@ -5,42 +5,71 @@ package common
 
 import (
 	"os"
-	"os/exec"
 	"strings"
-
-	"github.com/daytonaio/daemon/pkg/childreap"
+	"sync"
 )
 
+// shellsFilePath is a package-level var so tests can point resolution at a
+// temporary file.
+var shellsFilePath = "/etc/shells"
+
+var (
+	shellCacheMu sync.Mutex
+	cachedShell  string
+	shellCached  bool
+)
+
+// GetShell returns the preferred shell for the sandbox. The first successful
+// resolution (i.e. /etc/shells was readable) is cached for the daemon
+// lifetime; a failed read falls back per-call and is never cached, so a later
+// call retries the file.
 func GetShell() string {
-	cmd := exec.Command("sh", "-c", "grep '^[^#]' /etc/shells")
-	// childreap.Output (not cmd.Output) so the PID-1 reaper winning the
-	// race against cmd.Wait doesn't drop us into the err != nil branch
-	// and silently fall back to "sh" on sandboxes that actually have
-	// zsh/bash available.
-	out, exitCode, err := childreap.Output(cmd)
-	if err != nil || exitCode != 0 {
-		return "sh"
+	shellCacheMu.Lock()
+	defer shellCacheMu.Unlock()
+
+	if shellCached {
+		return cachedShell
 	}
 
-	if strings.Contains(string(out), "/usr/bin/zsh") {
-		return "/usr/bin/zsh"
+	shell, ok := resolveShell(shellsFilePath)
+	if ok {
+		cachedShell = shell
+		shellCached = true
 	}
 
-	if strings.Contains(string(out), "/bin/zsh") {
-		return "/bin/zsh"
+	return shell
+}
+
+// resolveShell reads the shells file at path and picks a shell by preference
+// order: /usr/bin/zsh > /bin/zsh > /usr/bin/bash > /bin/bash > $SHELL (if
+// set) > sh. The boolean reports whether the file was read successfully.
+func resolveShell(path string) (string, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return shellFallback(), false
 	}
 
-	if strings.Contains(string(out), "/usr/bin/bash") {
-		return "/usr/bin/bash"
+	var sb strings.Builder
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+	}
+	shells := sb.String()
+
+	for _, preferred := range []string{"/usr/bin/zsh", "/bin/zsh", "/usr/bin/bash", "/bin/bash"} {
+		if strings.Contains(shells, preferred) {
+			return preferred, true
+		}
 	}
 
-	if strings.Contains(string(out), "/bin/bash") {
-		return "/bin/bash"
-	}
+	return shellFallback(), true
+}
 
-	shellEnv, shellSet := os.LookupEnv("SHELL")
-
-	if shellSet {
+func shellFallback() string {
+	if shellEnv, shellSet := os.LookupEnv("SHELL"); shellSet {
 		return shellEnv
 	}
 

--- a/apps/daemon/pkg/common/get_shell_test.go
+++ b/apps/daemon/pkg/common/get_shell_test.go
@@ -1,0 +1,149 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeShellsFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "shells")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// unsetShellEnv unsets $SHELL for the test, restoring the original value
+// (or unset state) afterwards via t.Setenv's cleanup.
+func unsetShellEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("SHELL", "")
+	if err := os.Unsetenv("SHELL"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func resetShellCache(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		shellCacheMu.Lock()
+		defer shellCacheMu.Unlock()
+		cachedShell = ""
+		shellCached = false
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+func swapShellsFilePath(t *testing.T, path string) {
+	t.Helper()
+	original := shellsFilePath
+	shellsFilePath = path
+	t.Cleanup(func() { shellsFilePath = original })
+}
+
+func TestResolveShellPrefersZshOverBash(t *testing.T) {
+	path := writeShellsFile(t, "/bin/sh\n/bin/bash\n/usr/bin/bash\n/bin/zsh\n/usr/bin/zsh\n")
+
+	shell, ok := resolveShell(path)
+	if !ok {
+		t.Fatal("expected successful resolution")
+	}
+	if shell != "/usr/bin/zsh" {
+		t.Fatalf("expected /usr/bin/zsh, got %q", shell)
+	}
+}
+
+func TestResolveShellBashWhenNoZsh(t *testing.T) {
+	path := writeShellsFile(t, "/bin/sh\n/bin/bash\n")
+
+	shell, ok := resolveShell(path)
+	if !ok {
+		t.Fatal("expected successful resolution")
+	}
+	if shell != "/bin/bash" {
+		t.Fatalf("expected /bin/bash, got %q", shell)
+	}
+}
+
+func TestResolveShellEnvFallbackWhenNoPreferredShell(t *testing.T) {
+	t.Setenv("SHELL", "/opt/custom/fish")
+	path := writeShellsFile(t, "/bin/sh\n/opt/custom/fish\n")
+
+	shell, ok := resolveShell(path)
+	if !ok {
+		t.Fatal("expected successful resolution")
+	}
+	if shell != "/opt/custom/fish" {
+		t.Fatalf("expected /opt/custom/fish, got %q", shell)
+	}
+}
+
+func TestResolveShellShWhenFileMissingAndNoShellEnv(t *testing.T) {
+	unsetShellEnv(t)
+	path := filepath.Join(t.TempDir(), "does-not-exist")
+
+	shell, ok := resolveShell(path)
+	if ok {
+		t.Fatal("expected failed resolution for missing file")
+	}
+	if shell != "sh" {
+		t.Fatalf("expected sh, got %q", shell)
+	}
+}
+
+func TestResolveShellIgnoresCommentLines(t *testing.T) {
+	unsetShellEnv(t)
+	path := writeShellsFile(t, "# /usr/bin/zsh\n#/bin/zsh\n/bin/bash\n")
+
+	shell, ok := resolveShell(path)
+	if !ok {
+		t.Fatal("expected successful resolution")
+	}
+	if shell != "/bin/bash" {
+		t.Fatalf("expected /bin/bash, got %q", shell)
+	}
+}
+
+func TestGetShellCachesSuccessfulResolution(t *testing.T) {
+	resetShellCache(t)
+	path := writeShellsFile(t, "/usr/bin/zsh\n")
+	swapShellsFilePath(t, path)
+
+	if shell := GetShell(); shell != "/usr/bin/zsh" {
+		t.Fatalf("expected /usr/bin/zsh, got %q", shell)
+	}
+
+	// Mutate the file; the cached answer must not change.
+	if err := os.WriteFile(path, []byte("/bin/bash\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if shell := GetShell(); shell != "/usr/bin/zsh" {
+		t.Fatalf("expected cached /usr/bin/zsh, got %q", shell)
+	}
+}
+
+func TestGetShellDoesNotCacheFailedResolution(t *testing.T) {
+	resetShellCache(t)
+	unsetShellEnv(t)
+	path := filepath.Join(t.TempDir(), "shells")
+	swapShellsFilePath(t, path)
+
+	if shell := GetShell(); shell != "sh" {
+		t.Fatalf("expected sh while file is missing, got %q", shell)
+	}
+
+	// The failed read must not have been cached: once the file appears,
+	// the next call picks it up.
+	if err := os.WriteFile(path, []byte("/bin/bash\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if shell := GetShell(); shell != "/bin/bash" {
+		t.Fatalf("expected /bin/bash after file created, got %q", shell)
+	}
+}

--- a/apps/daemon/pkg/common/get_shell_test.go
+++ b/apps/daemon/pkg/common/get_shell_test.go
@@ -97,6 +97,19 @@ func TestResolveShellShWhenFileMissingAndNoShellEnv(t *testing.T) {
 	}
 }
 
+func TestResolveShellShWhenFileMissingAndEmptyShellEnv(t *testing.T) {
+	t.Setenv("SHELL", "")
+	path := filepath.Join(t.TempDir(), "does-not-exist")
+
+	shell, ok := resolveShell(path)
+	if ok {
+		t.Fatal("expected failed resolution for missing file")
+	}
+	if shell != "sh" {
+		t.Fatalf("expected sh, got %q", shell)
+	}
+}
+
 func TestResolveShellIgnoresCommentLines(t *testing.T) {
 	unsetShellEnv(t)
 	path := writeShellsFile(t, "# /usr/bin/zsh\n#/bin/zsh\n/bin/bash\n")


### PR DESCRIPTION
**TL;DR:** the daemon resolves the shell by reading `/etc/shells` in-process (no subprocess), caches a successful resolution for its lifetime, and can never return an empty shell.

## Description

Every toolbox exec, code-run, session create, and PTY spawn resolved the shell by spawning `sh -c \"grep '^[^#]' /etc/shells\"` - an extra fork+execve on the daemon's five hottest call sites, and the first thing to fail under degraded filesystem conditions (during the fd-exhaustion incident the probe died before the real command, silently downgrading users to `sh`).

Now `GetShell()`:
- reads `/etc/shells` directly and preserves the exact preference order (`/usr/bin/zsh` > `/bin/zsh` > `/usr/bin/bash` > `/bin/bash` > `$SHELL` if non-empty > `sh`);
- caches a successful resolution behind a mutex (daemon serves concurrent requests);
- never caches failure - an unreadable file falls back for that call only ($SHELL, then `sh`) and retries next call;
- never returns empty: `$SHELL` set-but-empty falls through to `sh` (review-caught edge; regression-tested).

Behavior note: a shell installed after daemon start is not picked up until restart (previously each exec re-probed). Accepted: daemon lifetime == sandbox session.

## Review guide

1. `apps/daemon/pkg/common/get_shell.go` - the whole change.
2. `get_shell_test.go` - 8 cases document the contract.

Lowest-risk PR of the six; no generated files, no API surface.

## Commit map

| Commit | What | Why it exists |
|---|---|---|
| c9ee8ef24 | in-process resolution + success-only cache | implementation (plan) |
| dac41cad9 | never return empty when /etc/shells unreadable | cubic review (valid) |

## Related PRs

Independent. Siblings from the same incident: #5001, #5002.

## Validation

- 8 unit tests: preference order, comment filtering, $SHELL fallback, missing-file fallback, empty-$SHELL regression, success cached (file mutated after first call - answer unchanged), failure not cached (file appears later - next call picks it up). Runs on darwin and in CI.
- `gofmt` clean, `golangci-lint` v2.6.2 zero issues.
- All CI checks green on dac41cad9.

Closes #4997
