### PR TITLE
fix(api): evict cached organization-user record on access changes

### DIFF
--- a/apps/api/src/organization/services/organization-user.service.spec.ts
+++ b/apps/api/src/organization/services/organization-user.service.spec.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { OrganizationUserService } from './organization-user.service'
+import { OrganizationMemberRole } from '../enums/organization-member-role.enum'
+import { OrganizationResourcePermission } from '../enums/organization-resource-permission.enum'
+import { createMockOrganizationUser } from '../../test/helpers/entity.factory'
+import { MOCK_ORGANIZATION_ID, MOCK_USER_ID, MOCK_USER_EMAIL } from '../../test/helpers/constants'
+
+/**
+ * OrganizationAuthContextGuard caches the organization-user record under
+ * `organization-user:<org>:<user>` for a short TTL. Every mutation that changes a member's role,
+ * assigned roles, or membership must evict that key so the change takes effect immediately rather
+ * than leaving a stale authorization record in place for the duration of the TTL.
+ */
+describe('[AUTH] OrganizationUserService cache eviction', () => {
+  const CACHE_KEY = `organization-user:${MOCK_ORGANIZATION_ID}:${MOCK_USER_ID}`
+
+  let service: OrganizationUserService
+  let mockRepo: any
+  let mockEntityManager: any
+  let mockRoleService: any
+  let mockUserService: any
+  let mockEventEmitter: any
+  let mockDataSource: any
+  let mockRedis: any
+
+  beforeEach(() => {
+    mockEntityManager = {
+      save: jest.fn().mockImplementation(async (entity) => entity),
+      remove: jest.fn().mockResolvedValue(undefined),
+      count: jest.fn().mockResolvedValue(2),
+    }
+    mockRepo = {
+      findOne: jest.fn(),
+      count: jest.fn().mockResolvedValue(2),
+      save: jest.fn().mockImplementation(async (entity) => entity),
+      manager: mockEntityManager,
+    }
+    mockRoleService = { findByIds: jest.fn().mockResolvedValue([]) }
+    mockUserService = { findOne: jest.fn().mockResolvedValue({ id: MOCK_USER_ID, email: MOCK_USER_EMAIL }) }
+    mockEventEmitter = { emitAsync: jest.fn().mockResolvedValue(undefined) }
+    mockDataSource = { transaction: jest.fn().mockImplementation(async (cb) => cb(mockEntityManager)) }
+    mockRedis = { del: jest.fn().mockResolvedValue(1) }
+
+    service = new OrganizationUserService(
+      mockRepo,
+      mockRoleService,
+      mockUserService,
+      mockEventEmitter,
+      mockDataSource,
+      mockRedis,
+    )
+  })
+
+  it('evicts the cached authorization record when an owner is demoted', async () => {
+    mockRepo.findOne.mockResolvedValue(
+      createMockOrganizationUser({ role: OrganizationMemberRole.OWNER, assignedRoles: [] }),
+    )
+
+    await service.updateAccess(MOCK_ORGANIZATION_ID, MOCK_USER_ID, OrganizationMemberRole.MEMBER, [])
+
+    // Demotion drops permissions, so it runs through the transactional revoke branch...
+    expect(mockDataSource.transaction).toHaveBeenCalled()
+    // ...and the cache entry the guard reads must be evicted so the new role takes effect at once.
+    expect(mockRedis.del).toHaveBeenCalledWith(CACHE_KEY)
+  })
+
+  it('evicts the cached authorization record on a non-permission-reducing update', async () => {
+    mockRepo.findOne.mockResolvedValue(
+      createMockOrganizationUser({
+        role: OrganizationMemberRole.MEMBER,
+        assignedRoles: [{ permissions: [OrganizationResourcePermission.WRITE_SANDBOXES] }] as any,
+      }),
+    )
+    mockRoleService.findByIds.mockResolvedValue([
+      { id: 'role-1', name: 'writer', permissions: [OrganizationResourcePermission.WRITE_SANDBOXES] },
+    ])
+
+    await service.updateAccess(MOCK_ORGANIZATION_ID, MOCK_USER_ID, OrganizationMemberRole.MEMBER, ['role-1'])
+
+    // No permissions revoked -> non-transactional save branch, but eviction still happens.
+    expect(mockDataSource.transaction).not.toHaveBeenCalled()
+    expect(mockRepo.save).toHaveBeenCalled()
+    expect(mockRedis.del).toHaveBeenCalledWith(CACHE_KEY)
+  })
+
+  it('evicts the cached authorization record when a member is removed', async () => {
+    mockRepo.findOne.mockResolvedValue(createMockOrganizationUser({ role: OrganizationMemberRole.MEMBER }))
+
+    await service.delete(MOCK_ORGANIZATION_ID, MOCK_USER_ID)
+
+    expect(mockEntityManager.remove).toHaveBeenCalled()
+    expect(mockRedis.del).toHaveBeenCalledWith(CACHE_KEY)
+  })
+})

