### PR TITLE
fix(cli): drop redundant BucketExists probes in minio client

### DIFF
--- a/apps/cli/pkg/minio/minio.go
+++ b/apps/cli/pkg/minio/minio.go
@@ -42,21 +42,10 @@ func NewClient(endpoint, accessKey, secretKey, bucket string, useSSL bool, sessi
 }
 
 func (c *Client) UploadFile(ctx context.Context, objectName string, data []byte) error {
-	exists, err := c.minioClient.BucketExists(ctx, c.bucket)
-	if err != nil {
-		return fmt.Errorf("error checking bucket existence: %w", err)
-	}
-	if !exists {
-		err = c.minioClient.MakeBucket(ctx, c.bucket, minio.MakeBucketOptions{})
-		if err != nil {
-			return fmt.Errorf("error creating bucket: %w", err)
-		}
-	}
-
 	reader := bytes.NewReader(data)
 	objectSize := int64(len(data))
 
-	_, err = c.minioClient.PutObject(ctx, c.bucket, objectName, reader, objectSize, minio.PutObjectOptions{
+	_, err := c.minioClient.PutObject(ctx, c.bucket, objectName, reader, objectSize, minio.PutObjectOptions{
 		ContentType: "application/octet-stream",
 	})
 	if err != nil {
@@ -378,14 +367,6 @@ func (c *Client) ProcessFile(ctx context.Context, filePath, orgID string, existi
 }
 
 func (c *Client) CreateDirectory(ctx context.Context, directoryPath string) error {
-	exists, err := c.minioClient.BucketExists(ctx, c.bucket)
-	if err != nil {
-		return fmt.Errorf("error checking bucket existence: %w", err)
-	}
-	if !exists {
-		return fmt.Errorf("bucket does not exist")
-	}
-
 	// Ensure the directory path ends with a slash to represent a directory
 	if !strings.HasSuffix(directoryPath, "/") {
 		directoryPath = directoryPath + "/"
@@ -394,7 +375,7 @@ func (c *Client) CreateDirectory(ctx context.Context, directoryPath string) erro
 	// Create an empty object to represent the directory
 	emptyContent := []byte{}
 	reader := bytes.NewReader(emptyContent)
-	_, err = c.minioClient.PutObject(ctx, c.bucket, directoryPath, reader, 0, minio.PutObjectOptions{
+	_, err := c.minioClient.PutObject(ctx, c.bucket, directoryPath, reader, 0, minio.PutObjectOptions{
 		ContentType: "application/directory",
 	})
 	if err != nil {


### PR DESCRIPTION
## Description

`daytona snapshot create --context` fails with `error checking bucket existence: Access Denied` since #4966 scoped the `s3:ListBucket` grant in the push-access STS policy with a `StringLike` condition on `s3:prefix`.

Root cause: the CLI's `minioClient.BucketExists()` issues an S3 `HeadBucket`, which is authorized via `s3:ListBucket` but carries **no** `s3:prefix` context key. A plain `StringLike` condition never matches a missing key, so the request hits an implicit deny.

Fix (CLI-only): remove the `BucketExists` probes in `UploadFile` and `CreateDirectory` (and the `MakeBucket` fallback, which could never succeed under scoped credentials). The bucket is provisioned by the API; uploads go straight to `PutObject`. With no `HeadBucket` issued anywhere, the existing plain `StringLike` policy works end-to-end on both MinIO and AWS, and tenant isolation is untouched.

An earlier revision of this PR also changed the policy operator to `StringLikeIfExists`; that was dropped after live testing showed it is rejected by MinIO's AssumeRole (breaking push access entirely on self-hosted) and would permit prefix-less `ListObjectsV2` cross-tenant key enumeration on AWS. See PR comments for details.

Verified: `go build`/`go vet`/`golangci-lint` clean on `apps/cli`; no `BucketExists`/`MakeBucket` references remain in `apps/cli`.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Fixes #5013

## Screenshots

N/A

## Notes

If `HeadBucket` support is ever needed for some client, it cannot be granted safely via an `IfExists` prefix condition (HeadBucket is indistinguishable from a prefix-less List at the policy layer). The correct hardening is an explicit `Deny` with `Null: {"s3:prefix": "true"}` to block missing-prefix listings, per AWS's documented pattern.
