### PR TITLE
fix(toolbox-api-client-go): allow additional properties so daemon response additions don't break clients

### DIFF
--- a/apps/daemon/internal/util/compat.go
+++ b/apps/daemon/internal/util/compat.go
@@ -1,0 +1,41 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package util
+
+import (
+	"net/http"
+
+	semver "github.com/Masterminds/semver/v3"
+)
+
+const (
+	sourceHeader = "X-Daytona-Source"
+	goSDKSource  = "sdk-go"
+
+	// First Go SDK release whose generated client tolerates unknown response
+	// fields. Keep in sync with the release that ships that client.
+	unknownFieldsTolerantMinSDKVersion = "0.188.0"
+)
+
+// ClientRejectsUnknownResponseFields reports whether the request comes from a Go
+// SDK client old enough to decode responses with a strict JSON decoder, which
+// breaks when the daemon adds new fields to a response type. Other sources, dev
+// builds, and unparseable/absent versions default to tolerant (false).
+func ClientRejectsUnknownResponseFields(header http.Header) bool {
+	if header.Get(sourceHeader) != goSDKSource {
+		return false
+	}
+	v := ExtractSdkVersionFromHeader(header)
+	if v == "" {
+		return false
+	}
+	if sv, err := semver.NewVersion(v); err == nil && sv.Major() == 0 && sv.Minor() == 0 && sv.Patch() == 0 {
+		return false
+	}
+	cmp, err := CompareVersions(v, unknownFieldsTolerantMinSDKVersion)
+	if err != nil {
+		return false
+	}
+	return *cmp < 0
+}

--- a/apps/daemon/internal/util/compat.go
+++ b/apps/daemon/internal/util/compat.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Daytona Platforms Inc.
+// Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: AGPL-3.0
 
 package util

--- a/apps/daemon/internal/util/compat_test.go
+++ b/apps/daemon/internal/util/compat_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Daytona Platforms Inc.
+// Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: AGPL-3.0
 
 package util