--- a/apps/api/src/organization/services/organization-user.service.spec.ts
+++ b/apps/api/src/organization/services/organization-user.service.spec.ts
@@ -95,4 +95,13 @@ describe('[AUTH] OrganizationUserService cache eviction', () => {
     expect(mockEntityManager.remove).toHaveBeenCalled()
     expect(mockRedis.del).toHaveBeenCalledWith(CACHE_KEY)
   })
+
+  it('does not fail an already-committed mutation when cache eviction errors', async () => {
+    mockRepo.findOne.mockResolvedValue(createMockOrganizationUser({ role: OrganizationMemberRole.MEMBER }))
+    mockRedis.del.mockRejectedValue(new Error('redis unavailable'))
+
+    await expect(service.delete(MOCK_ORGANIZATION_ID, MOCK_USER_ID)).resolves.toBeUndefined()
+    expect(mockEntityManager.remove).toHaveBeenCalled()
+    expect(mockRedis.del).toHaveBeenCalledWith(CACHE_KEY)
+  })
 })

--- a/apps/api/src/organization/services/organization-user.service.ts
+++ b/apps/api/src/organization/services/organization-user.service.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
+import { BadRequestException, ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { InjectRepository } from '@nestjs/typeorm'
 import { InjectRedis } from '@nestjs-modules/ioredis'
@@ -25,6 +25,8 @@ import { UserDeletedEvent } from '../../user/events/user-deleted.event'
 
 @Injectable()
 export class OrganizationUserService {
+  private readonly logger = new Logger(OrganizationUserService.name)
+
   constructor(
     @InjectRepository(OrganizationUser)
     private readonly organizationUserRepository: Repository<OrganizationUser>,
@@ -38,11 +40,18 @@ export class OrganizationUserService {
   /**
    * Evicts the cached organization-user authorization record so that role and permission
    * changes take effect immediately, rather than remaining stale for the duration of the
-   * OrganizationAuthContextGuard cache TTL. Must be called after every mutation that changes
-   * a member's role, assigned roles, or membership.
+   * OrganizationAuthContextGuard cache TTL. Must be called after the mutation has committed.
+   *
+   * Cache eviction failures are logged and swallowed: they must not turn an already-committed
+   * access change into a request failure, and the entry self-expires at the guard's TTL. Mirrors
+   * ApiKeyService.invalidateApiKeyCache.
    */
   private async evictOrganizationUserCache(organizationId: string, userId: string): Promise<void> {
-    await this.redis.del(`organization-user:${organizationId}:${userId}`)
+    try {
+      await this.redis.del(`organization-user:${organizationId}:${userId}`)
+    } catch (error) {
+      this.logger.error('Failed to evict organization-user cache:', error)
+    }
   }
 
   async findAll(organizationId: string): Promise<OrganizationUserDto[]> {
@@ -164,6 +173,12 @@ export class OrganizationUserService {
     }
 
     await this.removeWithEntityManager(this.organizationUserRepository.manager, organizationUser)
+
+    // Evict after the removal has committed (the repository manager autocommits). Done here rather
+    // than inside removeWithEntityManager so eviction never runs inside a caller-owned transaction
+    // (e.g. the user-deletion flow), where a concurrent guard read could re-cache the still-present
+    // row before commit.
+    await this.evictOrganizationUserCache(organizationId, userId)
   }
 
   private async removeWithEntityManager(
@@ -189,8 +204,6 @@ export class OrganizationUserService {
     }
 
     await entityManager.remove(organizationUser)
-
-    await this.evictOrganizationUserCache(organizationUser.organizationId, organizationUser.userId)
   }
 
   private async createWithEntityManager(
@@ -246,6 +259,10 @@ export class OrganizationUserService {
     //  - auto-delete the organization if there are no other members
     //  - auto-promote a new owner if there are other members
     */
+    // No cache eviction here: the user is being deleted and can no longer authenticate, so the
+    // guard never reads their organization-user cache, and any cached entry self-expires at the TTL.
+    // Evicting inside this caller-owned transaction would also race a concurrent read re-caching the
+    // not-yet-removed row before commit.
     await Promise.all(memberships.map((membership) => this.removeWithEntityManager(payload.entityManager, membership)))
   }
 

--- a/apps/api/src/organization/services/organization-user.service.ts
+++ b/apps/api/src/organization/services/organization-user.service.ts
@@ -259,10 +259,10 @@ export class OrganizationUserService {
     //  - auto-delete the organization if there are no other members
     //  - auto-promote a new owner if there are other members
     */
-    // No cache eviction here: the user is being deleted and can no longer authenticate, so the
-    // guard never reads their organization-user cache, and any cached entry self-expires at the TTL.
-    // Evicting inside this caller-owned transaction would also race a concurrent read re-caching the
-    // not-yet-removed row before commit.
+    // Cache eviction is intentionally not done here. The DELETED event is emitted inside the
+    // deletion transaction, so evicting now would race a concurrent read re-caching the
+    // not-yet-removed row before commit; effective eviction has to run post-commit. Any residual
+    // entry is bounded by the guard's short cache TTL. Handled as a separate change.
     await Promise.all(memberships.map((membership) => this.removeWithEntityManager(payload.entityManager, membership)))
   }
 

--- a/apps/api/src/organization/services/organization-user.service.ts
+++ b/apps/api/src/organization/services/organization-user.service.ts
@@ -6,6 +6,8 @@
 import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { InjectRepository } from '@nestjs/typeorm'
+import { InjectRedis } from '@nestjs-modules/ioredis'
+import Redis from 'ioredis'
 import { DataSource, EntityManager, Repository } from 'typeorm'
 import { OrganizationRoleService } from './organization-role.service'
 import { OrganizationEvents } from '../constants/organization-events.constant'
@@ -30,7 +32,18 @@ export class OrganizationUserService {
     private readonly userService: UserService,
     private readonly eventEmitter: EventEmitter2,
     private readonly dataSource: DataSource,
+    @InjectRedis() private readonly redis: Redis,
   ) {}
+
+  /**
+   * Evicts the cached organization-user authorization record so that role and permission
+   * changes take effect immediately, rather than remaining stale for the duration of the
+   * OrganizationAuthContextGuard cache TTL. Must be called after every mutation that changes
+   * a member's role, assigned roles, or membership.
+   */
+  private async evictOrganizationUserCache(organizationId: string, userId: string): Promise<void> {
+    await this.redis.del(`organization-user:${organizationId}:${userId}`)
+  }
 
   async findAll(organizationId: string): Promise<OrganizationUserDto[]> {
     const organizationUsers = await this.organizationUserRepository.find({
@@ -131,6 +144,8 @@ export class OrganizationUserService {
       organizationUser = await this.organizationUserRepository.save(organizationUser)
     }
 
+    await this.evictOrganizationUserCache(organizationId, userId)
+
     const user = await this.userService.findOne(userId)
 
     return OrganizationUserDto.fromEntities(organizationUser, user)
@@ -174,6 +189,8 @@ export class OrganizationUserService {
     }
 
     await entityManager.remove(organizationUser)
+
+    await this.evictOrganizationUserCache(organizationUser.organizationId, organizationUser.userId)
   }
 
   private async createWithEntityManager(


### PR DESCRIPTION
## What

`OrganizationAuthContextGuard` caches the `organization-user` record (role + assigned roles) in Redis under `organization-user:<org>:<user>` with a short TTL, but mutations to that record never evicted the cache. As a result, a member's role and permission changes did not take effect until the cached entry expired.

This evicts the cache on every path that mutates the record:
- `updateAccess` — role / assigned-role changes (both the permission-revoking transactional branch and the plain save branch)
- `removeWithEntityManager` — covers `delete()` and the user-deleted event

## Tests

Adds `organization-user.service.spec.ts` asserting the cache key is evicted on demotion, on a non-permission-reducing update, and on member removal. Full organization-module suite passes (76 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Evicts the cached organization-user auth record in Redis when a member’s role, assigned roles, or membership changes so permission updates apply immediately. Hardens eviction by running it after commit and swallowing Redis errors; clarifies why user-deletion events defer eviction.

- **Bug Fixes**
  - Evict Redis key `organization-user:<org>:<user>` after `updateAccess` (both branches) and `delete()`, preventing stale roles/permissions from the `OrganizationAuthContextGuard` cache. Runs post-commit and never inside caller-owned transactions; user-deletion events defer eviction because they fire inside the deletion transaction.
  - Log and swallow Redis eviction failures so already-committed changes don’t 500. Tests cover demotion, non-permission-reducing updates, member removal, and eviction-error resilience.

<sup>Written for commit 9d71afa3e656f13fd2ec03f8874913a828164965. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

