### PR TITLE
feat(api): separate sandbox state crons

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -843,7 +843,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
           const sandboxes = await this.sandboxRepository.find({
             where: {
               runnerId: runnerId === null ? IsNull() : runnerId,
-              state: Not(SandboxState.RESTORING),
+              state: Not(In([SandboxState.RESTORING, SandboxState.PULLING_SNAPSHOT, SandboxState.PENDING_BUILD])),
               pending: true,
             },
             select: ['id'],
@@ -877,9 +877,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     )
   }
 
-  // RESTORING is split out so it gets its own faster cadence and its own per-runner locks,
-  // and is not blocked by the longer-lived state syncs above.
-  @Cron(CronExpression.EVERY_5_SECONDS, { name: 'sync-restoring-states' })
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-restoring-states' })
   @TrackJobExecution()
   @WithInstrumentation()
   @LogExecution('sync-restoring-states')
@@ -900,11 +898,11 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
           const sandboxes = await this.sandboxRepository.find({
             where: {
               runnerId,
-              state: SandboxState.RESTORING,
+              state: In([SandboxState.RESTORING, SandboxState.PULLING_SNAPSHOT]),
               pending: true,
             },
             select: ['id'],
-            take: 50,
+            take: 100,
           })
 
           const pendingProcesses: Promise<void>[] = []
@@ -932,6 +930,51 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
         }
       }),
     )
+  }
+
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-pending-build-states' })
+  @TrackJobExecution()
+  @WithInstrumentation()
+  @LogExecution('sync-pending-build-states')
+  async syncPendingBuildStates(): Promise<void> {
+    const lockKey = 'sync-pending-build-states'
+    if (!(await this.redisLockProvider.lock(lockKey, 1 * 60))) {
+      return
+    }
+
+    try {
+      const sandboxes = await this.sandboxRepository.find({
+        where: {
+          state: SandboxState.PENDING_BUILD,
+          pending: true,
+        },
+        select: ['id'],
+        take: 100,
+      })
+
+      const pendingProcesses: Promise<void>[] = []
+      const concurrencyLimit = 10
+
+      for (const sandbox of sandboxes) {
+        const stateChangeLockKey = getStateChangeLockKey(sandbox.id)
+        if (await this.redisLockProvider.isLocked(stateChangeLockKey)) {
+          continue
+        }
+
+        const processPromise = this.syncInstanceState(sandbox.id)
+        pendingProcesses.push(processPromise)
+
+        if (pendingProcesses.length >= concurrencyLimit) {
+          await Promise.allSettled(pendingProcesses.splice(0, pendingProcesses.length))
+        }
+      }
+
+      if (pendingProcesses.length > 0) {
+        await Promise.allSettled(pendingProcesses)
+      }
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
   }
 
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-archived-desired-states' })


### PR DESCRIPTION
## Description

Separates the `pending_build` cron from the rest for more resilience, also moves the `pulling_snapshot` state to be processed along with `restoring`

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separated sandbox state syncing into dedicated crons to reduce contention and improve reliability. `PENDING_BUILD` now has its own cron, and `PULLING_SNAPSHOT` is processed with restoring.

- **Refactors**
  - New cron for PENDING_BUILD runs every 10s with a global lock and concurrency limit of 10 (batch size 100).
  - RESTORING cron now includes PULLING_SNAPSHOT, runs every 10s, and processes up to 100 items.
  - General pending sync now excludes RESTORING, PULLING_SNAPSHOT, and PENDING_BUILD states.

<sup>Written for commit d2892484faba7b6a982ffd8cca867a01a6cc910e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