--- a/apps/daemon/internal/util/compat_test.go
+++ b/apps/daemon/internal/util/compat_test.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package util
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestClientRejectsUnknownResponseFields(t *testing.T) {
+	// Set so keys canonicalize as net/http does for incoming requests.
+	header := func(kv ...string) http.Header {
+		h := http.Header{}
+		for i := 0; i+1 < len(kv); i += 2 {
+			h.Set(kv[i], kv[i+1])
+		}
+		return h
+	}
+
+	tests := []struct {
+		name   string
+		header http.Header
+		want   bool
+	}{
+		{
+			name:   "no source header",
+			header: header("X-Daytona-SDK-Version", "0.1.0"),
+			want:   false,
+		},
+		{
+			name:   "non-go source",
+			header: header("X-Daytona-Source", "sdk-typescript", "X-Daytona-SDK-Version", "0.1.0"),
+			want:   false,
+		},
+		{
+			name:   "go source without version",
+			header: header("X-Daytona-Source", "sdk-go"),
+			want:   false,
+		},
+		{
+			name:   "go source dev build",
+			header: header("X-Daytona-Source", "sdk-go", "X-Daytona-SDK-Version", "v0.0.0-dev"),
+			want:   false,
+		},
+		{
+			name:   "go source below threshold",
+			header: header("X-Daytona-Source", "sdk-go", "X-Daytona-SDK-Version", "0.187.0"),
+			want:   true,
+		},
+		{
+			name:   "go source one patch below threshold",
+			header: header("X-Daytona-Source", "sdk-go", "X-Daytona-SDK-Version", "0.187.9"),
+			want:   true,
+		},
+		{
+			name:   "go source at threshold",
+			header: header("X-Daytona-Source", "sdk-go", "X-Daytona-SDK-Version", "0.188.0"),
+			want:   false,
+		},
+		{
+			name:   "go source above threshold",
+			header: header("X-Daytona-Source", "sdk-go", "X-Daytona-SDK-Version", "0.189.1"),
+			want:   false,
+		},
+		{
+			name:   "go source unparseable version",
+			header: header("X-Daytona-Source", "sdk-go", "X-Daytona-SDK-Version", "not-a-version"),
+			want:   false,
+		},
+		{
+			name:   "go source version via websocket subprotocol",
+			header: header("X-Daytona-Source", "sdk-go", "Sec-WebSocket-Protocol", "X-Daytona-SDK-Version~0.187.0"),
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClientRejectsUnknownResponseFields(tt.header); got != tt.want {
+				t.Errorf("ClientRejectsUnknownResponseFields() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/libs/toolbox-api-client-go/model_accessibility_bounds.go
+++ b/libs/toolbox-api-client-go/model_accessibility_bounds.go
@@ -23,7 +23,10 @@ type AccessibilityBounds struct {
 	Width *int32 `json:"width,omitempty"`
 	X *int32 `json:"x,omitempty"`
 	Y *int32 `json:"y,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AccessibilityBounds AccessibilityBounds
 
 // NewAccessibilityBounds instantiates a new AccessibilityBounds object
 // This constructor will assign default values to properties that have it defined,
@@ -192,7 +195,36 @@ func (o AccessibilityBounds) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Y) {
 		toSerialize["y"] = o.Y
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *AccessibilityBounds) UnmarshalJSON(data []byte) (err error) {
+	varAccessibilityBounds := _AccessibilityBounds{}
+
+	err = json.Unmarshal(data, &varAccessibilityBounds)
+
+	if err != nil {
+		return err
+	}
+
+	*o = AccessibilityBounds(varAccessibilityBounds)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "height")
+		delete(additionalProperties, "width")
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAccessibilityBounds struct {

--- a/libs/toolbox-api-client-go/model_accessibility_invoke_request.go
+++ b/libs/toolbox-api-client-go/model_accessibility_invoke_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &AccessibilityInvokeRequest{}
 type AccessibilityInvokeRequest struct {
 	Action *string `json:"action,omitempty"`
 	Id string `json:"id"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AccessibilityInvokeRequest AccessibilityInvokeRequest
@@ -115,6 +115,11 @@ func (o AccessibilityInvokeRequest) ToMap() (map[string]interface{}, error) {
 		toSerialize["action"] = o.Action
 	}
 	toSerialize["id"] = o.Id
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -142,15 +147,21 @@ func (o *AccessibilityInvokeRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varAccessibilityInvokeRequest := _AccessibilityInvokeRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAccessibilityInvokeRequest)
+	err = json.Unmarshal(data, &varAccessibilityInvokeRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AccessibilityInvokeRequest(varAccessibilityInvokeRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "action")
+		delete(additionalProperties, "id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_accessibility_node_request.go
+++ b/libs/toolbox-api-client-go/model_accessibility_node_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &AccessibilityNodeRequest{}
 // AccessibilityNodeRequest struct for AccessibilityNodeRequest
 type AccessibilityNodeRequest struct {
 	Id string `json:"id"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AccessibilityNodeRequest AccessibilityNodeRequest
@@ -79,6 +79,11 @@ func (o AccessibilityNodeRequest) MarshalJSON() ([]byte, error) {
 func (o AccessibilityNodeRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["id"] = o.Id
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *AccessibilityNodeRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varAccessibilityNodeRequest := _AccessibilityNodeRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAccessibilityNodeRequest)
+	err = json.Unmarshal(data, &varAccessibilityNodeRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AccessibilityNodeRequest(varAccessibilityNodeRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_accessibility_nodes_response.go
+++ b/libs/toolbox-api-client-go/model_accessibility_nodes_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &AccessibilityNodesResponse{}
 type AccessibilityNodesResponse struct {
 	Matches []ComputerUseAccessibilityNode `json:"matches,omitempty"`
 	Truncated *bool `json:"truncated,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AccessibilityNodesResponse AccessibilityNodesResponse
 
 // NewAccessibilityNodesResponse instantiates a new AccessibilityNodesResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o AccessibilityNodesResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Truncated) {
 		toSerialize["truncated"] = o.Truncated
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *AccessibilityNodesResponse) UnmarshalJSON(data []byte) (err error) {
+	varAccessibilityNodesResponse := _AccessibilityNodesResponse{}
+
+	err = json.Unmarshal(data, &varAccessibilityNodesResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = AccessibilityNodesResponse(varAccessibilityNodesResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "matches")
+		delete(additionalProperties, "truncated")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAccessibilityNodesResponse struct {

--- a/libs/toolbox-api-client-go/model_accessibility_set_value_request.go
+++ b/libs/toolbox-api-client-go/model_accessibility_set_value_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &AccessibilitySetValueRequest{}
 type AccessibilitySetValueRequest struct {
 	Id string `json:"id"`
 	Value *string `json:"value,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AccessibilitySetValueRequest AccessibilitySetValueRequest
@@ -115,6 +115,11 @@ func (o AccessibilitySetValueRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Value) {
 		toSerialize["value"] = o.Value
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -142,15 +147,21 @@ func (o *AccessibilitySetValueRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varAccessibilitySetValueRequest := _AccessibilitySetValueRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAccessibilitySetValueRequest)
+	err = json.Unmarshal(data, &varAccessibilitySetValueRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AccessibilitySetValueRequest(varAccessibilitySetValueRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "value")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_accessibility_tree_response.go
+++ b/libs/toolbox-api-client-go/model_accessibility_tree_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &AccessibilityTreeResponse{}
 type AccessibilityTreeResponse struct {
 	Root *ComputerUseAccessibilityNode `json:"root,omitempty"`
 	Truncated *bool `json:"truncated,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AccessibilityTreeResponse AccessibilityTreeResponse
 
 // NewAccessibilityTreeResponse instantiates a new AccessibilityTreeResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o AccessibilityTreeResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Truncated) {
 		toSerialize["truncated"] = o.Truncated
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *AccessibilityTreeResponse) UnmarshalJSON(data []byte) (err error) {
+	varAccessibilityTreeResponse := _AccessibilityTreeResponse{}
+
+	err = json.Unmarshal(data, &varAccessibilityTreeResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = AccessibilityTreeResponse(varAccessibilityTreeResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "root")
+		delete(additionalProperties, "truncated")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAccessibilityTreeResponse struct {

--- a/libs/toolbox-api-client-go/model_chart.go
+++ b/libs/toolbox-api-client-go/model_chart.go
@@ -31,7 +31,10 @@ type Chart struct {
 	YScale *string `json:"y_scale,omitempty"`
 	YTickLabels []string `json:"y_tick_labels,omitempty"`
 	YTicks []float32 `json:"y_ticks,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Chart Chart
 
 // NewChart instantiates a new Chart object
 // This constructor will assign default values to properties that have it defined,
@@ -480,7 +483,44 @@ func (o Chart) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.YTicks) {
 		toSerialize["y_ticks"] = o.YTicks
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Chart) UnmarshalJSON(data []byte) (err error) {
+	varChart := _Chart{}
+
+	err = json.Unmarshal(data, &varChart)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Chart(varChart)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "elements")
+		delete(additionalProperties, "png")
+		delete(additionalProperties, "title")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "x_label")
+		delete(additionalProperties, "x_scale")
+		delete(additionalProperties, "x_tick_labels")
+		delete(additionalProperties, "x_ticks")
+		delete(additionalProperties, "y_label")
+		delete(additionalProperties, "y_scale")
+		delete(additionalProperties, "y_tick_labels")
+		delete(additionalProperties, "y_ticks")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableChart struct {

--- a/libs/toolbox-api-client-go/model_chart_element.go
+++ b/libs/toolbox-api-client-go/model_chart_element.go
@@ -36,7 +36,10 @@ type ChartElement struct {
 	Value *string `json:"value,omitempty"`
 	XLabel *string `json:"x_label,omitempty"`
 	YLabel *string `json:"y_label,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ChartElement ChartElement
 
 // NewChartElement instantiates a new ChartElement object
 // This constructor will assign default values to properties that have it defined,
@@ -660,7 +663,49 @@ func (o ChartElement) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.YLabel) {
 		toSerialize["y_label"] = o.YLabel
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ChartElement) UnmarshalJSON(data []byte) (err error) {
+	varChartElement := _ChartElement{}
+
+	err = json.Unmarshal(data, &varChartElement)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ChartElement(varChartElement)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "angle")
+		delete(additionalProperties, "first_quartile")
+		delete(additionalProperties, "group")
+		delete(additionalProperties, "label")
+		delete(additionalProperties, "max")
+		delete(additionalProperties, "median")
+		delete(additionalProperties, "min")
+		delete(additionalProperties, "outliers")
+		delete(additionalProperties, "png")
+		delete(additionalProperties, "points")
+		delete(additionalProperties, "radius")
+		delete(additionalProperties, "third_quartile")
+		delete(additionalProperties, "title")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "value")
+		delete(additionalProperties, "x_label")
+		delete(additionalProperties, "y_label")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableChartElement struct {

--- a/libs/toolbox-api-client-go/model_code_run_artifacts.go
+++ b/libs/toolbox-api-client-go/model_code_run_artifacts.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &CodeRunArtifacts{}
 // CodeRunArtifacts struct for CodeRunArtifacts
 type CodeRunArtifacts struct {
 	Charts []Chart `json:"charts,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CodeRunArtifacts CodeRunArtifacts
 
 // NewCodeRunArtifacts instantiates a new CodeRunArtifacts object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o CodeRunArtifacts) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Charts) {
 		toSerialize["charts"] = o.Charts
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CodeRunArtifacts) UnmarshalJSON(data []byte) (err error) {
+	varCodeRunArtifacts := _CodeRunArtifacts{}
+
+	err = json.Unmarshal(data, &varCodeRunArtifacts)
+
+	if err != nil {
+		return err
+	}
+
+	*o = CodeRunArtifacts(varCodeRunArtifacts)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "charts")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCodeRunArtifacts struct {

--- a/libs/toolbox-api-client-go/model_code_run_request.go
+++ b/libs/toolbox-api-client-go/model_code_run_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -27,6 +26,7 @@ type CodeRunRequest struct {
 	// python, javascript, typescript
 	Language string `json:"language"`
 	Timeout *int32 `json:"timeout,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CodeRunRequest CodeRunRequest
@@ -215,6 +215,11 @@ func (o CodeRunRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Timeout) {
 		toSerialize["timeout"] = o.Timeout
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -243,15 +248,24 @@ func (o *CodeRunRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varCodeRunRequest := _CodeRunRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCodeRunRequest)
+	err = json.Unmarshal(data, &varCodeRunRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CodeRunRequest(varCodeRunRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "argv")
+		delete(additionalProperties, "code")
+		delete(additionalProperties, "envs")
+		delete(additionalProperties, "language")
+		delete(additionalProperties, "timeout")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_code_run_response.go
+++ b/libs/toolbox-api-client-go/model_code_run_response.go
@@ -22,7 +22,10 @@ type CodeRunResponse struct {
 	Artifacts *CodeRunArtifacts `json:"artifacts,omitempty"`
 	ExitCode *int32 `json:"exitCode,omitempty"`
 	Result *string `json:"result,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CodeRunResponse CodeRunResponse
 
 // NewCodeRunResponse instantiates a new CodeRunResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -156,7 +159,35 @@ func (o CodeRunResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Result) {
 		toSerialize["result"] = o.Result
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CodeRunResponse) UnmarshalJSON(data []byte) (err error) {
+	varCodeRunResponse := _CodeRunResponse{}
+
+	err = json.Unmarshal(data, &varCodeRunResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = CodeRunResponse(varCodeRunResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "artifacts")
+		delete(additionalProperties, "exitCode")
+		delete(additionalProperties, "result")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCodeRunResponse struct {

--- a/libs/toolbox-api-client-go/model_command.go
+++ b/libs/toolbox-api-client-go/model_command.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type Command struct {
 	Command string `json:"command"`
 	ExitCode *int32 `json:"exitCode,omitempty"`
 	Id string `json:"id"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Command Command
@@ -142,6 +142,11 @@ func (o Command) ToMap() (map[string]interface{}, error) {
 		toSerialize["exitCode"] = o.ExitCode
 	}
 	toSerialize["id"] = o.Id
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -170,15 +175,22 @@ func (o *Command) UnmarshalJSON(data []byte) (err error) {
 
 	varCommand := _Command{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCommand)
+	err = json.Unmarshal(data, &varCommand)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Command(varCommand)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "command")
+		delete(additionalProperties, "exitCode")
+		delete(additionalProperties, "id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_completion_context.go
+++ b/libs/toolbox-api-client-go/model_completion_context.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &CompletionContext{}
 type CompletionContext struct {
 	TriggerCharacter *string `json:"triggerCharacter,omitempty"`
 	TriggerKind int32 `json:"triggerKind"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CompletionContext CompletionContext
@@ -115,6 +115,11 @@ func (o CompletionContext) ToMap() (map[string]interface{}, error) {
 		toSerialize["triggerCharacter"] = o.TriggerCharacter
 	}
 	toSerialize["triggerKind"] = o.TriggerKind
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -142,15 +147,21 @@ func (o *CompletionContext) UnmarshalJSON(data []byte) (err error) {
 
 	varCompletionContext := _CompletionContext{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCompletionContext)
+	err = json.Unmarshal(data, &varCompletionContext)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CompletionContext(varCompletionContext)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "triggerCharacter")
+		delete(additionalProperties, "triggerKind")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_completion_item.go
+++ b/libs/toolbox-api-client-go/model_completion_item.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -28,6 +27,7 @@ type CompletionItem struct {
 	Kind *int32 `json:"kind,omitempty"`
 	Label string `json:"label"`
 	SortText *string `json:"sortText,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CompletionItem CompletionItem
@@ -295,6 +295,11 @@ func (o CompletionItem) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SortText) {
 		toSerialize["sortText"] = o.SortText
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -322,15 +327,26 @@ func (o *CompletionItem) UnmarshalJSON(data []byte) (err error) {
 
 	varCompletionItem := _CompletionItem{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCompletionItem)
+	err = json.Unmarshal(data, &varCompletionItem)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CompletionItem(varCompletionItem)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "detail")
+		delete(additionalProperties, "documentation")
+		delete(additionalProperties, "filterText")
+		delete(additionalProperties, "insertText")
+		delete(additionalProperties, "kind")
+		delete(additionalProperties, "label")
+		delete(additionalProperties, "sortText")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_completion_list.go
+++ b/libs/toolbox-api-client-go/model_completion_list.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &CompletionList{}
 type CompletionList struct {
 	IsIncomplete bool `json:"isIncomplete"`
 	Items []CompletionItem `json:"items"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CompletionList CompletionList
@@ -106,6 +106,11 @@ func (o CompletionList) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["isIncomplete"] = o.IsIncomplete
 	toSerialize["items"] = o.Items
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -134,15 +139,21 @@ func (o *CompletionList) UnmarshalJSON(data []byte) (err error) {
 
 	varCompletionList := _CompletionList{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCompletionList)
+	err = json.Unmarshal(data, &varCompletionList)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CompletionList(varCompletionList)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "isIncomplete")
+		delete(additionalProperties, "items")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_computer_use_accessibility_node.go
+++ b/libs/toolbox-api-client-go/model_computer_use_accessibility_node.go
@@ -27,7 +27,10 @@ type ComputerUseAccessibilityNode struct {
 	Name *string `json:"name,omitempty"`
 	Role *string `json:"role,omitempty"`
 	States []string `json:"states,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ComputerUseAccessibilityNode ComputerUseAccessibilityNode
 
 // NewComputerUseAccessibilityNode instantiates a new ComputerUseAccessibilityNode object
 // This constructor will assign default values to properties that have it defined,
@@ -336,7 +339,40 @@ func (o ComputerUseAccessibilityNode) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.States) {
 		toSerialize["states"] = o.States
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ComputerUseAccessibilityNode) UnmarshalJSON(data []byte) (err error) {
+	varComputerUseAccessibilityNode := _ComputerUseAccessibilityNode{}
+
+	err = json.Unmarshal(data, &varComputerUseAccessibilityNode)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ComputerUseAccessibilityNode(varComputerUseAccessibilityNode)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "actions")
+		delete(additionalProperties, "bounds")
+		delete(additionalProperties, "children")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "role")
+		delete(additionalProperties, "states")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableComputerUseAccessibilityNode struct {

--- a/libs/toolbox-api-client-go/model_computer_use_start_response.go
+++ b/libs/toolbox-api-client-go/model_computer_use_start_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &ComputerUseStartResponse{}
 type ComputerUseStartResponse struct {
 	Message *string `json:"message,omitempty"`
 	Status *map[string]ProcessStatus `json:"status,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ComputerUseStartResponse ComputerUseStartResponse
 
 // NewComputerUseStartResponse instantiates a new ComputerUseStartResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o ComputerUseStartResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Status) {
 		toSerialize["status"] = o.Status
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ComputerUseStartResponse) UnmarshalJSON(data []byte) (err error) {
+	varComputerUseStartResponse := _ComputerUseStartResponse{}
+
+	err = json.Unmarshal(data, &varComputerUseStartResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ComputerUseStartResponse(varComputerUseStartResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "message")
+		delete(additionalProperties, "status")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableComputerUseStartResponse struct {

--- a/libs/toolbox-api-client-go/model_computer_use_status_response.go
+++ b/libs/toolbox-api-client-go/model_computer_use_status_response.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &ComputerUseStatusResponse{}
 // ComputerUseStatusResponse struct for ComputerUseStatusResponse
 type ComputerUseStatusResponse struct {
 	Status *string `json:"status,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ComputerUseStatusResponse ComputerUseStatusResponse
 
 // NewComputerUseStatusResponse instantiates a new ComputerUseStatusResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o ComputerUseStatusResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Status) {
 		toSerialize["status"] = o.Status
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ComputerUseStatusResponse) UnmarshalJSON(data []byte) (err error) {
+	varComputerUseStatusResponse := _ComputerUseStatusResponse{}
+
+	err = json.Unmarshal(data, &varComputerUseStatusResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ComputerUseStatusResponse(varComputerUseStatusResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "status")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableComputerUseStatusResponse struct {

--- a/libs/toolbox-api-client-go/model_computer_use_stop_response.go
+++ b/libs/toolbox-api-client-go/model_computer_use_stop_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &ComputerUseStopResponse{}
 type ComputerUseStopResponse struct {
 	Message *string `json:"message,omitempty"`
 	Status *map[string]ProcessStatus `json:"status,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ComputerUseStopResponse ComputerUseStopResponse
 
 // NewComputerUseStopResponse instantiates a new ComputerUseStopResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o ComputerUseStopResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Status) {
 		toSerialize["status"] = o.Status
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ComputerUseStopResponse) UnmarshalJSON(data []byte) (err error) {
+	varComputerUseStopResponse := _ComputerUseStopResponse{}
+
+	err = json.Unmarshal(data, &varComputerUseStopResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ComputerUseStopResponse(varComputerUseStopResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "message")
+		delete(additionalProperties, "status")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableComputerUseStopResponse struct {

--- a/libs/toolbox-api-client-go/model_create_context_request.go
+++ b/libs/toolbox-api-client-go/model_create_context_request.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &CreateContextRequest{}
 type CreateContextRequest struct {
 	Cwd *string `json:"cwd,omitempty"`
 	Language *string `json:"language,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CreateContextRequest CreateContextRequest
 
 // NewCreateContextRequest instantiates a new CreateContextRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o CreateContextRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Language) {
 		toSerialize["language"] = o.Language
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CreateContextRequest) UnmarshalJSON(data []byte) (err error) {
+	varCreateContextRequest := _CreateContextRequest{}
+
+	err = json.Unmarshal(data, &varCreateContextRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = CreateContextRequest(varCreateContextRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "cwd")
+		delete(additionalProperties, "language")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCreateContextRequest struct {

--- a/libs/toolbox-api-client-go/model_create_session_request.go
+++ b/libs/toolbox-api-client-go/model_create_session_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &CreateSessionRequest{}
 // CreateSessionRequest struct for CreateSessionRequest
 type CreateSessionRequest struct {
 	SessionId string `json:"sessionId"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateSessionRequest CreateSessionRequest
@@ -79,6 +79,11 @@ func (o CreateSessionRequest) MarshalJSON() ([]byte, error) {
 func (o CreateSessionRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["sessionId"] = o.SessionId
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *CreateSessionRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateSessionRequest := _CreateSessionRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateSessionRequest)
+	err = json.Unmarshal(data, &varCreateSessionRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateSessionRequest(varCreateSessionRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "sessionId")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_display_info.go
+++ b/libs/toolbox-api-client-go/model_display_info.go
@@ -25,7 +25,10 @@ type DisplayInfo struct {
 	Width *int32 `json:"width,omitempty"`
 	X *int32 `json:"x,omitempty"`
 	Y *int32 `json:"y,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DisplayInfo DisplayInfo
 
 // NewDisplayInfo instantiates a new DisplayInfo object
 // This constructor will assign default values to properties that have it defined,
@@ -264,7 +267,38 @@ func (o DisplayInfo) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Y) {
 		toSerialize["y"] = o.Y
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DisplayInfo) UnmarshalJSON(data []byte) (err error) {
+	varDisplayInfo := _DisplayInfo{}
+
+	err = json.Unmarshal(data, &varDisplayInfo)
+
+	if err != nil {
+		return err
+	}
+
+	*o = DisplayInfo(varDisplayInfo)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "height")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "isActive")
+		delete(additionalProperties, "width")
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDisplayInfo struct {

--- a/libs/toolbox-api-client-go/model_display_info_response.go
+++ b/libs/toolbox-api-client-go/model_display_info_response.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &DisplayInfoResponse{}
 // DisplayInfoResponse struct for DisplayInfoResponse
 type DisplayInfoResponse struct {
 	Displays []DisplayInfo `json:"displays,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DisplayInfoResponse DisplayInfoResponse
 
 // NewDisplayInfoResponse instantiates a new DisplayInfoResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o DisplayInfoResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Displays) {
 		toSerialize["displays"] = o.Displays
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DisplayInfoResponse) UnmarshalJSON(data []byte) (err error) {
+	varDisplayInfoResponse := _DisplayInfoResponse{}
+
+	err = json.Unmarshal(data, &varDisplayInfoResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = DisplayInfoResponse(varDisplayInfoResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "displays")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDisplayInfoResponse struct {

--- a/libs/toolbox-api-client-go/model_execute_request.go
+++ b/libs/toolbox-api-client-go/model_execute_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -28,6 +27,7 @@ type ExecuteRequest struct {
 	Envs *map[string]string `json:"envs,omitempty"`
 	// Timeout in seconds, defaults to 10 seconds
 	Timeout *int32 `json:"timeout,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ExecuteRequest ExecuteRequest
@@ -190,6 +190,11 @@ func (o ExecuteRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Timeout) {
 		toSerialize["timeout"] = o.Timeout
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -217,15 +222,23 @@ func (o *ExecuteRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varExecuteRequest := _ExecuteRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varExecuteRequest)
+	err = json.Unmarshal(data, &varExecuteRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ExecuteRequest(varExecuteRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "command")
+		delete(additionalProperties, "cwd")
+		delete(additionalProperties, "envs")
+		delete(additionalProperties, "timeout")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_execute_response.go
+++ b/libs/toolbox-api-client-go/model_execute_response.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &ExecuteResponse{}
 type ExecuteResponse struct {
 	ExitCode *int32 `json:"exitCode,omitempty"`
 	Result string `json:"result"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ExecuteResponse ExecuteResponse
@@ -115,6 +115,11 @@ func (o ExecuteResponse) ToMap() (map[string]interface{}, error) {
 		toSerialize["exitCode"] = o.ExitCode
 	}
 	toSerialize["result"] = o.Result
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -142,15 +147,21 @@ func (o *ExecuteResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varExecuteResponse := _ExecuteResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varExecuteResponse)
+	err = json.Unmarshal(data, &varExecuteResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ExecuteResponse(varExecuteResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "exitCode")
+		delete(additionalProperties, "result")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_file_info.go
+++ b/libs/toolbox-api-client-go/model_file_info.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type FileInfo struct {
 	Owner string `json:"owner"`
 	Permissions string `json:"permissions"`
 	Size int32 `json:"size"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FileInfo FileInfo
@@ -296,6 +296,11 @@ func (o FileInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize["owner"] = o.Owner
 	toSerialize["permissions"] = o.Permissions
 	toSerialize["size"] = o.Size
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -331,15 +336,28 @@ func (o *FileInfo) UnmarshalJSON(data []byte) (err error) {
 
 	varFileInfo := _FileInfo{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFileInfo)
+	err = json.Unmarshal(data, &varFileInfo)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FileInfo(varFileInfo)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "group")
+		delete(additionalProperties, "isDir")
+		delete(additionalProperties, "modTime")
+		delete(additionalProperties, "mode")
+		delete(additionalProperties, "modifiedAt")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "owner")
+		delete(additionalProperties, "permissions")
+		delete(additionalProperties, "size")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_file_status.go
+++ b/libs/toolbox-api-client-go/model_file_status.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -25,6 +24,7 @@ type FileStatus struct {
 	Name string `json:"name"`
 	Staging Status `json:"staging"`
 	Worktree Status `json:"worktree"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FileStatus FileStatus
@@ -160,6 +160,11 @@ func (o FileStatus) ToMap() (map[string]interface{}, error) {
 	toSerialize["name"] = o.Name
 	toSerialize["staging"] = o.Staging
 	toSerialize["worktree"] = o.Worktree
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -190,15 +195,23 @@ func (o *FileStatus) UnmarshalJSON(data []byte) (err error) {
 
 	varFileStatus := _FileStatus{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFileStatus)
+	err = json.Unmarshal(data, &varFileStatus)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FileStatus(varFileStatus)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "extra")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "staging")
+		delete(additionalProperties, "worktree")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_files_download_request.go
+++ b/libs/toolbox-api-client-go/model_files_download_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &FilesDownloadRequest{}
 // FilesDownloadRequest struct for FilesDownloadRequest
 type FilesDownloadRequest struct {
 	Paths []string `json:"paths"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FilesDownloadRequest FilesDownloadRequest
@@ -79,6 +79,11 @@ func (o FilesDownloadRequest) MarshalJSON() ([]byte, error) {
 func (o FilesDownloadRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["paths"] = o.Paths
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *FilesDownloadRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varFilesDownloadRequest := _FilesDownloadRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFilesDownloadRequest)
+	err = json.Unmarshal(data, &varFilesDownloadRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FilesDownloadRequest(varFilesDownloadRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "paths")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_find_accessibility_nodes_request.go
+++ b/libs/toolbox-api-client-go/model_find_accessibility_nodes_request.go
@@ -27,7 +27,10 @@ type FindAccessibilityNodesRequest struct {
 	Role *string `json:"role,omitempty"`
 	Scope *string `json:"scope,omitempty"`
 	States []string `json:"states,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _FindAccessibilityNodesRequest FindAccessibilityNodesRequest
 
 // NewFindAccessibilityNodesRequest instantiates a new FindAccessibilityNodesRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -301,7 +304,39 @@ func (o FindAccessibilityNodesRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.States) {
 		toSerialize["states"] = o.States
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *FindAccessibilityNodesRequest) UnmarshalJSON(data []byte) (err error) {
+	varFindAccessibilityNodesRequest := _FindAccessibilityNodesRequest{}
+
+	err = json.Unmarshal(data, &varFindAccessibilityNodesRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = FindAccessibilityNodesRequest(varFindAccessibilityNodesRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "limit")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "nameMatch")
+		delete(additionalProperties, "pid")
+		delete(additionalProperties, "role")
+		delete(additionalProperties, "scope")
+		delete(additionalProperties, "states")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableFindAccessibilityNodesRequest struct {

--- a/libs/toolbox-api-client-go/model_git_add_request.go
+++ b/libs/toolbox-api-client-go/model_git_add_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type GitAddRequest struct {
 	// files to add (use . for all files)
 	Files []string `json:"files"`
 	Path string `json:"path"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitAddRequest GitAddRequest
@@ -107,6 +107,11 @@ func (o GitAddRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["files"] = o.Files
 	toSerialize["path"] = o.Path
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *GitAddRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGitAddRequest := _GitAddRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitAddRequest)
+	err = json.Unmarshal(data, &varGitAddRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitAddRequest(varGitAddRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "files")
+		delete(additionalProperties, "path")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_git_branch_request.go
+++ b/libs/toolbox-api-client-go/model_git_branch_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &GitBranchRequest{}
 type GitBranchRequest struct {
 	Name string `json:"name"`
 	Path string `json:"path"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitBranchRequest GitBranchRequest
@@ -106,6 +106,11 @@ func (o GitBranchRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
 	toSerialize["path"] = o.Path
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -134,15 +139,21 @@ func (o *GitBranchRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGitBranchRequest := _GitBranchRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitBranchRequest)
+	err = json.Unmarshal(data, &varGitBranchRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitBranchRequest(varGitBranchRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "path")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_git_checkout_request.go
+++ b/libs/toolbox-api-client-go/model_git_checkout_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &GitCheckoutRequest{}
 type GitCheckoutRequest struct {
 	Branch string `json:"branch"`
 	Path string `json:"path"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitCheckoutRequest GitCheckoutRequest
@@ -106,6 +106,11 @@ func (o GitCheckoutRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["branch"] = o.Branch
 	toSerialize["path"] = o.Path
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -134,15 +139,21 @@ func (o *GitCheckoutRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGitCheckoutRequest := _GitCheckoutRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitCheckoutRequest)
+	err = json.Unmarshal(data, &varGitCheckoutRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitCheckoutRequest(varGitCheckoutRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "branch")
+		delete(additionalProperties, "path")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_git_clone_request.go
+++ b/libs/toolbox-api-client-go/model_git_clone_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -29,6 +28,7 @@ type GitCloneRequest struct {
 	Path string `json:"path"`
 	Url string `json:"url"`
 	Username *string `json:"username,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitCloneRequest GitCloneRequest
@@ -287,6 +287,11 @@ func (o GitCloneRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Username) {
 		toSerialize["username"] = o.Username
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -315,15 +320,26 @@ func (o *GitCloneRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGitCloneRequest := _GitCloneRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitCloneRequest)
+	err = json.Unmarshal(data, &varGitCloneRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitCloneRequest(varGitCloneRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "branch")
+		delete(additionalProperties, "commit_id")
+		delete(additionalProperties, "insecure_skip_tls")
+		delete(additionalProperties, "password")
+		delete(additionalProperties, "path")
+		delete(additionalProperties, "url")
+		delete(additionalProperties, "username")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_git_commit_info.go
+++ b/libs/toolbox-api-client-go/model_git_commit_info.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type GitCommitInfo struct {
 	Hash string `json:"hash"`
 	Message string `json:"message"`
 	Timestamp string `json:"timestamp"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitCommitInfo GitCommitInfo
@@ -187,6 +187,11 @@ func (o GitCommitInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize["hash"] = o.Hash
 	toSerialize["message"] = o.Message
 	toSerialize["timestamp"] = o.Timestamp
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -218,15 +223,24 @@ func (o *GitCommitInfo) UnmarshalJSON(data []byte) (err error) {
 
 	varGitCommitInfo := _GitCommitInfo{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitCommitInfo)
+	err = json.Unmarshal(data, &varGitCommitInfo)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitCommitInfo(varGitCommitInfo)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "author")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "hash")
+		delete(additionalProperties, "message")
+		delete(additionalProperties, "timestamp")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_git_commit_request.go
+++ b/libs/toolbox-api-client-go/model_git_commit_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type GitCommitRequest struct {
 	Email string `json:"email"`
 	Message string `json:"message"`
 	Path string `json:"path"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitCommitRequest GitCommitRequest
@@ -196,6 +196,11 @@ func (o GitCommitRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize["email"] = o.Email
 	toSerialize["message"] = o.Message
 	toSerialize["path"] = o.Path
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -226,15 +231,24 @@ func (o *GitCommitRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGitCommitRequest := _GitCommitRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitCommitRequest)
+	err = json.Unmarshal(data, &varGitCommitRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitCommitRequest(varGitCommitRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "allow_empty")
+		delete(additionalProperties, "author")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "message")
+		delete(additionalProperties, "path")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_git_commit_response.go
+++ b/libs/toolbox-api-client-go/model_git_commit_response.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &GitCommitResponse{}
 // GitCommitResponse struct for GitCommitResponse
 type GitCommitResponse struct {
 	Hash string `json:"hash"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitCommitResponse GitCommitResponse
@@ -79,6 +79,11 @@ func (o GitCommitResponse) MarshalJSON() ([]byte, error) {
 func (o GitCommitResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["hash"] = o.Hash
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *GitCommitResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varGitCommitResponse := _GitCommitResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitCommitResponse)
+	err = json.Unmarshal(data, &varGitCommitResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitCommitResponse(varGitCommitResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "hash")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_git_delete_branch_request.go
+++ b/libs/toolbox-api-client-go/model_git_delete_branch_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &GitDeleteBranchRequest{}
 type GitDeleteBranchRequest struct {
 	Name string `json:"name"`
 	Path string `json:"path"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitDeleteBranchRequest GitDeleteBranchRequest
@@ -106,6 +106,11 @@ func (o GitDeleteBranchRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
 	toSerialize["path"] = o.Path
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -134,15 +139,21 @@ func (o *GitDeleteBranchRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGitDeleteBranchRequest := _GitDeleteBranchRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitDeleteBranchRequest)
+	err = json.Unmarshal(data, &varGitDeleteBranchRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitDeleteBranchRequest(varGitDeleteBranchRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "path")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_git_repo_request.go
+++ b/libs/toolbox-api-client-go/model_git_repo_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type GitRepoRequest struct {
 	Password *string `json:"password,omitempty"`
 	Path string `json:"path"`
 	Username *string `json:"username,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitRepoRequest GitRepoRequest
@@ -151,6 +151,11 @@ func (o GitRepoRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Username) {
 		toSerialize["username"] = o.Username
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -178,15 +183,22 @@ func (o *GitRepoRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGitRepoRequest := _GitRepoRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitRepoRequest)
+	err = json.Unmarshal(data, &varGitRepoRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitRepoRequest(varGitRepoRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "password")
+		delete(additionalProperties, "path")
+		delete(additionalProperties, "username")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_git_status.go
+++ b/libs/toolbox-api-client-go/model_git_status.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type GitStatus struct {
 	BranchPublished *bool `json:"branchPublished,omitempty"`
 	CurrentBranch string `json:"currentBranch"`
 	FileStatus []FileStatus `json:"fileStatus"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitStatus GitStatus
@@ -214,6 +214,11 @@ func (o GitStatus) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["currentBranch"] = o.CurrentBranch
 	toSerialize["fileStatus"] = o.FileStatus
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -242,15 +247,24 @@ func (o *GitStatus) UnmarshalJSON(data []byte) (err error) {
 
 	varGitStatus := _GitStatus{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitStatus)
+	err = json.Unmarshal(data, &varGitStatus)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitStatus(varGitStatus)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "ahead")
+		delete(additionalProperties, "behind")
+		delete(additionalProperties, "branchPublished")
+		delete(additionalProperties, "currentBranch")
+		delete(additionalProperties, "fileStatus")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_initialize_request.go
+++ b/libs/toolbox-api-client-go/model_initialize_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &InitializeRequest{}
 // InitializeRequest struct for InitializeRequest
 type InitializeRequest struct {
 	Token string `json:"token"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _InitializeRequest InitializeRequest
@@ -79,6 +79,11 @@ func (o InitializeRequest) MarshalJSON() ([]byte, error) {
 func (o InitializeRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["token"] = o.Token
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *InitializeRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varInitializeRequest := _InitializeRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varInitializeRequest)
+	err = json.Unmarshal(data, &varInitializeRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = InitializeRequest(varInitializeRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "token")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_interpreter_context.go
+++ b/libs/toolbox-api-client-go/model_interpreter_context.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type InterpreterContext struct {
 	Cwd string `json:"cwd"`
 	Id string `json:"id"`
 	Language string `json:"language"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _InterpreterContext InterpreterContext
@@ -187,6 +187,11 @@ func (o InterpreterContext) ToMap() (map[string]interface{}, error) {
 	toSerialize["cwd"] = o.Cwd
 	toSerialize["id"] = o.Id
 	toSerialize["language"] = o.Language
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -218,15 +223,24 @@ func (o *InterpreterContext) UnmarshalJSON(data []byte) (err error) {
 
 	varInterpreterContext := _InterpreterContext{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varInterpreterContext)
+	err = json.Unmarshal(data, &varInterpreterContext)
 
 	if err != nil {
 		return err
 	}
 
 	*o = InterpreterContext(varInterpreterContext)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "active")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "cwd")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "language")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_is_port_in_use_response.go
+++ b/libs/toolbox-api-client-go/model_is_port_in_use_response.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &IsPortInUseResponse{}
 // IsPortInUseResponse struct for IsPortInUseResponse
 type IsPortInUseResponse struct {
 	IsInUse *bool `json:"isInUse,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _IsPortInUseResponse IsPortInUseResponse
 
 // NewIsPortInUseResponse instantiates a new IsPortInUseResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o IsPortInUseResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.IsInUse) {
 		toSerialize["isInUse"] = o.IsInUse
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *IsPortInUseResponse) UnmarshalJSON(data []byte) (err error) {
+	varIsPortInUseResponse := _IsPortInUseResponse{}
+
+	err = json.Unmarshal(data, &varIsPortInUseResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = IsPortInUseResponse(varIsPortInUseResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "isInUse")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableIsPortInUseResponse struct {

--- a/libs/toolbox-api-client-go/model_keyboard_hotkey_request.go
+++ b/libs/toolbox-api-client-go/model_keyboard_hotkey_request.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &KeyboardHotkeyRequest{}
 type KeyboardHotkeyRequest struct {
 	// e.g., \"ctrl+c\", \"cmd+v\"
 	Keys *string `json:"keys,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _KeyboardHotkeyRequest KeyboardHotkeyRequest
 
 // NewKeyboardHotkeyRequest instantiates a new KeyboardHotkeyRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,33 @@ func (o KeyboardHotkeyRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Keys) {
 		toSerialize["keys"] = o.Keys
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *KeyboardHotkeyRequest) UnmarshalJSON(data []byte) (err error) {
+	varKeyboardHotkeyRequest := _KeyboardHotkeyRequest{}
+
+	err = json.Unmarshal(data, &varKeyboardHotkeyRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = KeyboardHotkeyRequest(varKeyboardHotkeyRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "keys")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableKeyboardHotkeyRequest struct {

--- a/libs/toolbox-api-client-go/model_keyboard_press_request.go
+++ b/libs/toolbox-api-client-go/model_keyboard_press_request.go
@@ -22,7 +22,10 @@ type KeyboardPressRequest struct {
 	Key *string `json:"key,omitempty"`
 	// ctrl, alt, shift, cmd
 	Modifiers []string `json:"modifiers,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _KeyboardPressRequest KeyboardPressRequest
 
 // NewKeyboardPressRequest instantiates a new KeyboardPressRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,34 @@ func (o KeyboardPressRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Modifiers) {
 		toSerialize["modifiers"] = o.Modifiers
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *KeyboardPressRequest) UnmarshalJSON(data []byte) (err error) {
+	varKeyboardPressRequest := _KeyboardPressRequest{}
+
+	err = json.Unmarshal(data, &varKeyboardPressRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = KeyboardPressRequest(varKeyboardPressRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "key")
+		delete(additionalProperties, "modifiers")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableKeyboardPressRequest struct {

--- a/libs/toolbox-api-client-go/model_keyboard_type_request.go
+++ b/libs/toolbox-api-client-go/model_keyboard_type_request.go
@@ -22,7 +22,10 @@ type KeyboardTypeRequest struct {
 	// milliseconds between keystrokes
 	Delay *int32 `json:"delay,omitempty"`
 	Text *string `json:"text,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _KeyboardTypeRequest KeyboardTypeRequest
 
 // NewKeyboardTypeRequest instantiates a new KeyboardTypeRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,34 @@ func (o KeyboardTypeRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Text) {
 		toSerialize["text"] = o.Text
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *KeyboardTypeRequest) UnmarshalJSON(data []byte) (err error) {
+	varKeyboardTypeRequest := _KeyboardTypeRequest{}
+
+	err = json.Unmarshal(data, &varKeyboardTypeRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = KeyboardTypeRequest(varKeyboardTypeRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "delay")
+		delete(additionalProperties, "text")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableKeyboardTypeRequest struct {

--- a/libs/toolbox-api-client-go/model_list_branch_response.go
+++ b/libs/toolbox-api-client-go/model_list_branch_response.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &ListBranchResponse{}
 // ListBranchResponse struct for ListBranchResponse
 type ListBranchResponse struct {
 	Branches []string `json:"branches"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ListBranchResponse ListBranchResponse
@@ -79,6 +79,11 @@ func (o ListBranchResponse) MarshalJSON() ([]byte, error) {
 func (o ListBranchResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["branches"] = o.Branches
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *ListBranchResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varListBranchResponse := _ListBranchResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varListBranchResponse)
+	err = json.Unmarshal(data, &varListBranchResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ListBranchResponse(varListBranchResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "branches")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_list_contexts_response.go
+++ b/libs/toolbox-api-client-go/model_list_contexts_response.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &ListContextsResponse{}
 // ListContextsResponse struct for ListContextsResponse
 type ListContextsResponse struct {
 	Contexts []InterpreterContext `json:"contexts"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ListContextsResponse ListContextsResponse
@@ -79,6 +79,11 @@ func (o ListContextsResponse) MarshalJSON() ([]byte, error) {
 func (o ListContextsResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["contexts"] = o.Contexts
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *ListContextsResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varListContextsResponse := _ListContextsResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varListContextsResponse)
+	err = json.Unmarshal(data, &varListContextsResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ListContextsResponse(varListContextsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "contexts")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_list_recordings_response.go
+++ b/libs/toolbox-api-client-go/model_list_recordings_response.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &ListRecordingsResponse{}
 // ListRecordingsResponse struct for ListRecordingsResponse
 type ListRecordingsResponse struct {
 	Recordings []Recording `json:"recordings"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ListRecordingsResponse ListRecordingsResponse
@@ -79,6 +79,11 @@ func (o ListRecordingsResponse) MarshalJSON() ([]byte, error) {
 func (o ListRecordingsResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["recordings"] = o.Recordings
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *ListRecordingsResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varListRecordingsResponse := _ListRecordingsResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varListRecordingsResponse)
+	err = json.Unmarshal(data, &varListRecordingsResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ListRecordingsResponse(varListRecordingsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "recordings")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_lsp_completion_params.go
+++ b/libs/toolbox-api-client-go/model_lsp_completion_params.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type LspCompletionParams struct {
 	PathToProject string `json:"pathToProject"`
 	Position LspPosition `json:"position"`
 	Uri string `json:"uri"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _LspCompletionParams LspCompletionParams
@@ -196,6 +196,11 @@ func (o LspCompletionParams) ToMap() (map[string]interface{}, error) {
 	toSerialize["pathToProject"] = o.PathToProject
 	toSerialize["position"] = o.Position
 	toSerialize["uri"] = o.Uri
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -226,15 +231,24 @@ func (o *LspCompletionParams) UnmarshalJSON(data []byte) (err error) {
 
 	varLspCompletionParams := _LspCompletionParams{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varLspCompletionParams)
+	err = json.Unmarshal(data, &varLspCompletionParams)
 
 	if err != nil {
 		return err
 	}
 
 	*o = LspCompletionParams(varLspCompletionParams)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "context")
+		delete(additionalProperties, "languageId")
+		delete(additionalProperties, "pathToProject")
+		delete(additionalProperties, "position")
+		delete(additionalProperties, "uri")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_lsp_document_request.go
+++ b/libs/toolbox-api-client-go/model_lsp_document_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type LspDocumentRequest struct {
 	LanguageId string `json:"languageId"`
 	PathToProject string `json:"pathToProject"`
 	Uri string `json:"uri"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _LspDocumentRequest LspDocumentRequest
@@ -133,6 +133,11 @@ func (o LspDocumentRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize["languageId"] = o.LanguageId
 	toSerialize["pathToProject"] = o.PathToProject
 	toSerialize["uri"] = o.Uri
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -162,15 +167,22 @@ func (o *LspDocumentRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varLspDocumentRequest := _LspDocumentRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varLspDocumentRequest)
+	err = json.Unmarshal(data, &varLspDocumentRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = LspDocumentRequest(varLspDocumentRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "languageId")
+		delete(additionalProperties, "pathToProject")
+		delete(additionalProperties, "uri")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_lsp_location.go
+++ b/libs/toolbox-api-client-go/model_lsp_location.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &LspLocation{}
 type LspLocation struct {
 	Range LspRange `json:"range"`
 	Uri string `json:"uri"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _LspLocation LspLocation
@@ -106,6 +106,11 @@ func (o LspLocation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["range"] = o.Range
 	toSerialize["uri"] = o.Uri
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -134,15 +139,21 @@ func (o *LspLocation) UnmarshalJSON(data []byte) (err error) {
 
 	varLspLocation := _LspLocation{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varLspLocation)
+	err = json.Unmarshal(data, &varLspLocation)
 
 	if err != nil {
 		return err
 	}
 
 	*o = LspLocation(varLspLocation)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "range")
+		delete(additionalProperties, "uri")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_lsp_position.go
+++ b/libs/toolbox-api-client-go/model_lsp_position.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &LspPosition{}
 type LspPosition struct {
 	Character int32 `json:"character"`
 	Line int32 `json:"line"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _LspPosition LspPosition
@@ -106,6 +106,11 @@ func (o LspPosition) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["character"] = o.Character
 	toSerialize["line"] = o.Line
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -134,15 +139,21 @@ func (o *LspPosition) UnmarshalJSON(data []byte) (err error) {
 
 	varLspPosition := _LspPosition{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varLspPosition)
+	err = json.Unmarshal(data, &varLspPosition)
 
 	if err != nil {
 		return err
 	}
 
 	*o = LspPosition(varLspPosition)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "character")
+		delete(additionalProperties, "line")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_lsp_range.go
+++ b/libs/toolbox-api-client-go/model_lsp_range.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &LspRange{}
 type LspRange struct {
 	End LspPosition `json:"end"`
 	Start LspPosition `json:"start"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _LspRange LspRange
@@ -106,6 +106,11 @@ func (o LspRange) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["end"] = o.End
 	toSerialize["start"] = o.Start
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -134,15 +139,21 @@ func (o *LspRange) UnmarshalJSON(data []byte) (err error) {
 
 	varLspRange := _LspRange{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varLspRange)
+	err = json.Unmarshal(data, &varLspRange)
 
 	if err != nil {
 		return err
 	}
 
 	*o = LspRange(varLspRange)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "end")
+		delete(additionalProperties, "start")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_lsp_server_request.go
+++ b/libs/toolbox-api-client-go/model_lsp_server_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &LspServerRequest{}
 type LspServerRequest struct {
 	LanguageId string `json:"languageId"`
 	PathToProject string `json:"pathToProject"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _LspServerRequest LspServerRequest
@@ -106,6 +106,11 @@ func (o LspServerRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["languageId"] = o.LanguageId
 	toSerialize["pathToProject"] = o.PathToProject
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -134,15 +139,21 @@ func (o *LspServerRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varLspServerRequest := _LspServerRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varLspServerRequest)
+	err = json.Unmarshal(data, &varLspServerRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = LspServerRequest(varLspServerRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "languageId")
+		delete(additionalProperties, "pathToProject")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_lsp_symbol.go
+++ b/libs/toolbox-api-client-go/model_lsp_symbol.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type LspSymbol struct {
 	Kind int32 `json:"kind"`
 	Location LspLocation `json:"location"`
 	Name string `json:"name"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _LspSymbol LspSymbol
@@ -133,6 +133,11 @@ func (o LspSymbol) ToMap() (map[string]interface{}, error) {
 	toSerialize["kind"] = o.Kind
 	toSerialize["location"] = o.Location
 	toSerialize["name"] = o.Name
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -162,15 +167,22 @@ func (o *LspSymbol) UnmarshalJSON(data []byte) (err error) {
 
 	varLspSymbol := _LspSymbol{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varLspSymbol)
+	err = json.Unmarshal(data, &varLspSymbol)
 
 	if err != nil {
 		return err
 	}
 
 	*o = LspSymbol(varLspSymbol)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "kind")
+		delete(additionalProperties, "location")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_match.go
+++ b/libs/toolbox-api-client-go/model_match.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type Match struct {
 	Content string `json:"content"`
 	File string `json:"file"`
 	Line int32 `json:"line"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Match Match
@@ -133,6 +133,11 @@ func (o Match) ToMap() (map[string]interface{}, error) {
 	toSerialize["content"] = o.Content
 	toSerialize["file"] = o.File
 	toSerialize["line"] = o.Line
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -162,15 +167,22 @@ func (o *Match) UnmarshalJSON(data []byte) (err error) {
 
 	varMatch := _Match{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varMatch)
+	err = json.Unmarshal(data, &varMatch)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Match(varMatch)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "content")
+		delete(additionalProperties, "file")
+		delete(additionalProperties, "line")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_mouse_click_request.go
+++ b/libs/toolbox-api-client-go/model_mouse_click_request.go
@@ -24,7 +24,10 @@ type MouseClickRequest struct {
 	Double *bool `json:"double,omitempty"`
 	X *int32 `json:"x,omitempty"`
 	Y *int32 `json:"y,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MouseClickRequest MouseClickRequest
 
 // NewMouseClickRequest instantiates a new MouseClickRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,36 @@ func (o MouseClickRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Y) {
 		toSerialize["y"] = o.Y
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MouseClickRequest) UnmarshalJSON(data []byte) (err error) {
+	varMouseClickRequest := _MouseClickRequest{}
+
+	err = json.Unmarshal(data, &varMouseClickRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = MouseClickRequest(varMouseClickRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "button")
+		delete(additionalProperties, "double")
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMouseClickRequest struct {

--- a/libs/toolbox-api-client-go/model_mouse_click_response.go
+++ b/libs/toolbox-api-client-go/model_mouse_click_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &MouseClickResponse{}
 type MouseClickResponse struct {
 	X *int32 `json:"x,omitempty"`
 	Y *int32 `json:"y,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MouseClickResponse MouseClickResponse
 
 // NewMouseClickResponse instantiates a new MouseClickResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o MouseClickResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Y) {
 		toSerialize["y"] = o.Y
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MouseClickResponse) UnmarshalJSON(data []byte) (err error) {
+	varMouseClickResponse := _MouseClickResponse{}
+
+	err = json.Unmarshal(data, &varMouseClickResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = MouseClickResponse(varMouseClickResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMouseClickResponse struct {

--- a/libs/toolbox-api-client-go/model_mouse_drag_request.go
+++ b/libs/toolbox-api-client-go/model_mouse_drag_request.go
@@ -24,7 +24,10 @@ type MouseDragRequest struct {
 	EndY *int32 `json:"endY,omitempty"`
 	StartX *int32 `json:"startX,omitempty"`
 	StartY *int32 `json:"startY,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MouseDragRequest MouseDragRequest
 
 // NewMouseDragRequest instantiates a new MouseDragRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -228,7 +231,37 @@ func (o MouseDragRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.StartY) {
 		toSerialize["startY"] = o.StartY
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MouseDragRequest) UnmarshalJSON(data []byte) (err error) {
+	varMouseDragRequest := _MouseDragRequest{}
+
+	err = json.Unmarshal(data, &varMouseDragRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = MouseDragRequest(varMouseDragRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "button")
+		delete(additionalProperties, "endX")
+		delete(additionalProperties, "endY")
+		delete(additionalProperties, "startX")
+		delete(additionalProperties, "startY")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMouseDragRequest struct {

--- a/libs/toolbox-api-client-go/model_mouse_drag_response.go
+++ b/libs/toolbox-api-client-go/model_mouse_drag_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &MouseDragResponse{}
 type MouseDragResponse struct {
 	X *int32 `json:"x,omitempty"`
 	Y *int32 `json:"y,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MouseDragResponse MouseDragResponse
 
 // NewMouseDragResponse instantiates a new MouseDragResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o MouseDragResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Y) {
 		toSerialize["y"] = o.Y
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MouseDragResponse) UnmarshalJSON(data []byte) (err error) {
+	varMouseDragResponse := _MouseDragResponse{}
+
+	err = json.Unmarshal(data, &varMouseDragResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = MouseDragResponse(varMouseDragResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMouseDragResponse struct {

--- a/libs/toolbox-api-client-go/model_mouse_move_request.go
+++ b/libs/toolbox-api-client-go/model_mouse_move_request.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &MouseMoveRequest{}
 type MouseMoveRequest struct {
 	X *int32 `json:"x,omitempty"`
 	Y *int32 `json:"y,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MouseMoveRequest MouseMoveRequest
 
 // NewMouseMoveRequest instantiates a new MouseMoveRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o MouseMoveRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Y) {
 		toSerialize["y"] = o.Y
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MouseMoveRequest) UnmarshalJSON(data []byte) (err error) {
+	varMouseMoveRequest := _MouseMoveRequest{}
+
+	err = json.Unmarshal(data, &varMouseMoveRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = MouseMoveRequest(varMouseMoveRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMouseMoveRequest struct {

--- a/libs/toolbox-api-client-go/model_mouse_position_response.go
+++ b/libs/toolbox-api-client-go/model_mouse_position_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &MousePositionResponse{}
 type MousePositionResponse struct {
 	X *int32 `json:"x,omitempty"`
 	Y *int32 `json:"y,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MousePositionResponse MousePositionResponse
 
 // NewMousePositionResponse instantiates a new MousePositionResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o MousePositionResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Y) {
 		toSerialize["y"] = o.Y
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MousePositionResponse) UnmarshalJSON(data []byte) (err error) {
+	varMousePositionResponse := _MousePositionResponse{}
+
+	err = json.Unmarshal(data, &varMousePositionResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = MousePositionResponse(varMousePositionResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMousePositionResponse struct {

--- a/libs/toolbox-api-client-go/model_mouse_scroll_request.go
+++ b/libs/toolbox-api-client-go/model_mouse_scroll_request.go
@@ -24,7 +24,10 @@ type MouseScrollRequest struct {
 	Direction *string `json:"direction,omitempty"`
 	X *int32 `json:"x,omitempty"`
 	Y *int32 `json:"y,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MouseScrollRequest MouseScrollRequest
 
 // NewMouseScrollRequest instantiates a new MouseScrollRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,36 @@ func (o MouseScrollRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Y) {
 		toSerialize["y"] = o.Y
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MouseScrollRequest) UnmarshalJSON(data []byte) (err error) {
+	varMouseScrollRequest := _MouseScrollRequest{}
+
+	err = json.Unmarshal(data, &varMouseScrollRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = MouseScrollRequest(varMouseScrollRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "direction")
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMouseScrollRequest struct {

--- a/libs/toolbox-api-client-go/model_port_list.go
+++ b/libs/toolbox-api-client-go/model_port_list.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &PortList{}
 // PortList struct for PortList
 type PortList struct {
 	Ports []int32 `json:"ports,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PortList PortList
 
 // NewPortList instantiates a new PortList object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o PortList) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Ports) {
 		toSerialize["ports"] = o.Ports
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PortList) UnmarshalJSON(data []byte) (err error) {
+	varPortList := _PortList{}
+
+	err = json.Unmarshal(data, &varPortList)
+
+	if err != nil {
+		return err
+	}
+
+	*o = PortList(varPortList)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "ports")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePortList struct {

--- a/libs/toolbox-api-client-go/model_position.go
+++ b/libs/toolbox-api-client-go/model_position.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &Position{}
 type Position struct {
 	X *int32 `json:"x,omitempty"`
 	Y *int32 `json:"y,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Position Position
 
 // NewPosition instantiates a new Position object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o Position) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Y) {
 		toSerialize["y"] = o.Y
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Position) UnmarshalJSON(data []byte) (err error) {
+	varPosition := _Position{}
+
+	err = json.Unmarshal(data, &varPosition)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Position(varPosition)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePosition struct {

--- a/libs/toolbox-api-client-go/model_process_errors_response.go
+++ b/libs/toolbox-api-client-go/model_process_errors_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &ProcessErrorsResponse{}
 type ProcessErrorsResponse struct {
 	Errors *string `json:"errors,omitempty"`
 	ProcessName *string `json:"processName,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ProcessErrorsResponse ProcessErrorsResponse
 
 // NewProcessErrorsResponse instantiates a new ProcessErrorsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o ProcessErrorsResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ProcessName) {
 		toSerialize["processName"] = o.ProcessName
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ProcessErrorsResponse) UnmarshalJSON(data []byte) (err error) {
+	varProcessErrorsResponse := _ProcessErrorsResponse{}
+
+	err = json.Unmarshal(data, &varProcessErrorsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ProcessErrorsResponse(varProcessErrorsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "errors")
+		delete(additionalProperties, "processName")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableProcessErrorsResponse struct {

--- a/libs/toolbox-api-client-go/model_process_logs_response.go
+++ b/libs/toolbox-api-client-go/model_process_logs_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &ProcessLogsResponse{}
 type ProcessLogsResponse struct {
 	Logs *string `json:"logs,omitempty"`
 	ProcessName *string `json:"processName,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ProcessLogsResponse ProcessLogsResponse
 
 // NewProcessLogsResponse instantiates a new ProcessLogsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o ProcessLogsResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ProcessName) {
 		toSerialize["processName"] = o.ProcessName
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ProcessLogsResponse) UnmarshalJSON(data []byte) (err error) {
+	varProcessLogsResponse := _ProcessLogsResponse{}
+
+	err = json.Unmarshal(data, &varProcessLogsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ProcessLogsResponse(varProcessLogsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "logs")
+		delete(additionalProperties, "processName")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableProcessLogsResponse struct {

--- a/libs/toolbox-api-client-go/model_process_restart_response.go
+++ b/libs/toolbox-api-client-go/model_process_restart_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &ProcessRestartResponse{}
 type ProcessRestartResponse struct {
 	Message *string `json:"message,omitempty"`
 	ProcessName *string `json:"processName,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ProcessRestartResponse ProcessRestartResponse
 
 // NewProcessRestartResponse instantiates a new ProcessRestartResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o ProcessRestartResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ProcessName) {
 		toSerialize["processName"] = o.ProcessName
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ProcessRestartResponse) UnmarshalJSON(data []byte) (err error) {
+	varProcessRestartResponse := _ProcessRestartResponse{}
+
+	err = json.Unmarshal(data, &varProcessRestartResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ProcessRestartResponse(varProcessRestartResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "message")
+		delete(additionalProperties, "processName")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableProcessRestartResponse struct {

--- a/libs/toolbox-api-client-go/model_process_status.go
+++ b/libs/toolbox-api-client-go/model_process_status.go
@@ -23,7 +23,10 @@ type ProcessStatus struct {
 	Pid *int32 `json:"pid,omitempty"`
 	Priority *int32 `json:"priority,omitempty"`
 	Running *bool `json:"running,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ProcessStatus ProcessStatus
 
 // NewProcessStatus instantiates a new ProcessStatus object
 // This constructor will assign default values to properties that have it defined,
@@ -192,7 +195,36 @@ func (o ProcessStatus) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Running) {
 		toSerialize["running"] = o.Running
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ProcessStatus) UnmarshalJSON(data []byte) (err error) {
+	varProcessStatus := _ProcessStatus{}
+
+	err = json.Unmarshal(data, &varProcessStatus)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ProcessStatus(varProcessStatus)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "autoRestart")
+		delete(additionalProperties, "pid")
+		delete(additionalProperties, "priority")
+		delete(additionalProperties, "running")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableProcessStatus struct {

--- a/libs/toolbox-api-client-go/model_process_status_response.go
+++ b/libs/toolbox-api-client-go/model_process_status_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &ProcessStatusResponse{}
 type ProcessStatusResponse struct {
 	ProcessName *string `json:"processName,omitempty"`
 	Running *bool `json:"running,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ProcessStatusResponse ProcessStatusResponse
 
 // NewProcessStatusResponse instantiates a new ProcessStatusResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o ProcessStatusResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Running) {
 		toSerialize["running"] = o.Running
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ProcessStatusResponse) UnmarshalJSON(data []byte) (err error) {
+	varProcessStatusResponse := _ProcessStatusResponse{}
+
+	err = json.Unmarshal(data, &varProcessStatusResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ProcessStatusResponse(varProcessStatusResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "processName")
+		delete(additionalProperties, "running")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableProcessStatusResponse struct {

--- a/libs/toolbox-api-client-go/model_pty_create_request.go
+++ b/libs/toolbox-api-client-go/model_pty_create_request.go
@@ -26,7 +26,10 @@ type PtyCreateRequest struct {
 	// Don't start PTY until first client connects
 	LazyStart *bool `json:"lazyStart,omitempty"`
 	Rows *int32 `json:"rows,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PtyCreateRequest PtyCreateRequest
 
 // NewPtyCreateRequest instantiates a new PtyCreateRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -265,7 +268,38 @@ func (o PtyCreateRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Rows) {
 		toSerialize["rows"] = o.Rows
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PtyCreateRequest) UnmarshalJSON(data []byte) (err error) {
+	varPtyCreateRequest := _PtyCreateRequest{}
+
+	err = json.Unmarshal(data, &varPtyCreateRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = PtyCreateRequest(varPtyCreateRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "cols")
+		delete(additionalProperties, "cwd")
+		delete(additionalProperties, "envs")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "lazyStart")
+		delete(additionalProperties, "rows")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePtyCreateRequest struct {

--- a/libs/toolbox-api-client-go/model_pty_create_response.go
+++ b/libs/toolbox-api-client-go/model_pty_create_response.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &PtyCreateResponse{}
 // PtyCreateResponse struct for PtyCreateResponse
 type PtyCreateResponse struct {
 	SessionId string `json:"sessionId"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PtyCreateResponse PtyCreateResponse
@@ -79,6 +79,11 @@ func (o PtyCreateResponse) MarshalJSON() ([]byte, error) {
 func (o PtyCreateResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["sessionId"] = o.SessionId
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *PtyCreateResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varPtyCreateResponse := _PtyCreateResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPtyCreateResponse)
+	err = json.Unmarshal(data, &varPtyCreateResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PtyCreateResponse(varPtyCreateResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "sessionId")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_pty_list_response.go
+++ b/libs/toolbox-api-client-go/model_pty_list_response.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &PtyListResponse{}
 // PtyListResponse struct for PtyListResponse
 type PtyListResponse struct {
 	Sessions []PtySessionInfo `json:"sessions"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PtyListResponse PtyListResponse
@@ -79,6 +79,11 @@ func (o PtyListResponse) MarshalJSON() ([]byte, error) {
 func (o PtyListResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["sessions"] = o.Sessions
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *PtyListResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varPtyListResponse := _PtyListResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPtyListResponse)
+	err = json.Unmarshal(data, &varPtyListResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PtyListResponse(varPtyListResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "sessions")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_pty_resize_request.go
+++ b/libs/toolbox-api-client-go/model_pty_resize_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &PtyResizeRequest{}
 type PtyResizeRequest struct {
 	Cols int32 `json:"cols"`
 	Rows int32 `json:"rows"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PtyResizeRequest PtyResizeRequest
@@ -106,6 +106,11 @@ func (o PtyResizeRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["cols"] = o.Cols
 	toSerialize["rows"] = o.Rows
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -134,15 +139,21 @@ func (o *PtyResizeRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varPtyResizeRequest := _PtyResizeRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPtyResizeRequest)
+	err = json.Unmarshal(data, &varPtyResizeRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PtyResizeRequest(varPtyResizeRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "cols")
+		delete(additionalProperties, "rows")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_pty_session_info.go
+++ b/libs/toolbox-api-client-go/model_pty_session_info.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -30,6 +29,7 @@ type PtySessionInfo struct {
 	// Whether this session uses lazy start
 	LazyStart bool `json:"lazyStart"`
 	Rows int32 `json:"rows"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PtySessionInfo PtySessionInfo
@@ -269,6 +269,11 @@ func (o PtySessionInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize["id"] = o.Id
 	toSerialize["lazyStart"] = o.LazyStart
 	toSerialize["rows"] = o.Rows
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -303,15 +308,27 @@ func (o *PtySessionInfo) UnmarshalJSON(data []byte) (err error) {
 
 	varPtySessionInfo := _PtySessionInfo{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPtySessionInfo)
+	err = json.Unmarshal(data, &varPtySessionInfo)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PtySessionInfo(varPtySessionInfo)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "active")
+		delete(additionalProperties, "cols")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "cwd")
+		delete(additionalProperties, "envs")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "lazyStart")
+		delete(additionalProperties, "rows")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_recording.go
+++ b/libs/toolbox-api-client-go/model_recording.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -29,6 +28,7 @@ type Recording struct {
 	SizeBytes *int32 `json:"sizeBytes,omitempty"`
 	StartTime string `json:"startTime"`
 	Status string `json:"status"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Recording Recording
@@ -295,6 +295,11 @@ func (o Recording) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["startTime"] = o.StartTime
 	toSerialize["status"] = o.Status
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -326,15 +331,27 @@ func (o *Recording) UnmarshalJSON(data []byte) (err error) {
 
 	varRecording := _Recording{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varRecording)
+	err = json.Unmarshal(data, &varRecording)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Recording(varRecording)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "durationSeconds")
+		delete(additionalProperties, "endTime")
+		delete(additionalProperties, "fileName")
+		delete(additionalProperties, "filePath")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "sizeBytes")
+		delete(additionalProperties, "startTime")
+		delete(additionalProperties, "status")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_replace_request.go
+++ b/libs/toolbox-api-client-go/model_replace_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type ReplaceRequest struct {
 	Files []string `json:"files"`
 	NewValue string `json:"newValue"`
 	Pattern string `json:"pattern"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ReplaceRequest ReplaceRequest
@@ -133,6 +133,11 @@ func (o ReplaceRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize["files"] = o.Files
 	toSerialize["newValue"] = o.NewValue
 	toSerialize["pattern"] = o.Pattern
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -162,15 +167,22 @@ func (o *ReplaceRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varReplaceRequest := _ReplaceRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varReplaceRequest)
+	err = json.Unmarshal(data, &varReplaceRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ReplaceRequest(varReplaceRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "files")
+		delete(additionalProperties, "newValue")
+		delete(additionalProperties, "pattern")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_replace_result.go
+++ b/libs/toolbox-api-client-go/model_replace_result.go
@@ -22,7 +22,10 @@ type ReplaceResult struct {
 	Error *string `json:"error,omitempty"`
 	File *string `json:"file,omitempty"`
 	Success *bool `json:"success,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ReplaceResult ReplaceResult
 
 // NewReplaceResult instantiates a new ReplaceResult object
 // This constructor will assign default values to properties that have it defined,
@@ -156,7 +159,35 @@ func (o ReplaceResult) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Success) {
 		toSerialize["success"] = o.Success
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ReplaceResult) UnmarshalJSON(data []byte) (err error) {
+	varReplaceResult := _ReplaceResult{}
+
+	err = json.Unmarshal(data, &varReplaceResult)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ReplaceResult(varReplaceResult)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "error")
+		delete(additionalProperties, "file")
+		delete(additionalProperties, "success")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableReplaceResult struct {

--- a/libs/toolbox-api-client-go/model_screenshot_response.go
+++ b/libs/toolbox-api-client-go/model_screenshot_response.go
@@ -22,7 +22,10 @@ type ScreenshotResponse struct {
 	CursorPosition *Position `json:"cursorPosition,omitempty"`
 	Screenshot *string `json:"screenshot,omitempty"`
 	SizeBytes *int32 `json:"sizeBytes,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ScreenshotResponse ScreenshotResponse
 
 // NewScreenshotResponse instantiates a new ScreenshotResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -156,7 +159,35 @@ func (o ScreenshotResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SizeBytes) {
 		toSerialize["sizeBytes"] = o.SizeBytes
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ScreenshotResponse) UnmarshalJSON(data []byte) (err error) {
+	varScreenshotResponse := _ScreenshotResponse{}
+
+	err = json.Unmarshal(data, &varScreenshotResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ScreenshotResponse(varScreenshotResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "cursorPosition")
+		delete(additionalProperties, "screenshot")
+		delete(additionalProperties, "sizeBytes")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableScreenshotResponse struct {

--- a/libs/toolbox-api-client-go/model_scroll_response.go
+++ b/libs/toolbox-api-client-go/model_scroll_response.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &ScrollResponse{}
 // ScrollResponse struct for ScrollResponse
 type ScrollResponse struct {
 	Success *bool `json:"success,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ScrollResponse ScrollResponse
 
 // NewScrollResponse instantiates a new ScrollResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o ScrollResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Success) {
 		toSerialize["success"] = o.Success
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ScrollResponse) UnmarshalJSON(data []byte) (err error) {
+	varScrollResponse := _ScrollResponse{}
+
+	err = json.Unmarshal(data, &varScrollResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ScrollResponse(varScrollResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableScrollResponse struct {

--- a/libs/toolbox-api-client-go/model_search_files_response.go
+++ b/libs/toolbox-api-client-go/model_search_files_response.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &SearchFilesResponse{}
 // SearchFilesResponse struct for SearchFilesResponse
 type SearchFilesResponse struct {
 	Files []string `json:"files"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SearchFilesResponse SearchFilesResponse
@@ -79,6 +79,11 @@ func (o SearchFilesResponse) MarshalJSON() ([]byte, error) {
 func (o SearchFilesResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["files"] = o.Files
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *SearchFilesResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varSearchFilesResponse := _SearchFilesResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSearchFilesResponse)
+	err = json.Unmarshal(data, &varSearchFilesResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SearchFilesResponse(varSearchFilesResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "files")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_session.go
+++ b/libs/toolbox-api-client-go/model_session.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &Session{}
 type Session struct {
 	Commands []Command `json:"commands"`
 	SessionId string `json:"sessionId"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Session Session
@@ -106,6 +106,11 @@ func (o Session) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["commands"] = o.Commands
 	toSerialize["sessionId"] = o.SessionId
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -134,15 +139,21 @@ func (o *Session) UnmarshalJSON(data []byte) (err error) {
 
 	varSession := _Session{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSession)
+	err = json.Unmarshal(data, &varSession)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Session(varSession)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "commands")
+		delete(additionalProperties, "sessionId")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_session_command_logs_response.go
+++ b/libs/toolbox-api-client-go/model_session_command_logs_response.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type SessionCommandLogsResponse struct {
 	Output string `json:"output"`
 	Stderr string `json:"stderr"`
 	Stdout string `json:"stdout"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SessionCommandLogsResponse SessionCommandLogsResponse
@@ -133,6 +133,11 @@ func (o SessionCommandLogsResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize["output"] = o.Output
 	toSerialize["stderr"] = o.Stderr
 	toSerialize["stdout"] = o.Stdout
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -162,15 +167,22 @@ func (o *SessionCommandLogsResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varSessionCommandLogsResponse := _SessionCommandLogsResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSessionCommandLogsResponse)
+	err = json.Unmarshal(data, &varSessionCommandLogsResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SessionCommandLogsResponse(varSessionCommandLogsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "output")
+		delete(additionalProperties, "stderr")
+		delete(additionalProperties, "stdout")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_session_execute_request.go
+++ b/libs/toolbox-api-client-go/model_session_execute_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -25,6 +24,7 @@ type SessionExecuteRequest struct {
 	Command string `json:"command"`
 	RunAsync *bool `json:"runAsync,omitempty"`
 	SuppressInputEcho *bool `json:"suppressInputEcho,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SessionExecuteRequest SessionExecuteRequest
@@ -187,6 +187,11 @@ func (o SessionExecuteRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SuppressInputEcho) {
 		toSerialize["suppressInputEcho"] = o.SuppressInputEcho
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -214,15 +219,23 @@ func (o *SessionExecuteRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varSessionExecuteRequest := _SessionExecuteRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSessionExecuteRequest)
+	err = json.Unmarshal(data, &varSessionExecuteRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SessionExecuteRequest(varSessionExecuteRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "async")
+		delete(additionalProperties, "command")
+		delete(additionalProperties, "runAsync")
+		delete(additionalProperties, "suppressInputEcho")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_session_execute_response.go
+++ b/libs/toolbox-api-client-go/model_session_execute_response.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type SessionExecuteResponse struct {
 	Output *string `json:"output,omitempty"`
 	Stderr *string `json:"stderr,omitempty"`
 	Stdout *string `json:"stdout,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SessionExecuteResponse SessionExecuteResponse
@@ -223,6 +223,11 @@ func (o SessionExecuteResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Stdout) {
 		toSerialize["stdout"] = o.Stdout
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -250,15 +255,24 @@ func (o *SessionExecuteResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varSessionExecuteResponse := _SessionExecuteResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSessionExecuteResponse)
+	err = json.Unmarshal(data, &varSessionExecuteResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SessionExecuteResponse(varSessionExecuteResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "cmdId")
+		delete(additionalProperties, "exitCode")
+		delete(additionalProperties, "output")
+		delete(additionalProperties, "stderr")
+		delete(additionalProperties, "stdout")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_session_send_input_request.go
+++ b/libs/toolbox-api-client-go/model_session_send_input_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &SessionSendInputRequest{}
 // SessionSendInputRequest struct for SessionSendInputRequest
 type SessionSendInputRequest struct {
 	Data string `json:"data"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SessionSendInputRequest SessionSendInputRequest
@@ -79,6 +79,11 @@ func (o SessionSendInputRequest) MarshalJSON() ([]byte, error) {
 func (o SessionSendInputRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["data"] = o.Data
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *SessionSendInputRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varSessionSendInputRequest := _SessionSendInputRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSessionSendInputRequest)
+	err = json.Unmarshal(data, &varSessionSendInputRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SessionSendInputRequest(varSessionSendInputRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "data")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_start_recording_request.go
+++ b/libs/toolbox-api-client-go/model_start_recording_request.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &StartRecordingRequest{}
 // StartRecordingRequest struct for StartRecordingRequest
 type StartRecordingRequest struct {
 	Label *string `json:"label,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _StartRecordingRequest StartRecordingRequest
 
 // NewStartRecordingRequest instantiates a new StartRecordingRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o StartRecordingRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Label) {
 		toSerialize["label"] = o.Label
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *StartRecordingRequest) UnmarshalJSON(data []byte) (err error) {
+	varStartRecordingRequest := _StartRecordingRequest{}
+
+	err = json.Unmarshal(data, &varStartRecordingRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = StartRecordingRequest(varStartRecordingRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "label")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableStartRecordingRequest struct {

--- a/libs/toolbox-api-client-go/model_stop_recording_request.go
+++ b/libs/toolbox-api-client-go/model_stop_recording_request.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &StopRecordingRequest{}
 // StopRecordingRequest struct for StopRecordingRequest
 type StopRecordingRequest struct {
 	Id string `json:"id"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _StopRecordingRequest StopRecordingRequest
@@ -79,6 +79,11 @@ func (o StopRecordingRequest) MarshalJSON() ([]byte, error) {
 func (o StopRecordingRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["id"] = o.Id
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *StopRecordingRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varStopRecordingRequest := _StopRecordingRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varStopRecordingRequest)
+	err = json.Unmarshal(data, &varStopRecordingRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = StopRecordingRequest(varStopRecordingRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_user_home_dir_response.go
+++ b/libs/toolbox-api-client-go/model_user_home_dir_response.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &UserHomeDirResponse{}
 // UserHomeDirResponse struct for UserHomeDirResponse
 type UserHomeDirResponse struct {
 	Dir string `json:"dir"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserHomeDirResponse UserHomeDirResponse
@@ -79,6 +79,11 @@ func (o UserHomeDirResponse) MarshalJSON() ([]byte, error) {
 func (o UserHomeDirResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["dir"] = o.Dir
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *UserHomeDirResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varUserHomeDirResponse := _UserHomeDirResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserHomeDirResponse)
+	err = json.Unmarshal(data, &varUserHomeDirResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserHomeDirResponse(varUserHomeDirResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "dir")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/model_window_info.go
+++ b/libs/toolbox-api-client-go/model_window_info.go
@@ -26,7 +26,10 @@ type WindowInfo struct {
 	Width *int32 `json:"width,omitempty"`
 	X *int32 `json:"x,omitempty"`
 	Y *int32 `json:"y,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _WindowInfo WindowInfo
 
 // NewWindowInfo instantiates a new WindowInfo object
 // This constructor will assign default values to properties that have it defined,
@@ -300,7 +303,39 @@ func (o WindowInfo) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Y) {
 		toSerialize["y"] = o.Y
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *WindowInfo) UnmarshalJSON(data []byte) (err error) {
+	varWindowInfo := _WindowInfo{}
+
+	err = json.Unmarshal(data, &varWindowInfo)
+
+	if err != nil {
+		return err
+	}
+
+	*o = WindowInfo(varWindowInfo)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "height")
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "isActive")
+		delete(additionalProperties, "title")
+		delete(additionalProperties, "width")
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableWindowInfo struct {

--- a/libs/toolbox-api-client-go/model_windows_response.go
+++ b/libs/toolbox-api-client-go/model_windows_response.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &WindowsResponse{}
 // WindowsResponse struct for WindowsResponse
 type WindowsResponse struct {
 	Windows []WindowInfo `json:"windows,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _WindowsResponse WindowsResponse
 
 // NewWindowsResponse instantiates a new WindowsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o WindowsResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Windows) {
 		toSerialize["windows"] = o.Windows
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *WindowsResponse) UnmarshalJSON(data []byte) (err error) {
+	varWindowsResponse := _WindowsResponse{}
+
+	err = json.Unmarshal(data, &varWindowsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = WindowsResponse(varWindowsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "windows")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableWindowsResponse struct {

--- a/libs/toolbox-api-client-go/model_work_dir_response.go
+++ b/libs/toolbox-api-client-go/model_work_dir_response.go
@@ -12,7 +12,6 @@ package toolbox
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &WorkDirResponse{}
 // WorkDirResponse struct for WorkDirResponse
 type WorkDirResponse struct {
 	Dir string `json:"dir"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _WorkDirResponse WorkDirResponse
@@ -79,6 +79,11 @@ func (o WorkDirResponse) MarshalJSON() ([]byte, error) {
 func (o WorkDirResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["dir"] = o.Dir
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *WorkDirResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varWorkDirResponse := _WorkDirResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varWorkDirResponse)
+	err = json.Unmarshal(data, &varWorkDirResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = WorkDirResponse(varWorkDirResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "dir")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/toolbox-api-client-go/project.json
+++ b/libs/toolbox-api-client-go/project.json
@@ -42,7 +42,7 @@
       "options": {
         "commands": [
           "rm -f {projectRoot}/*.go",
-          "yarn run openapi-generator-cli generate --git-repo-id=daytona/libs/toolbox-api-client-go --git-user-id=daytonaio -i apps/daemon/pkg/toolbox/docs/swagger.json -g go -t hack/go-client/openapi-templates --model-name-mappings computeruse.AccessibilityNode=ComputerUseAccessibilityNode --additional-properties=packageName=toolbox,moduleVersion=$DEFAULT_PACKAGE_VERSION,generateInterfaces=true,enumClassPrefix=true,structPrefix=true,enumUnknownDefaultCase=true -o libs/toolbox-api-client-go",
+          "yarn run openapi-generator-cli generate --git-repo-id=daytona/libs/toolbox-api-client-go --git-user-id=daytonaio -i apps/daemon/pkg/toolbox/docs/swagger.json -g go -t hack/go-client/openapi-templates --model-name-mappings computeruse.AccessibilityNode=ComputerUseAccessibilityNode --additional-properties=packageName=toolbox,moduleVersion=$DEFAULT_PACKAGE_VERSION,generateInterfaces=true,enumClassPrefix=true,structPrefix=true,enumUnknownDefaultCase=true,disallowAdditionalPropertiesIfNotPresent=false -o libs/toolbox-api-client-go",
           "bash hack/go-client/postprocess.sh libs/toolbox-api-client-go toolbox toolbox-api-client-go"
         ],
         "parallel": false


### PR DESCRIPTION
## Summary

Add `disallowAdditionalPropertiesIfNotPresent=false` to the openapi-generator options for the Go toolbox API client.

## Why

The published Go client decodes responses with `DisallowUnknownFields`, so any new field added to a daemon response type breaks older Go clients during deserialization. Setting this flag makes the generated models tolerant of unknown/extra properties, so future daemon additions to response types stay backward compatible.

## Changes

- `libs/toolbox-api-client-go/project.json` — append `disallowAdditionalPropertiesIfNotPresent=false` to the `generate:api-client` generator options and regenerate the client.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Go toolbox API client tolerate new fields in daemon responses and add a daemon helper to detect older Go SDK callers that reject unknown fields. Also remove the license year from headers.

- **Bug Fixes**
  - Set `disallowAdditionalPropertiesIfNotPresent=false` in `libs/toolbox-api-client-go/project.json` for the `openapi-generator`, then regenerated `toolbox` models to use `AdditionalProperties` and stop `json.Decoder.DisallowUnknownFields`.

- **New Features**
  - Added daemon util `ClientRejectsUnknownResponseFields` to detect Go SDK requests via `X-Daytona-Source`/`X-Daytona-SDK-Version` and treat versions older than `0.188.0` as strict; includes tests.

<sup>Written for commit ff57398440ef5efd35c05fb5942477245e9d4312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

