### PR TITLE
ci: add code coverage reporting on pull requests

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -52,6 +52,7 @@ jobs:
           file: coverage/apps/daytona/cobertura-coverage.xml
           language: TypeScript
           label: coverage/api
+          fail-on-error: false
 
       - name: Test Python SDK with coverage
         run: |
@@ -71,6 +72,7 @@ jobs:
           file: coverage/sdk-python/coverage.xml
           language: Python
           label: coverage/sdk-python
+          fail-on-error: false
 
       - name: Test Go modules with coverage
         run: |
@@ -90,6 +92,7 @@ jobs:
           file: coverage/go-daemon/coverage.xml
           language: Go
           label: coverage/daemon
+          fail-on-error: false
 
       - name: Upload Go SDK coverage
         uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
@@ -97,6 +100,7 @@ jobs:
           file: coverage/go-sdk-go/coverage.xml
           language: Go
           label: coverage/sdk-go
+          fail-on-error: false
 
       - name: Upload CLI coverage
         uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
@@ -104,3 +108,4 @@ jobs:
           file: coverage/go-cli/coverage.xml
           language: Go
           label: coverage/cli
+          fail-on-error: false

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -1,0 +1,106 @@
+name: '[PR] Code coverage'
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  POETRY_VIRTUALENVS_IN_PROJECT: true
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+jobs:
+  coverage:
+    # Coverage uploads require code-quality write access, which fork PRs do not get
+    if: github.repository == 'daytonaio/daytona' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      code-quality: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          install-ruby: 'false'
+          install-java: 'false'
+          install-swag: 'false'
+
+      - name: Test API with coverage
+        run: |
+          yarn nx test api --coverage --coverageReporters=cobertura --coverageReporters=text-summary --skipNxCache
+          # jest emits filenames relative to apps/api; rewrite them repo-relative
+          sed -i "s|<source>.*</source>|<source>.</source>|" coverage/apps/daytona/cobertura-coverage.xml
+          sed -i "s|filename=\"|filename=\"apps/api/|g" coverage/apps/daytona/cobertura-coverage.xml
+
+      - name: Upload API coverage
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
+        with:
+          file: coverage/apps/daytona/cobertura-coverage.xml
+          language: TypeScript
+          label: coverage/api
+
+      - name: Test Python SDK with coverage
+        run: |
+          source "$(poetry env info --path)/bin/activate"
+          pip install pytest pytest-asyncio pytest-cov
+          # relative_files keeps report paths repo-relative for GitHub's file mapping
+          printf '[run]\nrelative_files = true\n' > /tmp/coveragerc
+          poetry run python -m pytest libs/sdk-python/tests/ --tb=short \
+            --ignore=libs/sdk-python/tests/test_e2e.py \
+            --cov=libs/sdk-python/src/daytona \
+            --cov-config=/tmp/coveragerc \
+            --cov-report=xml:coverage/sdk-python/coverage.xml
+
+      - name: Upload Python SDK coverage
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
+        with:
+          file: coverage/sdk-python/coverage.xml
+          language: Python
+          label: coverage/sdk-python
+
+      - name: Test Go modules with coverage
+        run: |
+          for mod in apps/daemon libs/sdk-go apps/cli; do
+            name=$(basename "$mod")
+            (cd "$mod" && go test -coverprofile=coverage.out ./...)
+            mkdir -p "coverage/go-$name"
+            (cd "$mod" && go run github.com/boumenot/gocover-cobertura@v1.5.0 < coverage.out > "$GITHUB_WORKSPACE/coverage/go-$name/coverage.xml")
+            # gocover-cobertura emits module-relative filenames; rewrite them repo-relative
+            sed -i "s|<source>.*</source>|<source>.</source>|" "coverage/go-$name/coverage.xml"
+            sed -i "s|filename=\"|filename=\"$mod/|g" "coverage/go-$name/coverage.xml"
+          done
+
+      - name: Upload daemon coverage
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
+        with:
+          file: coverage/go-daemon/coverage.xml
+          language: Go
+          label: coverage/daemon
+
+      - name: Upload Go SDK coverage
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
+        with:
+          file: coverage/go-sdk-go/coverage.xml
+          language: Go
+          label: coverage/sdk-go
+
+      - name: Upload CLI coverage
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
+        with:
+          file: coverage/go-cli/coverage.xml
+          language: Go
+          label: coverage/cli


### PR DESCRIPTION
## Description

Adds a dedicated workflow for GitHub's native code coverage on pull requests (public preview, part of GitHub Code Quality).

- Runs unit tests with coverage for the API (jest), Python SDK (pytest-cov), and the Go modules that have test suites (daemon, sdk-go, cli)
- Converts Go profiles to Cobertura via gocover-cobertura and normalizes all report paths to be repo-relative
- Uploads each report via `actions/upload-code-coverage` with per-component labels
- The `push` trigger on `main` establishes the comparison baseline; fork PRs are skipped since uploads need `code-quality: write` access

Not a required check. The PR coverage comment appears once Code Quality is enabled in repo settings; the workflow is green regardless.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

N/A

## Notes

Coverage scope is intentionally limited to components with meaningful unit test suites. Java/Ruby SDK coverage can follow once this is validated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI workflow that runs tests and uploads code coverage to GitHub Code Quality on pull requests. Covers the API, Python SDK, and Go modules with repo‑relative Cobertura reports and per-component labels.

- **New Features**
  - Tests and uploads coverage for API (`jest`), Python SDK (`pytest-cov`), and Go modules (`daemon`, `sdk-go`, `cli`).
  - Converts Go profiles to Cobertura via `gocover-cobertura` and normalizes paths to repo‑relative.
  - Uploads per-component reports with `actions/upload-code-coverage` and labels.
  - Triggers on PRs to `main`/`develop`; `push` to `main` sets the comparison baseline.
  - Requires `code-quality: write`; fork PRs are skipped.
  - Workflow stays green if Code Quality isn’t enabled (`fail-on-error: false`); coverage comment appears once enabled.

<sup>Written for commit f2f03a07e0e61f1f99a173f3f13acf736ece4c6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

