### PR TITLE
fix(dashboard): update config uris

### DIFF
--- a/.devcontainer/dex/config.yaml
+++ b/.devcontainer/dex/config.yaml
@@ -10,6 +10,7 @@ staticClients:
   - id: daytona
     redirectURIs:
       - 'http://localhost:3000'
+      - 'http://localhost:3000/dashboard'
       - 'http://localhost:3000/api/oauth2-redirect.html'
       - 'http://localhost:3009/callback'
       - 'http://proxy.localhost:4000/callback'

--- a/apps/dashboard/src/providers/ConfigProvider.tsx
+++ b/apps/dashboard/src/providers/ConfigProvider.tsx
@@ -41,7 +41,7 @@ export function ConfigProvider(props: Props) {
         audience: config.oidc.audience,
       },
       scope: 'openid profile email',
-      redirect_uri: window.location.origin,
+      redirect_uri: window.location.origin + '/dashboard',
       staleStateAgeInSeconds: 60,
       accessTokenExpiringNotificationTimeInSeconds: 290,
       userStore: new WebStorageStateStore({ store: stateStore }),
@@ -51,7 +51,7 @@ export function ConfigProvider(props: Props) {
         window.history.replaceState({}, '', targetUrl)
         window.dispatchEvent(new PopStateEvent('popstate'))
       },
-      post_logout_redirect_uri: window.location.origin,
+      post_logout_redirect_uri: window.location.origin + '/dashboard',
     }
   }, [config])
 

--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -181,11 +181,11 @@ openssl rand -hex 16
 The script updates `docker/dex/config.yaml` to set:
 
 - `issuer` to `https://YOUR_DOMAIN/dex`
-- `redirectURIs` to use `https://YOUR_DOMAIN` instead of `localhost`
+- `redirectURIs` to use `https://YOUR_DOMAIN` and `https://YOUR_DOMAIN/dashboard` instead of `localhost`
 - `staticPasswords` with your chosen email and bcrypt-hashed password
 
 :::caution
-The `redirectURIs` must use `https://` and your actual domain. If these still reference `localhost`, OIDC callbacks will fail after login.
+The `redirectURIs` must use `https://`, your actual domain, and include the `/dashboard` callback URI. If these still reference `localhost` or omit `/dashboard`, OIDC callbacks will fail after login.
 :::
 
 To generate a bcrypt password hash manually:
@@ -551,7 +551,7 @@ Navigate to `Applications` > `Applications` in the left sidebar and select the a
 In the `Allowed Callback URIs` field, add the following URLs:
 
 ```
-http://localhost:3000
+http://localhost:3000/dashboard
 http://localhost:3000/api/oauth2-redirect.html
 http://localhost:4000/callback
 http://proxy.localhost:4000/callback
@@ -560,7 +560,7 @@ http://proxy.localhost:4000/callback
 For `Allowed Logout URIs`, add:
 
 ```
-http://localhost:3000
+http://localhost:3000/dashboard
 ```
 
 And for `Allowed Web Origins`, add:

--- a/docker/README.md
+++ b/docker/README.md
@@ -74,7 +74,7 @@ Navigate to `Applications` > `Applications` in the left sidebar and select the a
 In the `Allowed Callback URIs` field, add the following URLs:
 
 ```
-http://localhost:3000
+http://localhost:3000/dashboard
 http://localhost:3000/api/oauth2-redirect.html
 http://localhost:4000/callback
 http://proxy.localhost:4000/callback
@@ -83,7 +83,7 @@ http://proxy.localhost:4000/callback
 For `Allowed Logout URIs`, add:
 
 ```
-http://localhost:3000
+http://localhost:3000/dashboard
 ```
 
 And for `Allowed Web Origins`, add:

--- a/docker/dex/config.yaml
+++ b/docker/dex/config.yaml
@@ -13,6 +13,7 @@ staticClients:
   - id: daytona
     redirectURIs:
       - 'http://localhost:3000'
+      - 'http://localhost:3000/dashboard'
       - 'http://localhost:3000/api/oauth2-redirect.html'
       - 'http://localhost:3009/callback'
       - 'http://proxy.localhost:4000/callback'

--- a/scripts/setup-domain-oss-deployment.sh
+++ b/scripts/setup-domain-oss-deployment.sh
@@ -412,6 +412,7 @@ staticClients:
   - id: daytona
     redirectURIs:
       - 'https://DOMAIN_PH'
+      - 'https://DOMAIN_PH/dashboard'
       - 'https://DOMAIN_PH/api/oauth2-redirect.html'
       - 'https://DOMAIN_PH/callback'
       - 'https://proxy.DOMAIN_PH/callback'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point OIDC `redirect_uri` and `post_logout_redirect_uri` to `/dashboard` and add `/dashboard` to Dex redirect URIs (configs, setup script, docs) so callbacks return users to the dashboard after sign-in/sign-out.

<sup>Written for commit 5b9c18ad794e17586f921696c0164460637c4f01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

