### PR TITLE
feat(dashboard): sync available regions after snapshot select

### DIFF
--- a/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
+++ b/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
@@ -4,15 +4,11 @@
  */
 
 import { CreateResourceButton } from '@/components/CreateResourceButton'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
 import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
-import { InputGroup, InputGroupAddon } from '@/components/ui/input-group'
 import { Label } from '@/components/ui/label'
-import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
   Sheet,
@@ -28,9 +24,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useCreateSandboxMutation } from '@/hooks/mutations/useCreateSandboxMutation'
 import { useSetOrganizationDefaultRegionMutation } from '@/hooks/mutations/useSetOrganizationDefaultRegionMutation'
 import { useOrganizationUsageOverviewQuery } from '@/hooks/queries/useOrganizationUsageOverviewQuery'
-import { useSnapshotsQuery } from '@/hooks/queries/useSnapshotsQuery'
 import { useConfig } from '@/hooks/useConfig'
-import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { useRegions } from '@/hooks/useRegions'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { parseEnvFile } from '@/lib/env'
@@ -38,18 +32,18 @@ import { handleApiError } from '@/lib/error-handling'
 import { GPU_TYPE_LABELS } from '@/lib/gpu-types'
 import { imageNameSchema } from '@/lib/schema'
 import { cn, getRegionFullDisplayName } from '@/lib/utils'
-import { GpuType, OrganizationUserRoleEnum, SnapshotState, type Region, type SnapshotDto } from '@daytona/api-client'
+import { GpuType, OrganizationUserRoleEnum, RegionType, type Region, type SnapshotDto } from '@daytona/api-client'
 import { Sandbox } from '@daytona/sdk'
 import { useForm, useStore } from '@tanstack/react-form'
 import { isAxiosError } from 'axios'
-import { AnimatePresence, motion } from 'framer-motion'
-import { Check, ChevronDownIcon, Info, Minus, Plus, SearchIcon, Upload } from 'lucide-react'
+import { Info, Minus, Plus, Upload } from 'lucide-react'
 import { ComponentProps, Ref, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { NumericFormat } from 'react-number-format'
 import { toast } from 'sonner'
 import { z } from 'zod'
 import { Tooltip } from '../Tooltip'
 import { ScrollArea } from '../ui/scroll-area'
+import { SnapshotSelect } from './SnapshotSelect'
 
 const NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
 
@@ -173,215 +167,6 @@ const InfoTooltipButton = ({ className, ...props }: ComponentProps<'button'>) =>
   )
 }
 
-const commandInputIconMotion = {
-  initial: { opacity: 0, y: 4, scale: 0.95 },
-  animate: { opacity: 1, y: 0, scale: 1 },
-  exit: { opacity: 0, y: -4, scale: 0.95 },
-  transition: { duration: 0.14, ease: 'easeOut' },
-} as const
-
-function CommandInputStatusIcon({ fetching }: { fetching: boolean }) {
-  return (
-    <span className="relative flex size-4 shrink-0 items-center justify-center opacity-50">
-      <AnimatePresence initial={false} mode="wait">
-        {fetching ? (
-          <motion.span
-            key="fetching"
-            className="absolute inset-0 flex items-center justify-center"
-            {...commandInputIconMotion}
-          >
-            <Spinner className="size-4" />
-          </motion.span>
-        ) : (
-          <motion.span
-            key="search"
-            className="absolute inset-0 flex items-center justify-center"
-            {...commandInputIconMotion}
-          >
-            <SearchIcon className="size-4" />
-          </motion.span>
-        )}
-      </AnimatePresence>
-    </span>
-  )
-}
-
-// todo(rpavlini): pull out an async combobox component
-function SnapshotCommandSelect({
-  id,
-  value,
-  selectedSnapshot,
-  snapshots,
-  loading,
-  fetching,
-  searchValue,
-  getRegionName,
-  open,
-  popoverContainer,
-  onChange,
-  onOpenChange,
-  onSearchChange,
-}: {
-  id: string
-  value?: string
-  selectedSnapshot?: SnapshotDto
-  snapshots: SnapshotDto[]
-  loading: boolean
-  fetching: boolean
-  searchValue: string
-  getRegionName: (regionId: string) => string | undefined
-  open: boolean
-  popoverContainer?: HTMLElement | null
-  onChange: (snapshot: SnapshotDto) => void
-  onOpenChange: (open: boolean) => void
-  onSearchChange: (value: string) => void
-}) {
-  const selectedLabel = selectedSnapshot?.name ?? value ?? 'Default snapshot'
-
-  const handleChange = (snapshot: SnapshotDto) => {
-    onChange(snapshot)
-    onOpenChange(false)
-  }
-
-  return (
-    <Popover open={open} onOpenChange={onOpenChange}>
-      <PopoverAnchor asChild>
-        <InputGroup
-          className={cn('h-8 overflow-hidden', {
-            'opacity-50': loading,
-          })}
-          data-disabled={loading ? true : undefined}
-        >
-          <PopoverTrigger asChild>
-            <button
-              id={id}
-              type="button"
-              disabled={loading}
-              data-slot="input-group-control"
-              className="absolute inset-0 z-10 rounded-md outline-none disabled:cursor-not-allowed"
-              aria-label={loading ? 'Loading snapshots' : selectedLabel}
-            />
-          </PopoverTrigger>
-          <span
-            aria-hidden="true"
-            className={cn('min-w-0 flex-1 truncate px-3 text-sm', {
-              'text-muted-foreground': !value,
-            })}
-          >
-            {loading ? 'Loading snapshots...' : selectedLabel}
-          </span>
-          <InputGroupAddon align="inline-end">
-            <ChevronDownIcon aria-hidden="true" className="size-4 text-muted-foreground" />
-          </InputGroupAddon>
-        </InputGroup>
-      </PopoverAnchor>
-      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start" container={popoverContainer}>
-        <Command shouldFilter={false}>
-          <CommandInput
-            value={searchValue}
-            onValueChange={onSearchChange}
-            placeholder="Search snapshots..."
-            icon={<CommandInputStatusIcon fetching={fetching} />}
-          />
-          <CommandList className="max-h-64 overscroll-contain">
-            {loading ? (
-              <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
-                <Spinner className="size-4" />
-                Loading snapshots...
-              </div>
-            ) : (
-              <>
-                <CommandEmpty>{fetching ? 'Searching snapshots...' : 'No active snapshots found.'}</CommandEmpty>
-                <CommandGroup
-                  className={cn('transition-opacity duration-150 ease-out', {
-                    'opacity-50': fetching && snapshots.length > 0,
-                  })}
-                >
-                  {snapshots.map((snapshot) => (
-                    <CommandItem
-                      key={snapshot.id}
-                      value={`${snapshot.name} ${(snapshot.regionIds ?? [])
-                        .map((regionId) => getRegionName(regionId) ?? regionId)
-                        .join(' ')}`}
-                      onSelect={() => handleChange(snapshot)}
-                      className="cursor-pointer gap-2"
-                    >
-                      <Check
-                        className={cn('size-4 shrink-0', {
-                          'opacity-100': value === snapshot.name,
-                          'opacity-0': value !== snapshot.name,
-                        })}
-                      />
-                      <div className="flex min-w-0 flex-1 items-center gap-2">
-                        <span className="truncate">{snapshot.name}</span>
-                        {snapshot.general && (
-                          <Badge variant="secondary" className="shrink-0">
-                            System
-                          </Badge>
-                        )}
-                      </div>
-                      <SnapshotRegionInline regionIds={snapshot.regionIds} getRegionName={getRegionName} />
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </>
-            )}
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  )
-}
-
-function SnapshotRegionInline({
-  regionIds,
-  getRegionName,
-}: {
-  regionIds?: string[]
-  getRegionName: (regionId: string) => string | undefined
-}) {
-  if (!regionIds?.length) {
-    return <span className="ml-auto shrink-0 text-xs text-muted-foreground">-</span>
-  }
-
-  const regionNames = regionIds.map((regionId) => getRegionName(regionId) ?? regionId)
-  const firstRegion = regionNames[0]
-  const remainingCount = regionNames.length - 1
-
-  if (remainingCount === 0) {
-    return (
-      <span
-        className="ml-auto block max-w-[150px] shrink-0 truncate text-right text-xs text-muted-foreground"
-        title={firstRegion}
-      >
-        {firstRegion}
-      </span>
-    )
-  }
-
-  return (
-    <Tooltip
-      label={
-        <div className="ml-auto flex shrink-0 items-center gap-1.5">
-          <span className="max-w-[150px] truncate text-xs text-muted-foreground">{firstRegion}</span>
-          <Badge variant="secondary" className="h-5 px-1.5 py-0 text-xs">
-            +{remainingCount}
-          </Badge>
-        </div>
-      }
-      content={
-        <div className="flex flex-col gap-1">
-          {regionNames.map((regionName, index) => (
-            <span key={`${regionName}-${index}`}>{regionName}</span>
-          ))}
-        </div>
-      }
-    />
-  )
-}
-
-const DEFAULT_SNAPSHOTS: SnapshotDto[] = []
-
 export const CreateSandboxSheet = ({
   className,
   ref,
@@ -392,17 +177,18 @@ export const CreateSandboxSheet = ({
   onSandboxCreated?: (sandbox: Sandbox) => void
 }) => {
   const [open, setOpen] = useState(false)
-  const [snapshotSelectOpen, setSnapshotSelectOpen] = useState(false)
-  const [snapshotSearchValue, setSnapshotSearchValue] = useState('')
   const [selectedSnapshotOption, setSelectedSnapshotOption] = useState<SnapshotDto | undefined>(undefined)
 
   const config = useConfig()
-  const { availableRegions: regions, loadingAvailableRegions: loadingRegions, getRegionName } = useRegions()
+  const { availableRegions: regions, loadingAvailableRegions: loadingRegions } = useRegions()
   const { selectedOrganization, authenticatedUserOrganizationMember } = useSelectedOrganization()
   const { reset: resetCreateSandboxMutation, ...createSandboxMutation } = useCreateSandboxMutation()
   const setDefaultRegionMutation = useSetOrganizationDefaultRegionMutation()
   const formRef = useRef<HTMLFormElement>(null)
-  const sheetContentRef = useRef<HTMLDivElement>(null)
+  const [popoverContainer, setPopoverContainer] = useState<HTMLDivElement | null>(null)
+  const handleSheetContentRef = useCallback((node: HTMLDivElement | null) => {
+    setPopoverContainer(node)
+  }, [])
   const formDefaultValues = useMemo<FormValues>(
     () => ({
       ...defaultValues,
@@ -427,39 +213,6 @@ export const CreateSandboxSheet = ({
   })
 
   const formSchema = useMemo(() => buildFormSchema(maxCpu, maxMemory, maxDisk), [maxCpu, maxMemory, maxDisk])
-
-  const debouncedSnapshotSearchValue = useDebouncedValue(snapshotSearchValue, 300)
-  const snapshotNameFilter = debouncedSnapshotSearchValue.trim()
-  const {
-    data: snapshotsData,
-    isLoading: snapshotsLoading,
-    isFetching: snapshotsFetching,
-  } = useSnapshotsQuery({
-    page: 1,
-    pageSize: 100,
-    filters: snapshotNameFilter ? { name: snapshotNameFilter } : undefined,
-  })
-
-  const snapshots = useMemo(
-    () => snapshotsData?.items.filter((snapshot) => snapshot.state === SnapshotState.ACTIVE) ?? DEFAULT_SNAPSHOTS,
-    [snapshotsData?.items],
-  )
-  const defaultSnapshotFromList = useMemo(
-    () => snapshots.find((snapshot) => snapshot.name === config.defaultSnapshot),
-    [config.defaultSnapshot, snapshots],
-  )
-  const shouldFetchDefaultSnapshot = Boolean(snapshotsData && !defaultSnapshotFromList)
-  const { data: defaultSnapshotData, isFetching: defaultSnapshotFetching } = useSnapshotsQuery(
-    {
-      page: 1,
-      pageSize: 10,
-      filters: { name: config.defaultSnapshot },
-    },
-    { enabled: shouldFetchDefaultSnapshot },
-  )
-
-  const snapshotsSearchPending = snapshotSearchValue !== debouncedSnapshotSearchValue
-  const snapshotsSearchActive = snapshotsFetching || snapshotsSearchPending
 
   const form = useForm({
     defaultValues: formDefaultValues,
@@ -569,24 +322,8 @@ export const CreateSandboxSheet = ({
       return undefined
     }
 
-    return snapshots.find((snapshot) => snapshot.name === selectedSnapshotName) ?? selectedSnapshotOption
-  }, [selectedSnapshotName, selectedSnapshotOption, snapshots])
-  const defaultSnapshot =
-    defaultSnapshotFromList ??
-    defaultSnapshotData?.items.find(
-      (snapshot) => snapshot.state === SnapshotState.ACTIVE && snapshot.name === config.defaultSnapshot,
-    )
-  const effectiveSnapshot = useMemo(() => {
-    if (selectedSnapshot) {
-      return selectedSnapshot
-    }
-
-    if (!selectedSnapshotName || selectedSnapshotName === config.defaultSnapshot) {
-      return defaultSnapshot
-    }
-
-    return undefined
-  }, [config.defaultSnapshot, defaultSnapshot, selectedSnapshot, selectedSnapshotName])
+    return selectedSnapshotOption?.name === selectedSnapshotName ? selectedSnapshotOption : undefined
+  }, [selectedSnapshotName, selectedSnapshotOption])
   const getRegionsForSnapshot = useCallback(
     (snapshot?: SnapshotDto) => {
       if (!snapshot) {
@@ -602,17 +339,22 @@ export const CreateSandboxSheet = ({
     },
     [regions],
   )
+  const sharedAvailableRegions = useMemo(
+    () => regions.filter((region) => region.regionType === RegionType.SHARED),
+    [regions],
+  )
   const snapshotFilteredRegions = useMemo(() => {
     if (selectedSource !== Source.SNAPSHOT) {
       return regions
     }
 
-    return getRegionsForSnapshot(effectiveSnapshot)
-  }, [effectiveSnapshot, getRegionsForSnapshot, regions, selectedSource])
-  const defaultSnapshotNeeded = !selectedSnapshotName || selectedSnapshotName === config.defaultSnapshot
-  const defaultSnapshotLoading = defaultSnapshotNeeded && !defaultSnapshot && defaultSnapshotFetching
-  const regionsDisabled =
-    loadingRegions || (selectedSource === Source.SNAPSHOT && (snapshotsSearchActive || defaultSnapshotLoading))
+    if (!selectedSnapshot) {
+      return sharedAvailableRegions
+    }
+
+    return getRegionsForSnapshot(selectedSnapshot)
+  }, [getRegionsForSnapshot, regions, selectedSnapshot, selectedSource, sharedAvailableRegions])
+  const regionsDisabled = loadingRegions
 
   const setRegionFromAvailableRegions = useCallback(
     (nextRegions: Region[]) => {
@@ -660,7 +402,6 @@ export const CreateSandboxSheet = ({
     (snapshot: SnapshotDto) => {
       form.setFieldValue('snapshot', snapshot.name)
       setSelectedSnapshotOption(snapshot)
-      setSnapshotSearchValue(snapshot.name)
       setRegionFromAvailableRegions(getRegionsForSnapshot(snapshot))
     },
     [form, getRegionsForSnapshot, setRegionFromAvailableRegions],
@@ -669,21 +410,13 @@ export const CreateSandboxSheet = ({
   const resetState = useCallback(() => {
     resetForm(formDefaultValues)
     resetCreateSandboxMutation()
-    setSnapshotSelectOpen(false)
-    setSnapshotSearchValue('')
     setSelectedSnapshotOption(undefined)
   }, [formDefaultValues, resetForm, resetCreateSandboxMutation])
 
   const handleDefaultSnapshotSelect = useCallback(() => {
-    if (defaultSnapshot) {
-      handleSnapshotChange(defaultSnapshot)
-    } else {
-      form.setFieldValue('snapshot', config.defaultSnapshot)
-      setSelectedSnapshotOption(undefined)
-      setSnapshotSearchValue(config.defaultSnapshot)
-    }
-    setSnapshotSelectOpen(false)
-  }, [config.defaultSnapshot, defaultSnapshot, form, handleSnapshotChange])
+    form.setFieldValue('snapshot', config.defaultSnapshot)
+    setSelectedSnapshotOption(undefined)
+  }, [config.defaultSnapshot, form])
 
   const handleEnvFileImport = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -734,7 +467,6 @@ export const CreateSandboxSheet = ({
     if (!open || loadingRegions) return
 
     if (selectedSource === Source.SNAPSHOT) {
-      if (snapshotsSearchActive) return
       setRegionFromAvailableRegions(snapshotFilteredRegions)
       return
     }
@@ -752,7 +484,6 @@ export const CreateSandboxSheet = ({
     selectedSource,
     setRegionFromAvailableRegions,
     snapshotFilteredRegions,
-    snapshotsSearchActive,
   ])
 
   return (
@@ -765,7 +496,7 @@ export const CreateSandboxSheet = ({
       <SheetTrigger asChild>
         <CreateResourceButton resource="Sandbox" />
       </SheetTrigger>
-      <SheetContent ref={sheetContentRef} className={`w-dvw sm:w-[500px] p-0 flex flex-col gap-0 ${className ?? ''}`}>
+      <SheetContent ref={handleSheetContentRef} className={cn('w-dvw sm:w-[500px] flex flex-col gap-0 p-0', className)}>
         <SheetHeader className="border-b border-border p-4 px-5 items-center flex text-left flex-row">
           <SheetTitle>Create Sandbox</SheetTitle>
           <SheetDescription className="sr-only">Create a new sandbox in your organization.</SheetDescription>
@@ -828,20 +559,13 @@ export const CreateSandboxSheet = ({
                       {(field) => (
                         <Field>
                           <FieldLabel htmlFor={field.name}>Snapshot</FieldLabel>
-                          <SnapshotCommandSelect
+                          <SnapshotSelect
                             id={field.name}
+                            name={field.name}
                             value={field.state.value}
-                            selectedSnapshot={selectedSnapshot}
-                            snapshots={snapshots}
-                            loading={snapshotsLoading}
-                            fetching={snapshotsSearchActive}
-                            searchValue={snapshotSearchValue}
-                            getRegionName={getRegionName}
-                            open={snapshotSelectOpen}
-                            popoverContainer={sheetContentRef.current}
-                            onChange={handleSnapshotChange}
-                            onOpenChange={setSnapshotSelectOpen}
-                            onSearchChange={setSnapshotSearchValue}
+                            placeholder="Default snapshot"
+                            popoverContainer={popoverContainer}
+                            onValueChange={handleSnapshotChange}
                           />
                           <FieldDescription>
                             If unspecified,{' '}
@@ -1086,11 +810,9 @@ export const CreateSandboxSheet = ({
                           placeholder={
                             loadingRegions
                               ? 'Loading regions...'
-                              : selectedSource === Source.SNAPSHOT && (snapshotsSearchActive || defaultSnapshotLoading)
-                                ? 'Loading snapshot regions...'
-                                : snapshotFilteredRegions.length === 0
-                                  ? 'No regions available'
-                                  : 'Select a region'
+                              : snapshotFilteredRegions.length === 0
+                                ? 'No regions available'
+                                : 'Select a region'
                           }
                         />
                       </SelectTrigger>
@@ -1103,9 +825,9 @@ export const CreateSandboxSheet = ({
                       </SelectContent>
                     </Select>
                     <FieldDescription>
-                      {selectedSource === Source.SNAPSHOT && effectiveSnapshot && snapshotFilteredRegions.length === 0
+                      {selectedSource === Source.SNAPSHOT && selectedSnapshot && snapshotFilteredRegions.length === 0
                         ? 'The selected snapshot is not available in any selectable region.'
-                        : selectedSource === Source.SNAPSHOT && effectiveSnapshot?.regionIds?.length
+                        : selectedSource === Source.SNAPSHOT && selectedSnapshot?.regionIds?.length
                           ? 'Only regions where the selected snapshot is available are shown.'
                           : 'The region where the sandbox will be created.'}
                     </FieldDescription>

--- a/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
+++ b/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
@@ -3,13 +3,15 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Badge } from '@/components/ui/badge'
 import { CreateResourceButton } from '@/components/CreateResourceButton'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
 import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
   Sheet,
@@ -34,11 +36,11 @@ import { handleApiError } from '@/lib/error-handling'
 import { GPU_TYPE_LABELS } from '@/lib/gpu-types'
 import { imageNameSchema } from '@/lib/schema'
 import { cn, getRegionFullDisplayName } from '@/lib/utils'
-import { GpuType, OrganizationUserRoleEnum } from '@daytona/api-client'
+import { GpuType, OrganizationUserRoleEnum, type Region, type SnapshotDto } from '@daytona/api-client'
 import { Sandbox } from '@daytona/sdk'
-import { useForm } from '@tanstack/react-form'
+import { useForm, useStore } from '@tanstack/react-form'
 import { isAxiosError } from 'axios'
-import { Info, Minus, Plus, Upload } from 'lucide-react'
+import { Check, ChevronDownIcon, ChevronsUpDown, Info, Minus, Plus, Upload } from 'lucide-react'
 import { ComponentProps, Ref, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { NumericFormat } from 'react-number-format'
 import { toast } from 'sonner'
@@ -160,6 +162,163 @@ const InfoTooltipButton = ({ className, ...props }: ComponentProps<'button'>) =>
   )
 }
 
+function SnapshotCommandSelect({
+  id,
+  value,
+  defaultSnapshot,
+  snapshots,
+  snapshotsLoading,
+  availableRegions,
+  getRegionName,
+  popoverContainer,
+  onChange,
+}: {
+  id: string
+  value?: string
+  defaultSnapshot: string
+  snapshots: SnapshotDto[]
+  snapshotsLoading: boolean
+  availableRegions: Region[]
+  getRegionName: (regionId: string) => string | undefined
+  popoverContainer?: HTMLElement | null
+  onChange: (value: string) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const selectedSnapshot = snapshots.find((snapshot) => snapshot.name === value)
+  const selectableSnapshots = snapshots.filter((snapshot) => snapshot.name !== defaultSnapshot)
+  const defaultRegionIds = availableRegions.map((region) => region.id)
+  const selectedLabel = selectedSnapshot?.name ?? defaultSnapshot
+
+  const handleChange = (nextValue: string) => {
+    onChange(nextValue)
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={snapshotsLoading}
+          className="h-8 w-full justify-between px-3 font-normal"
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="truncate">{snapshotsLoading ? 'Loading snapshots...' : selectedLabel}</span>
+          </span>
+          <ChevronDownIcon className="size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start" container={popoverContainer}>
+        <Command>
+          <CommandInput placeholder="Search snapshots..." />
+          <CommandList className="max-h-64 overscroll-contain">
+            {snapshotsLoading ? (
+              <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
+                <Spinner className="size-4" />
+                Loading snapshots...
+              </div>
+            ) : (
+              <>
+                <CommandEmpty>No snapshots found.</CommandEmpty>
+                <CommandGroup>
+                  <CommandItem
+                    value={`${NONE_VALUE} ${defaultSnapshot} default system ${defaultRegionIds
+                      .map((regionId) => getRegionName(regionId) ?? regionId)
+                      .join(' ')}`}
+                    onSelect={() => handleChange('')}
+                    className="cursor-pointer gap-2"
+                  >
+                    <Check
+                      className={cn('size-4 shrink-0', {
+                        'opacity-100': !value,
+                        'opacity-0': !!value,
+                      })}
+                    />
+                    <div className="flex min-w-0 flex-1 items-center gap-2">
+                      <span className="truncate">{defaultSnapshot}</span>
+                      <Badge className="shrink-0">default</Badge>
+                      <Badge variant="secondary" className="shrink-0">
+                        System
+                      </Badge>
+                    </div>
+                    <SnapshotRegionInline regionIds={defaultRegionIds} getRegionName={getRegionName} />
+                  </CommandItem>
+                  {selectableSnapshots.map((snapshot) => (
+                    <CommandItem
+                      key={snapshot.id}
+                      value={`${snapshot.name} ${(snapshot.regionIds ?? [])
+                        .map((regionId) => getRegionName(regionId) ?? regionId)
+                        .join(' ')}`}
+                      onSelect={() => handleChange(snapshot.name)}
+                      className="cursor-pointer gap-2"
+                    >
+                      <Check
+                        className={cn('size-4 shrink-0', {
+                          'opacity-100': value === snapshot.name,
+                          'opacity-0': value !== snapshot.name,
+                        })}
+                      />
+                      <div className="flex min-w-0 flex-1 items-center gap-2">
+                        <span className="truncate">{snapshot.name}</span>
+                        {snapshot.general && (
+                          <Badge variant="secondary" className="shrink-0">
+                            System
+                          </Badge>
+                        )}
+                      </div>
+                      <SnapshotRegionInline regionIds={snapshot.regionIds} getRegionName={getRegionName} />
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function SnapshotRegionInline({
+  regionIds,
+  getRegionName,
+}: {
+  regionIds?: string[]
+  getRegionName: (regionId: string) => string | undefined
+}) {
+  if (!regionIds?.length) {
+    return <span className="ml-auto shrink-0 text-xs text-muted-foreground">-</span>
+  }
+
+  const regionNames = regionIds.map((regionId) => getRegionName(regionId) ?? regionId)
+  const firstRegion = regionNames[0]
+  const remainingCount = regionNames.length - 1
+  const label = remainingCount > 0 ? `${firstRegion} +${remainingCount}` : firstRegion
+
+  return (
+    <Tooltip
+      label={
+        <span className="ml-auto max-w-24 shrink-0 truncate text-right text-xs text-muted-foreground" title={label}>
+          {label}
+        </span>
+      }
+      content={
+        <div className="flex flex-col gap-1">
+          {regionNames.map((regionName) => (
+            <span key={regionName}>{regionName}</span>
+          ))}
+        </div>
+      }
+    />
+  )
+}
+
+const DEFAULT_SNAPSHOTS: SnapshotDto[] = []
+
 export const CreateSandboxSheet = ({
   className,
   ref,
@@ -172,11 +331,12 @@ export const CreateSandboxSheet = ({
   const [open, setOpen] = useState(false)
 
   const config = useConfig()
-  const { availableRegions: regions, loadingAvailableRegions: loadingRegions } = useRegions()
+  const { availableRegions: regions, loadingAvailableRegions: loadingRegions, getRegionName } = useRegions()
   const { selectedOrganization, authenticatedUserOrganizationMember } = useSelectedOrganization()
   const { reset: resetCreateSandboxMutation, ...createSandboxMutation } = useCreateSandboxMutation()
   const setDefaultRegionMutation = useSetOrganizationDefaultRegionMutation()
   const formRef = useRef<HTMLFormElement>(null)
+  const sheetContentRef = useRef<HTMLDivElement>(null)
   const formDefaultValues = useMemo<FormValues>(
     () => ({
       ...defaultValues,
@@ -206,6 +366,8 @@ export const CreateSandboxSheet = ({
     page: 1,
     pageSize: 100,
   })
+
+  const snapshots = snapshotsData?.items ?? DEFAULT_SNAPSHOTS
 
   const form = useForm({
     defaultValues: formDefaultValues,
@@ -308,6 +470,57 @@ export const CreateSandboxSheet = ({
     },
   })
   const { reset: resetForm } = form
+  const selectedSource = useStore(form.store, (state) => state.values.source)
+  const selectedSnapshotName = useStore(form.store, (state) => state.values.snapshot)
+  const selectedSnapshot = useMemo(
+    () => snapshots?.find((snapshot) => snapshot.name === selectedSnapshotName),
+    [selectedSnapshotName, snapshots],
+  )
+  const getRegionsForSnapshot = useCallback(
+    (snapshotName?: string) => {
+      const snapshot = snapshots.find((snapshot) => snapshot.name === snapshotName)
+      if (!snapshot?.regionIds?.length) {
+        return regions
+      }
+
+      const snapshotRegionIds = new Set(snapshot.regionIds)
+      return regions.filter((region) => snapshotRegionIds.has(region.id))
+    },
+    [regions, snapshots],
+  )
+  const snapshotFilteredRegions = useMemo(() => {
+    if (selectedSource !== Source.SNAPSHOT) {
+      return regions
+    }
+
+    return getRegionsForSnapshot(selectedSnapshotName)
+  }, [getRegionsForSnapshot, regions, selectedSnapshotName, selectedSource])
+
+  const syncRegionForSnapshot = useCallback(
+    (snapshotName?: string) => {
+      const nextRegions = getRegionsForSnapshot(snapshotName)
+      const currentRegionId = form.getFieldValue('regionId')
+      const currentRegionAvailable = !!currentRegionId && nextRegions.some((region) => region.id === currentRegionId)
+
+      if (currentRegionAvailable) {
+        return
+      }
+
+      if (nextRegions.length === 0) {
+        if (currentRegionId) {
+          form.setFieldValue('regionId', undefined)
+        }
+        return
+      }
+
+      const defaultRegion = selectedOrganization?.defaultRegionId
+        ? nextRegions.find((region) => region.id === selectedOrganization.defaultRegionId)
+        : undefined
+
+      form.setFieldValue('regionId', defaultRegion?.id ?? nextRegions[0].id)
+    },
+    [form, getRegionsForSnapshot, selectedOrganization?.defaultRegionId],
+  )
 
   const handleSourceChange = useCallback(
     (val: string) => {
@@ -324,6 +537,14 @@ export const CreateSandboxSheet = ({
       }
     },
     [form],
+  )
+  const handleSnapshotChange = useCallback(
+    (snapshotName: string) => {
+      const nextSnapshotName = snapshotName || undefined
+      form.setFieldValue('snapshot', nextSnapshotName)
+      syncRegionForSnapshot(nextSnapshotName)
+    },
+    [form, syncRegionForSnapshot],
   )
 
   const resetState = useCallback(() => {
@@ -378,11 +599,26 @@ export const CreateSandboxSheet = ({
 
   useEffect(() => {
     if (!open || loadingRegions) return
+
+    if (selectedSource === Source.SNAPSHOT && selectedSnapshotName) {
+      syncRegionForSnapshot(selectedSnapshotName)
+      return
+    }
+
     if (regions.length !== 1) return
     if (selectedOrganization?.defaultRegionId) return
     if (form.getFieldValue('regionId')) return
     form.setFieldValue('regionId', regions[0].id)
-  }, [open, loadingRegions, regions, selectedOrganization?.defaultRegionId, form])
+  }, [
+    form,
+    loadingRegions,
+    open,
+    regions,
+    selectedOrganization?.defaultRegionId,
+    selectedSnapshotName,
+    selectedSource,
+    syncRegionForSnapshot,
+  ])
 
   return (
     <Sheet
@@ -394,7 +630,7 @@ export const CreateSandboxSheet = ({
       <SheetTrigger asChild>
         <CreateResourceButton resource="Sandbox" />
       </SheetTrigger>
-      <SheetContent className={`w-dvw sm:w-[500px] p-0 flex flex-col gap-0 ${className ?? ''}`}>
+      <SheetContent ref={sheetContentRef} className={`w-dvw sm:w-[500px] p-0 flex flex-col gap-0 ${className ?? ''}`}>
         <SheetHeader className="border-b border-border p-4 px-5 items-center flex text-left flex-row">
           <SheetTitle>Create Sandbox</SheetTitle>
           <SheetDescription className="sr-only">Create a new sandbox in your organization.</SheetDescription>
@@ -457,31 +693,17 @@ export const CreateSandboxSheet = ({
                       {(field) => (
                         <Field>
                           <FieldLabel htmlFor={field.name}>Snapshot</FieldLabel>
-                          <Select
-                            value={field.state.value || NONE_VALUE}
-                            onValueChange={(val) => field.handleChange(val === NONE_VALUE ? '' : val)}
-                          >
-                            <SelectTrigger
-                              className="h-8"
-                              id={field.name}
-                              disabled={snapshotsLoading}
-                              loading={snapshotsLoading}
-                            >
-                              <SelectValue
-                                placeholder={snapshotsLoading ? 'Loading snapshots...' : 'Select a snapshot'}
-                              />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value={NONE_VALUE}>
-                                {config.defaultSnapshot} <Badge variant="secondary">default</Badge>
-                              </SelectItem>
-                              {snapshotsData?.items?.map((snapshot) => (
-                                <SelectItem key={snapshot.id} value={snapshot.name}>
-                                  {snapshot.name}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
+                          <SnapshotCommandSelect
+                            id={field.name}
+                            value={field.state.value}
+                            defaultSnapshot={config.defaultSnapshot}
+                            snapshots={snapshots}
+                            snapshotsLoading={snapshotsLoading}
+                            availableRegions={regions}
+                            getRegionName={getRegionName}
+                            popoverContainer={sheetContentRef.current}
+                            onChange={handleSnapshotChange}
+                          />
                         </Field>
                       )}
                     </form.Field>
@@ -701,18 +923,35 @@ export const CreateSandboxSheet = ({
                 <Field>
                   <FieldLabel htmlFor={field.name}>Region</FieldLabel>
                   <Select value={field.state.value} onValueChange={field.handleChange}>
-                    <SelectTrigger className="h-8" id={field.name} disabled={loadingRegions} loading={loadingRegions}>
-                      <SelectValue placeholder={loadingRegions ? 'Loading regions...' : 'Select a region'} />
+                    <SelectTrigger
+                      className="h-8"
+                      id={field.name}
+                      disabled={loadingRegions || snapshotFilteredRegions.length === 0}
+                      loading={loadingRegions}
+                    >
+                      <SelectValue
+                        placeholder={
+                          loadingRegions
+                            ? 'Loading regions...'
+                            : snapshotFilteredRegions.length === 0
+                              ? 'No regions available'
+                              : 'Select a region'
+                        }
+                      />
                     </SelectTrigger>
                     <SelectContent>
-                      {regions.map((region) => (
+                      {snapshotFilteredRegions.map((region) => (
                         <SelectItem key={region.id} value={region.id}>
                           {getRegionFullDisplayName(region)}
                         </SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
-                  <FieldDescription>The region where the sandbox will be created.</FieldDescription>
+                  <FieldDescription>
+                    {selectedSource === Source.SNAPSHOT && selectedSnapshot?.regionIds?.length
+                      ? 'Only regions where the selected snapshot is available are shown.'
+                      : 'The region where the sandbox will be created.'}
+                  </FieldDescription>
                 </Field>
               )}
             </form.Field>

--- a/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
+++ b/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
@@ -444,6 +444,19 @@ export const CreateSandboxSheet = ({
     () => snapshotsData?.items.filter((snapshot) => snapshot.state === SnapshotState.ACTIVE) ?? DEFAULT_SNAPSHOTS,
     [snapshotsData?.items],
   )
+  const defaultSnapshotFromList = useMemo(
+    () => snapshots.find((snapshot) => snapshot.name === config.defaultSnapshot),
+    [config.defaultSnapshot, snapshots],
+  )
+  const shouldFetchDefaultSnapshot = Boolean(snapshotsData && !defaultSnapshotFromList)
+  const { data: defaultSnapshotData, isFetching: defaultSnapshotFetching } = useSnapshotsQuery(
+    {
+      page: 1,
+      pageSize: 10,
+      filters: { name: config.defaultSnapshot },
+    },
+    { enabled: shouldFetchDefaultSnapshot },
+  )
 
   const snapshotsSearchPending = snapshotSearchValue !== debouncedSnapshotSearchValue
   const snapshotsSearchActive = snapshotsFetching || snapshotsSearchPending
@@ -558,10 +571,26 @@ export const CreateSandboxSheet = ({
 
     return snapshots.find((snapshot) => snapshot.name === selectedSnapshotName) ?? selectedSnapshotOption
   }, [selectedSnapshotName, selectedSnapshotOption, snapshots])
+  const defaultSnapshot =
+    defaultSnapshotFromList ??
+    defaultSnapshotData?.items.find(
+      (snapshot) => snapshot.state === SnapshotState.ACTIVE && snapshot.name === config.defaultSnapshot,
+    )
+  const effectiveSnapshot = useMemo(() => {
+    if (selectedSnapshot) {
+      return selectedSnapshot
+    }
+
+    if (!selectedSnapshotName || selectedSnapshotName === config.defaultSnapshot) {
+      return defaultSnapshot
+    }
+
+    return undefined
+  }, [config.defaultSnapshot, defaultSnapshot, selectedSnapshot, selectedSnapshotName])
   const getRegionsForSnapshot = useCallback(
     (snapshot?: SnapshotDto) => {
       if (!snapshot) {
-        return regions
+        return []
       }
 
       if (!snapshot.regionIds?.length) {
@@ -578,9 +607,12 @@ export const CreateSandboxSheet = ({
       return regions
     }
 
-    return getRegionsForSnapshot(selectedSnapshot)
-  }, [getRegionsForSnapshot, regions, selectedSnapshot, selectedSource])
-  const regionsDisabled = loadingRegions || (selectedSource === Source.SNAPSHOT && snapshotsSearchActive)
+    return getRegionsForSnapshot(effectiveSnapshot)
+  }, [effectiveSnapshot, getRegionsForSnapshot, regions, selectedSource])
+  const defaultSnapshotNeeded = !selectedSnapshotName || selectedSnapshotName === config.defaultSnapshot
+  const defaultSnapshotLoading = defaultSnapshotNeeded && !defaultSnapshot && defaultSnapshotFetching
+  const regionsDisabled =
+    loadingRegions || (selectedSource === Source.SNAPSHOT && (snapshotsSearchActive || defaultSnapshotLoading))
 
   const setRegionFromAvailableRegions = useCallback(
     (nextRegions: Region[]) => {
@@ -643,7 +675,6 @@ export const CreateSandboxSheet = ({
   }, [formDefaultValues, resetForm, resetCreateSandboxMutation])
 
   const handleDefaultSnapshotSelect = useCallback(() => {
-    const defaultSnapshot = snapshots.find((snapshot) => snapshot.name === config.defaultSnapshot)
     if (defaultSnapshot) {
       handleSnapshotChange(defaultSnapshot)
     } else {
@@ -652,7 +683,7 @@ export const CreateSandboxSheet = ({
       setSnapshotSearchValue(config.defaultSnapshot)
     }
     setSnapshotSelectOpen(false)
-  }, [config.defaultSnapshot, form, handleSnapshotChange, snapshots])
+  }, [config.defaultSnapshot, defaultSnapshot, form, handleSnapshotChange])
 
   const handleEnvFileImport = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -1055,7 +1086,7 @@ export const CreateSandboxSheet = ({
                           placeholder={
                             loadingRegions
                               ? 'Loading regions...'
-                              : selectedSource === Source.SNAPSHOT && snapshotsSearchActive
+                              : selectedSource === Source.SNAPSHOT && (snapshotsSearchActive || defaultSnapshotLoading)
                                 ? 'Loading snapshot regions...'
                                 : snapshotFilteredRegions.length === 0
                                   ? 'No regions available'
@@ -1072,9 +1103,9 @@ export const CreateSandboxSheet = ({
                       </SelectContent>
                     </Select>
                     <FieldDescription>
-                      {selectedSource === Source.SNAPSHOT && selectedSnapshot && snapshotFilteredRegions.length === 0
+                      {selectedSource === Source.SNAPSHOT && effectiveSnapshot && snapshotFilteredRegions.length === 0
                         ? 'The selected snapshot is not available in any selectable region.'
-                        : selectedSource === Source.SNAPSHOT && selectedSnapshot?.regionIds?.length
+                        : selectedSource === Source.SNAPSHOT && effectiveSnapshot?.regionIds?.length
                           ? 'Only regions where the selected snapshot is available are shown.'
                           : 'The region where the sandbox will be created.'}
                     </FieldDescription>

--- a/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
+++ b/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
@@ -406,17 +406,22 @@ export const CreateSandboxSheet = ({
     },
     [form, getRegionsForSnapshot, setRegionFromAvailableRegions],
   )
+  const handleSnapshotValueChange = useCallback(
+    (snapshotName: string | undefined) => {
+      form.setFieldValue('snapshot', snapshotName)
+
+      if (!snapshotName) {
+        setSelectedSnapshotOption(undefined)
+      }
+    },
+    [form],
+  )
 
   const resetState = useCallback(() => {
     resetForm(formDefaultValues)
     resetCreateSandboxMutation()
     setSelectedSnapshotOption(undefined)
   }, [formDefaultValues, resetForm, resetCreateSandboxMutation])
-
-  const handleDefaultSnapshotSelect = useCallback(() => {
-    form.setFieldValue('snapshot', config.defaultSnapshot)
-    setSelectedSnapshotOption(undefined)
-  }, [config.defaultSnapshot, form])
 
   const handleEnvFileImport = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -565,18 +570,12 @@ export const CreateSandboxSheet = ({
                             value={field.state.value}
                             placeholder="Default snapshot"
                             popoverContainer={popoverContainer}
-                            onValueChange={handleSnapshotChange}
+                            onSnapshotChange={handleSnapshotChange}
+                            onValueChange={handleSnapshotValueChange}
                           />
                           <FieldDescription>
                             If unspecified,{' '}
-                            <button
-                              type="button"
-                              className="font-medium text-foreground underline underline-offset-2"
-                              onClick={handleDefaultSnapshotSelect}
-                            >
-                              {config.defaultSnapshot}
-                            </button>{' '}
-                            will be used.
+                            <span className="font-medium text-foreground">{config.defaultSnapshot}</span> will be used.
                           </FieldDescription>
                         </Field>
                       )}

--- a/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
+++ b/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
@@ -478,9 +478,17 @@ export const CreateSandboxSheet = ({
   )
   const getRegionsForSnapshot = useCallback(
     (snapshotName?: string) => {
-      const snapshot = snapshots.find((snapshot) => snapshot.name === snapshotName)
-      if (!snapshot?.regionIds?.length) {
+      if (!snapshotName) {
         return regions
+      }
+
+      const snapshot = snapshots.find((snapshot) => snapshot.name === snapshotName)
+      if (!snapshot) {
+        return []
+      }
+
+      if (!snapshot.regionIds?.length) {
+        return []
       }
 
       const snapshotRegionIds = new Set(snapshot.regionIds)
@@ -948,9 +956,11 @@ export const CreateSandboxSheet = ({
                     </SelectContent>
                   </Select>
                   <FieldDescription>
-                    {selectedSource === Source.SNAPSHOT && selectedSnapshot?.regionIds?.length
-                      ? 'Only regions where the selected snapshot is available are shown.'
-                      : 'The region where the sandbox will be created.'}
+                    {selectedSource === Source.SNAPSHOT && selectedSnapshot && snapshotFilteredRegions.length === 0
+                      ? 'The selected snapshot is not available in any selectable region.'
+                      : selectedSource === Source.SNAPSHOT && selectedSnapshot?.regionIds?.length
+                        ? 'Only regions where the selected snapshot is available are shown.'
+                        : 'The region where the sandbox will be created.'}
                   </FieldDescription>
                 </Field>
               )}

--- a/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
+++ b/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
@@ -112,18 +112,28 @@ const buildBaseFormSchema = (maxCpu?: number, maxMemory?: number, maxDisk?: numb
 
 const buildFormSchema = (maxCpu?: number, maxMemory?: number, maxDisk?: number) => {
   const base = buildBaseFormSchema(maxCpu, maxMemory, maxDisk)
-  return z.discriminatedUnion('source', [
-    base.extend({
-      source: z.literal(Source.SNAPSHOT),
-      snapshot: z.string().optional(),
-      image: z.string().optional(),
-    }),
-    base.extend({
-      source: z.literal(Source.IMAGE),
-      snapshot: z.string().optional(),
-      image: imageNameSchema,
-    }),
-  ])
+  return z
+    .discriminatedUnion('source', [
+      base.extend({
+        source: z.literal(Source.SNAPSHOT),
+        snapshot: z.string().optional(),
+        image: z.string().optional(),
+      }),
+      base.extend({
+        source: z.literal(Source.IMAGE),
+        snapshot: z.string().optional(),
+        image: imageNameSchema,
+      }),
+    ])
+    .superRefine((val, ctx) => {
+      if (val.source === Source.SNAPSHOT && !val.regionId) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['regionId'],
+          message: 'Selected snapshot is not available in any region you can use.',
+        })
+      }
+    })
 }
 
 type FormValues = z.input<ReturnType<typeof buildBaseFormSchema>> & {
@@ -185,8 +195,9 @@ function SnapshotCommandSelect({
 }) {
   const [open, setOpen] = useState(false)
   const selectedSnapshot = snapshots.find((snapshot) => snapshot.name === value)
+  const defaultSnapshotItem = snapshots.find((snapshot) => snapshot.name === defaultSnapshot)
   const selectableSnapshots = snapshots.filter((snapshot) => snapshot.name !== defaultSnapshot)
-  const defaultRegionIds = availableRegions.map((region) => region.id)
+  const defaultRegionIds = defaultSnapshotItem?.regionIds
   const selectedLabel = selectedSnapshot?.name ?? defaultSnapshot
 
   const handleChange = (nextValue: string) => {
@@ -226,7 +237,7 @@ function SnapshotCommandSelect({
                 <CommandEmpty>No snapshots found.</CommandEmpty>
                 <CommandGroup>
                   <CommandItem
-                    value={`${NONE_VALUE} ${defaultSnapshot} default system ${defaultRegionIds
+                    value={`${NONE_VALUE} ${defaultSnapshot} default system ${(defaultRegionIds ?? [])
                       .map((regionId) => getRegionName(regionId) ?? regionId)
                       .join(' ')}`}
                     onSelect={() => handleChange('')}
@@ -297,19 +308,32 @@ function SnapshotRegionInline({
   const regionNames = regionIds.map((regionId) => getRegionName(regionId) ?? regionId)
   const firstRegion = regionNames[0]
   const remainingCount = regionNames.length - 1
-  const label = remainingCount > 0 ? `${firstRegion} +${remainingCount}` : firstRegion
+
+  if (remainingCount === 0) {
+    return (
+      <span
+        className="ml-auto block max-w-[150px] shrink-0 truncate text-right text-xs text-muted-foreground"
+        title={firstRegion}
+      >
+        {firstRegion}
+      </span>
+    )
+  }
 
   return (
     <Tooltip
       label={
-        <span className="ml-auto max-w-24 shrink-0 truncate text-right text-xs text-muted-foreground" title={label}>
-          {label}
-        </span>
+        <div className="ml-auto flex shrink-0 items-center gap-1.5">
+          <span className="max-w-[150px] truncate text-xs text-muted-foreground">{firstRegion}</span>
+          <Badge variant="secondary" className="h-5 px-1.5 py-0 text-xs">
+            +{remainingCount}
+          </Badge>
+        </div>
       }
       content={
         <div className="flex flex-col gap-1">
-          {regionNames.map((regionName) => (
-            <span key={regionName}>{regionName}</span>
+          {regionNames.map((regionName, index) => (
+            <span key={`${regionName}-${index}`}>{regionName}</span>
           ))}
         </div>
       }
@@ -473,16 +497,12 @@ export const CreateSandboxSheet = ({
   const selectedSource = useStore(form.store, (state) => state.values.source)
   const selectedSnapshotName = useStore(form.store, (state) => state.values.snapshot)
   const selectedSnapshot = useMemo(
-    () => snapshots?.find((snapshot) => snapshot.name === selectedSnapshotName),
-    [selectedSnapshotName, snapshots],
+    () => snapshots?.find((snapshot) => snapshot.name === (selectedSnapshotName ?? config.defaultSnapshot)),
+    [config.defaultSnapshot, selectedSnapshotName, snapshots],
   )
   const getRegionsForSnapshot = useCallback(
     (snapshotName?: string) => {
-      if (!snapshotName) {
-        return regions
-      }
-
-      const snapshot = snapshots.find((snapshot) => snapshot.name === snapshotName)
+      const snapshot = snapshots.find((snapshot) => snapshot.name === (snapshotName ?? config.defaultSnapshot))
       if (!snapshot) {
         return []
       }
@@ -494,7 +514,7 @@ export const CreateSandboxSheet = ({
       const snapshotRegionIds = new Set(snapshot.regionIds)
       return regions.filter((region) => snapshotRegionIds.has(region.id))
     },
-    [regions, snapshots],
+    [config.defaultSnapshot, regions, snapshots],
   )
   const snapshotFilteredRegions = useMemo(() => {
     if (selectedSource !== Source.SNAPSHOT) {
@@ -608,7 +628,7 @@ export const CreateSandboxSheet = ({
   useEffect(() => {
     if (!open || loadingRegions) return
 
-    if (selectedSource === Source.SNAPSHOT && selectedSnapshotName) {
+    if (selectedSource === Source.SNAPSHOT) {
       syncRegionForSnapshot(selectedSnapshotName)
       return
     }
@@ -927,43 +947,48 @@ export const CreateSandboxSheet = ({
             </form.Subscribe>
 
             <form.Field name="regionId">
-              {(field) => (
-                <Field>
-                  <FieldLabel htmlFor={field.name}>Region</FieldLabel>
-                  <Select value={field.state.value} onValueChange={field.handleChange}>
-                    <SelectTrigger
-                      className="h-8"
-                      id={field.name}
-                      disabled={loadingRegions || snapshotFilteredRegions.length === 0}
-                      loading={loadingRegions}
-                    >
-                      <SelectValue
-                        placeholder={
-                          loadingRegions
-                            ? 'Loading regions...'
-                            : snapshotFilteredRegions.length === 0
-                              ? 'No regions available'
-                              : 'Select a region'
-                        }
-                      />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {snapshotFilteredRegions.map((region) => (
-                        <SelectItem key={region.id} value={region.id}>
-                          {getRegionFullDisplayName(region)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FieldDescription>
-                    {selectedSource === Source.SNAPSHOT && selectedSnapshot && snapshotFilteredRegions.length === 0
-                      ? 'The selected snapshot is not available in any selectable region.'
-                      : selectedSource === Source.SNAPSHOT && selectedSnapshot?.regionIds?.length
-                        ? 'Only regions where the selected snapshot is available are shown.'
-                        : 'The region where the sandbox will be created.'}
-                  </FieldDescription>
-                </Field>
-              )}
+              {(field) => {
+                const hasErrors = field.state.meta.errors.length > 0
+                return (
+                  <Field data-invalid={hasErrors}>
+                    <FieldLabel htmlFor={field.name}>Region</FieldLabel>
+                    <Select value={field.state.value} onValueChange={field.handleChange}>
+                      <SelectTrigger
+                        aria-invalid={hasErrors}
+                        className="h-8"
+                        id={field.name}
+                        disabled={loadingRegions || snapshotFilteredRegions.length === 0}
+                        loading={loadingRegions}
+                      >
+                        <SelectValue
+                          placeholder={
+                            loadingRegions
+                              ? 'Loading regions...'
+                              : snapshotFilteredRegions.length === 0
+                                ? 'No regions available'
+                                : 'Select a region'
+                          }
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {snapshotFilteredRegions.map((region) => (
+                          <SelectItem key={region.id} value={region.id}>
+                            {getRegionFullDisplayName(region)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FieldDescription>
+                      {selectedSource === Source.SNAPSHOT && snapshotFilteredRegions.length === 0
+                        ? 'The selected snapshot is not available in any selectable region.'
+                        : selectedSource === Source.SNAPSHOT && selectedSnapshot?.regionIds?.length
+                          ? 'Only regions where the selected snapshot is available are shown.'
+                          : 'The region where the sandbox will be created.'}
+                    </FieldDescription>
+                    {hasErrors && <FieldError errors={field.state.meta.errors} />}
+                  </Field>
+                )
+              }}
             </form.Field>
             {canSetDefaultRegion && (
               <form.Field name="setAsDefaultRegion">

--- a/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
+++ b/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
@@ -10,8 +10,9 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
 import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
+import { InputGroup, InputGroupAddon } from '@/components/ui/input-group'
 import { Label } from '@/components/ui/label'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
   Sheet,
@@ -29,6 +30,7 @@ import { useSetOrganizationDefaultRegionMutation } from '@/hooks/mutations/useSe
 import { useOrganizationUsageOverviewQuery } from '@/hooks/queries/useOrganizationUsageOverviewQuery'
 import { useSnapshotsQuery } from '@/hooks/queries/useSnapshotsQuery'
 import { useConfig } from '@/hooks/useConfig'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { useRegions } from '@/hooks/useRegions'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { parseEnvFile } from '@/lib/env'
@@ -36,11 +38,12 @@ import { handleApiError } from '@/lib/error-handling'
 import { GPU_TYPE_LABELS } from '@/lib/gpu-types'
 import { imageNameSchema } from '@/lib/schema'
 import { cn, getRegionFullDisplayName } from '@/lib/utils'
-import { GpuType, OrganizationUserRoleEnum, type Region, type SnapshotDto } from '@daytona/api-client'
+import { GpuType, OrganizationUserRoleEnum, SnapshotState, type Region, type SnapshotDto } from '@daytona/api-client'
 import { Sandbox } from '@daytona/sdk'
 import { useForm, useStore } from '@tanstack/react-form'
 import { isAxiosError } from 'axios'
-import { Check, ChevronDownIcon, ChevronsUpDown, Info, Minus, Plus, Upload } from 'lucide-react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { Check, ChevronDownIcon, Info, Minus, Plus, SearchIcon, Upload } from 'lucide-react'
 import { ComponentProps, Ref, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { NumericFormat } from 'react-number-format'
 import { toast } from 'sonner'
@@ -49,8 +52,6 @@ import { Tooltip } from '../Tooltip'
 import { ScrollArea } from '../ui/scroll-area'
 
 const NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
-
-const NONE_VALUE = '__none__'
 
 const SELECTABLE_GPU_TYPES = (Object.values(GpuType) as GpuType[]).filter((t) => t !== GpuType.UNKNOWN_DEFAULT_OPEN_API)
 
@@ -172,99 +173,137 @@ const InfoTooltipButton = ({ className, ...props }: ComponentProps<'button'>) =>
   )
 }
 
+const commandInputIconMotion = {
+  initial: { opacity: 0, y: 4, scale: 0.95 },
+  animate: { opacity: 1, y: 0, scale: 1 },
+  exit: { opacity: 0, y: -4, scale: 0.95 },
+  transition: { duration: 0.14, ease: 'easeOut' },
+} as const
+
+function CommandInputStatusIcon({ fetching }: { fetching: boolean }) {
+  return (
+    <span className="relative flex size-4 shrink-0 items-center justify-center opacity-50">
+      <AnimatePresence initial={false} mode="wait">
+        {fetching ? (
+          <motion.span
+            key="fetching"
+            className="absolute inset-0 flex items-center justify-center"
+            {...commandInputIconMotion}
+          >
+            <Spinner className="size-4" />
+          </motion.span>
+        ) : (
+          <motion.span
+            key="search"
+            className="absolute inset-0 flex items-center justify-center"
+            {...commandInputIconMotion}
+          >
+            <SearchIcon className="size-4" />
+          </motion.span>
+        )}
+      </AnimatePresence>
+    </span>
+  )
+}
+
+// todo(rpavlini): pull out an async combobox component
 function SnapshotCommandSelect({
   id,
   value,
-  defaultSnapshot,
+  selectedSnapshot,
   snapshots,
-  snapshotsLoading,
-  availableRegions,
+  loading,
+  fetching,
+  searchValue,
   getRegionName,
+  open,
   popoverContainer,
   onChange,
+  onOpenChange,
+  onSearchChange,
 }: {
   id: string
   value?: string
-  defaultSnapshot: string
+  selectedSnapshot?: SnapshotDto
   snapshots: SnapshotDto[]
-  snapshotsLoading: boolean
-  availableRegions: Region[]
+  loading: boolean
+  fetching: boolean
+  searchValue: string
   getRegionName: (regionId: string) => string | undefined
+  open: boolean
   popoverContainer?: HTMLElement | null
-  onChange: (value: string) => void
+  onChange: (snapshot: SnapshotDto) => void
+  onOpenChange: (open: boolean) => void
+  onSearchChange: (value: string) => void
 }) {
-  const [open, setOpen] = useState(false)
-  const selectedSnapshot = snapshots.find((snapshot) => snapshot.name === value)
-  const defaultSnapshotItem = snapshots.find((snapshot) => snapshot.name === defaultSnapshot)
-  const selectableSnapshots = snapshots.filter((snapshot) => snapshot.name !== defaultSnapshot)
-  const defaultRegionIds = defaultSnapshotItem?.regionIds
-  const selectedLabel = selectedSnapshot?.name ?? defaultSnapshot
+  const selectedLabel = selectedSnapshot?.name ?? value ?? 'Default snapshot'
 
-  const handleChange = (nextValue: string) => {
-    onChange(nextValue)
-    setOpen(false)
+  const handleChange = (snapshot: SnapshotDto) => {
+    onChange(snapshot)
+    onOpenChange(false)
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          id={id}
-          type="button"
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          disabled={snapshotsLoading}
-          className="h-8 w-full justify-between px-3 font-normal"
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverAnchor asChild>
+        <InputGroup
+          className={cn('h-8 overflow-hidden', {
+            'opacity-50': loading,
+          })}
+          data-disabled={loading ? true : undefined}
         >
-          <span className="flex min-w-0 items-center gap-2">
-            <span className="truncate">{snapshotsLoading ? 'Loading snapshots...' : selectedLabel}</span>
+          <PopoverTrigger asChild>
+            <button
+              id={id}
+              type="button"
+              disabled={loading}
+              data-slot="input-group-control"
+              className="absolute inset-0 z-10 rounded-md outline-none disabled:cursor-not-allowed"
+              aria-label={loading ? 'Loading snapshots' : selectedLabel}
+            />
+          </PopoverTrigger>
+          <span
+            aria-hidden="true"
+            className={cn('min-w-0 flex-1 truncate px-3 text-sm', {
+              'text-muted-foreground': !value,
+            })}
+          >
+            {loading ? 'Loading snapshots...' : selectedLabel}
           </span>
-          <ChevronDownIcon className="size-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
+          <InputGroupAddon align="inline-end">
+            <ChevronDownIcon aria-hidden="true" className="size-4 text-muted-foreground" />
+          </InputGroupAddon>
+        </InputGroup>
+      </PopoverAnchor>
       <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start" container={popoverContainer}>
-        <Command>
-          <CommandInput placeholder="Search snapshots..." />
+        <Command shouldFilter={false}>
+          <CommandInput
+            value={searchValue}
+            onValueChange={onSearchChange}
+            placeholder="Search snapshots..."
+            icon={<CommandInputStatusIcon fetching={fetching} />}
+          />
           <CommandList className="max-h-64 overscroll-contain">
-            {snapshotsLoading ? (
+            {loading ? (
               <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
                 <Spinner className="size-4" />
                 Loading snapshots...
               </div>
             ) : (
               <>
-                <CommandEmpty>No snapshots found.</CommandEmpty>
-                <CommandGroup>
-                  <CommandItem
-                    value={`${NONE_VALUE} ${defaultSnapshot} default system ${(defaultRegionIds ?? [])
-                      .map((regionId) => getRegionName(regionId) ?? regionId)
-                      .join(' ')}`}
-                    onSelect={() => handleChange('')}
-                    className="cursor-pointer gap-2"
-                  >
-                    <Check
-                      className={cn('size-4 shrink-0', {
-                        'opacity-100': !value,
-                        'opacity-0': !!value,
-                      })}
-                    />
-                    <div className="flex min-w-0 flex-1 items-center gap-2">
-                      <span className="truncate">{defaultSnapshot}</span>
-                      <Badge className="shrink-0">default</Badge>
-                      <Badge variant="secondary" className="shrink-0">
-                        System
-                      </Badge>
-                    </div>
-                    <SnapshotRegionInline regionIds={defaultRegionIds} getRegionName={getRegionName} />
-                  </CommandItem>
-                  {selectableSnapshots.map((snapshot) => (
+                <CommandEmpty>{fetching ? 'Searching snapshots...' : 'No active snapshots found.'}</CommandEmpty>
+                <CommandGroup
+                  className={cn('transition-opacity duration-150 ease-out', {
+                    'opacity-50': fetching && snapshots.length > 0,
+                  })}
+                >
+                  {snapshots.map((snapshot) => (
                     <CommandItem
                       key={snapshot.id}
                       value={`${snapshot.name} ${(snapshot.regionIds ?? [])
                         .map((regionId) => getRegionName(regionId) ?? regionId)
                         .join(' ')}`}
-                      onSelect={() => handleChange(snapshot.name)}
+                      onSelect={() => handleChange(snapshot)}
                       className="cursor-pointer gap-2"
                     >
                       <Check
@@ -353,6 +392,9 @@ export const CreateSandboxSheet = ({
   onSandboxCreated?: (sandbox: Sandbox) => void
 }) => {
   const [open, setOpen] = useState(false)
+  const [snapshotSelectOpen, setSnapshotSelectOpen] = useState(false)
+  const [snapshotSearchValue, setSnapshotSearchValue] = useState('')
+  const [selectedSnapshotOption, setSelectedSnapshotOption] = useState<SnapshotDto | undefined>(undefined)
 
   const config = useConfig()
   const { availableRegions: regions, loadingAvailableRegions: loadingRegions, getRegionName } = useRegions()
@@ -386,12 +428,25 @@ export const CreateSandboxSheet = ({
 
   const formSchema = useMemo(() => buildFormSchema(maxCpu, maxMemory, maxDisk), [maxCpu, maxMemory, maxDisk])
 
-  const { data: snapshotsData, isLoading: snapshotsLoading } = useSnapshotsQuery({
+  const debouncedSnapshotSearchValue = useDebouncedValue(snapshotSearchValue, 300)
+  const snapshotNameFilter = debouncedSnapshotSearchValue.trim()
+  const {
+    data: snapshotsData,
+    isLoading: snapshotsLoading,
+    isFetching: snapshotsFetching,
+  } = useSnapshotsQuery({
     page: 1,
     pageSize: 100,
+    filters: snapshotNameFilter ? { name: snapshotNameFilter } : undefined,
   })
 
-  const snapshots = snapshotsData?.items ?? DEFAULT_SNAPSHOTS
+  const snapshots = useMemo(
+    () => snapshotsData?.items.filter((snapshot) => snapshot.state === SnapshotState.ACTIVE) ?? DEFAULT_SNAPSHOTS,
+    [snapshotsData?.items],
+  )
+
+  const snapshotsSearchPending = snapshotSearchValue !== debouncedSnapshotSearchValue
+  const snapshotsSearchActive = snapshotsFetching || snapshotsSearchPending
 
   const form = useForm({
     defaultValues: formDefaultValues,
@@ -496,15 +551,17 @@ export const CreateSandboxSheet = ({
   const { reset: resetForm } = form
   const selectedSource = useStore(form.store, (state) => state.values.source)
   const selectedSnapshotName = useStore(form.store, (state) => state.values.snapshot)
-  const selectedSnapshot = useMemo(
-    () => snapshots?.find((snapshot) => snapshot.name === (selectedSnapshotName ?? config.defaultSnapshot)),
-    [config.defaultSnapshot, selectedSnapshotName, snapshots],
-  )
+  const selectedSnapshot = useMemo(() => {
+    if (!selectedSnapshotName) {
+      return undefined
+    }
+
+    return snapshots.find((snapshot) => snapshot.name === selectedSnapshotName) ?? selectedSnapshotOption
+  }, [selectedSnapshotName, selectedSnapshotOption, snapshots])
   const getRegionsForSnapshot = useCallback(
-    (snapshotName?: string) => {
-      const snapshot = snapshots.find((snapshot) => snapshot.name === (snapshotName ?? config.defaultSnapshot))
+    (snapshot?: SnapshotDto) => {
       if (!snapshot) {
-        return []
+        return regions
       }
 
       if (!snapshot.regionIds?.length) {
@@ -514,19 +571,19 @@ export const CreateSandboxSheet = ({
       const snapshotRegionIds = new Set(snapshot.regionIds)
       return regions.filter((region) => snapshotRegionIds.has(region.id))
     },
-    [config.defaultSnapshot, regions, snapshots],
+    [regions],
   )
   const snapshotFilteredRegions = useMemo(() => {
     if (selectedSource !== Source.SNAPSHOT) {
       return regions
     }
 
-    return getRegionsForSnapshot(selectedSnapshotName)
-  }, [getRegionsForSnapshot, regions, selectedSnapshotName, selectedSource])
+    return getRegionsForSnapshot(selectedSnapshot)
+  }, [getRegionsForSnapshot, regions, selectedSnapshot, selectedSource])
+  const regionsDisabled = loadingRegions || (selectedSource === Source.SNAPSHOT && snapshotsSearchActive)
 
-  const syncRegionForSnapshot = useCallback(
-    (snapshotName?: string) => {
-      const nextRegions = getRegionsForSnapshot(snapshotName)
+  const setRegionFromAvailableRegions = useCallback(
+    (nextRegions: Region[]) => {
       const currentRegionId = form.getFieldValue('regionId')
       const currentRegionAvailable = !!currentRegionId && nextRegions.some((region) => region.id === currentRegionId)
 
@@ -547,7 +604,7 @@ export const CreateSandboxSheet = ({
 
       form.setFieldValue('regionId', defaultRegion?.id ?? nextRegions[0].id)
     },
-    [form, getRegionsForSnapshot, selectedOrganization?.defaultRegionId],
+    [form, selectedOrganization?.defaultRegionId],
   )
 
   const handleSourceChange = useCallback(
@@ -562,23 +619,40 @@ export const CreateSandboxSheet = ({
         form.setFieldValue('gpuType', undefined)
       } else {
         form.setFieldValue('snapshot', undefined)
+        setSelectedSnapshotOption(undefined)
       }
     },
     [form],
   )
   const handleSnapshotChange = useCallback(
-    (snapshotName: string) => {
-      const nextSnapshotName = snapshotName || undefined
-      form.setFieldValue('snapshot', nextSnapshotName)
-      syncRegionForSnapshot(nextSnapshotName)
+    (snapshot: SnapshotDto) => {
+      form.setFieldValue('snapshot', snapshot.name)
+      setSelectedSnapshotOption(snapshot)
+      setSnapshotSearchValue(snapshot.name)
+      setRegionFromAvailableRegions(getRegionsForSnapshot(snapshot))
     },
-    [form, syncRegionForSnapshot],
+    [form, getRegionsForSnapshot, setRegionFromAvailableRegions],
   )
 
   const resetState = useCallback(() => {
     resetForm(formDefaultValues)
     resetCreateSandboxMutation()
+    setSnapshotSelectOpen(false)
+    setSnapshotSearchValue('')
+    setSelectedSnapshotOption(undefined)
   }, [formDefaultValues, resetForm, resetCreateSandboxMutation])
+
+  const handleDefaultSnapshotSelect = useCallback(() => {
+    const defaultSnapshot = snapshots.find((snapshot) => snapshot.name === config.defaultSnapshot)
+    if (defaultSnapshot) {
+      handleSnapshotChange(defaultSnapshot)
+    } else {
+      form.setFieldValue('snapshot', config.defaultSnapshot)
+      setSelectedSnapshotOption(undefined)
+      setSnapshotSearchValue(config.defaultSnapshot)
+    }
+    setSnapshotSelectOpen(false)
+  }, [config.defaultSnapshot, form, handleSnapshotChange, snapshots])
 
   const handleEnvFileImport = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -629,7 +703,8 @@ export const CreateSandboxSheet = ({
     if (!open || loadingRegions) return
 
     if (selectedSource === Source.SNAPSHOT) {
-      syncRegionForSnapshot(selectedSnapshotName)
+      if (snapshotsSearchActive) return
+      setRegionFromAvailableRegions(snapshotFilteredRegions)
       return
     }
 
@@ -643,9 +718,10 @@ export const CreateSandboxSheet = ({
     open,
     regions,
     selectedOrganization?.defaultRegionId,
-    selectedSnapshotName,
     selectedSource,
-    syncRegionForSnapshot,
+    setRegionFromAvailableRegions,
+    snapshotFilteredRegions,
+    snapshotsSearchActive,
   ])
 
   return (
@@ -724,14 +800,29 @@ export const CreateSandboxSheet = ({
                           <SnapshotCommandSelect
                             id={field.name}
                             value={field.state.value}
-                            defaultSnapshot={config.defaultSnapshot}
+                            selectedSnapshot={selectedSnapshot}
                             snapshots={snapshots}
-                            snapshotsLoading={snapshotsLoading}
-                            availableRegions={regions}
+                            loading={snapshotsLoading}
+                            fetching={snapshotsSearchActive}
+                            searchValue={snapshotSearchValue}
                             getRegionName={getRegionName}
+                            open={snapshotSelectOpen}
                             popoverContainer={sheetContentRef.current}
                             onChange={handleSnapshotChange}
+                            onOpenChange={setSnapshotSelectOpen}
+                            onSearchChange={setSnapshotSearchValue}
                           />
+                          <FieldDescription>
+                            If unspecified,{' '}
+                            <button
+                              type="button"
+                              className="font-medium text-foreground underline underline-offset-2"
+                              onClick={handleDefaultSnapshotSelect}
+                            >
+                              {config.defaultSnapshot}
+                            </button>{' '}
+                            will be used.
+                          </FieldDescription>
                         </Field>
                       )}
                     </form.Field>
@@ -957,16 +1048,18 @@ export const CreateSandboxSheet = ({
                         aria-invalid={hasErrors}
                         className="h-8"
                         id={field.name}
-                        disabled={loadingRegions || snapshotFilteredRegions.length === 0}
-                        loading={loadingRegions}
+                        disabled={regionsDisabled || snapshotFilteredRegions.length === 0}
+                        loading={regionsDisabled}
                       >
                         <SelectValue
                           placeholder={
                             loadingRegions
                               ? 'Loading regions...'
-                              : snapshotFilteredRegions.length === 0
-                                ? 'No regions available'
-                                : 'Select a region'
+                              : selectedSource === Source.SNAPSHOT && snapshotsSearchActive
+                                ? 'Loading snapshot regions...'
+                                : snapshotFilteredRegions.length === 0
+                                  ? 'No regions available'
+                                  : 'Select a region'
                           }
                         />
                       </SelectTrigger>
@@ -979,7 +1072,7 @@ export const CreateSandboxSheet = ({
                       </SelectContent>
                     </Select>
                     <FieldDescription>
-                      {selectedSource === Source.SNAPSHOT && snapshotFilteredRegions.length === 0
+                      {selectedSource === Source.SNAPSHOT && selectedSnapshot && snapshotFilteredRegions.length === 0
                         ? 'The selected snapshot is not available in any selectable region.'
                         : selectedSource === Source.SNAPSHOT && selectedSnapshot?.regionIds?.length
                           ? 'Only regions where the selected snapshot is available are shown.'

--- a/apps/dashboard/src/components/Sandbox/SnapshotSelect.tsx
+++ b/apps/dashboard/src/components/Sandbox/SnapshotSelect.tsx
@@ -14,8 +14,8 @@ import { useRegions } from '@/hooks/useRegions'
 import { cn } from '@/lib/utils'
 import { SnapshotState, type SnapshotDto } from '@daytona/api-client'
 import { AnimatePresence, motion } from 'framer-motion'
-import { Check, ChevronDownIcon, SearchIcon } from 'lucide-react'
-import { Ref, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import { Check, ChevronDownIcon, SearchIcon, X } from 'lucide-react'
+import { MouseEvent, Ref, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { Tooltip } from '../Tooltip'
 
 const EMPTY_SNAPSHOTS: SnapshotDto[] = []
@@ -116,7 +116,8 @@ export interface SnapshotSelectProps {
   className?: string
   popoverContainer?: HTMLElement | null
   onOpenChange?: (open: boolean) => void
-  onValueChange?: (snapshot: SnapshotDto) => void
+  onSnapshotChange?: (snapshot: SnapshotDto) => void
+  onValueChange?: (value: string | undefined) => void
 }
 
 export interface SnapshotSelectRef {
@@ -134,6 +135,7 @@ export function SnapshotSelect({
   className,
   popoverContainer,
   onOpenChange,
+  onSnapshotChange,
   onValueChange,
 }: SnapshotSelectProps) {
   const [open, setOpen] = useState(false)
@@ -205,8 +207,18 @@ export function SnapshotSelect({
   )
 
   const handleChange = (snapshot: SnapshotDto) => {
-    onValueChange?.(snapshot)
+    onValueChange?.(snapshot.name)
+    onSnapshotChange?.(snapshot)
     setSearchValue(snapshot.name)
+    handleOpenChange(false)
+  }
+
+  const handleClear = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    onValueChange?.(undefined)
+    setSearchValue('')
     handleOpenChange(false)
   }
 
@@ -216,7 +228,7 @@ export function SnapshotSelect({
       <PopoverAnchor asChild>
         <InputGroup
           className={cn(
-            'h-8 overflow-hidden',
+            'h-8 overflow-hidden data-[disabled]:opacity-50',
             {
               'opacity-50': loading,
             },
@@ -242,8 +254,21 @@ export function SnapshotSelect({
           >
             {loading ? 'Loading snapshots...' : selectedLabel}
           </span>
-          <InputGroupAddon align="inline-end">
-            <ChevronDownIcon aria-hidden="true" className="size-4 text-muted-foreground" />
+          <InputGroupAddon align="inline-end" className="text-foreground">
+            <span className="flex size-5 items-center justify-center">
+              {value && (
+                <button
+                  type="button"
+                  aria-label="Clear snapshot"
+                  disabled={loading || disabled}
+                  className="relative z-20 rounded-sm p-0.5 text-current opacity-50 hover:text-foreground disabled:cursor-not-allowed"
+                  onClick={handleClear}
+                >
+                  <X aria-hidden="true" className="size-3.5" />
+                </button>
+              )}
+            </span>
+            <ChevronDownIcon aria-hidden="true" className="size-4 text-current opacity-50" />
           </InputGroupAddon>
         </InputGroup>
       </PopoverAnchor>

--- a/apps/dashboard/src/components/Sandbox/SnapshotSelect.tsx
+++ b/apps/dashboard/src/components/Sandbox/SnapshotSelect.tsx
@@ -1,0 +1,305 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Badge } from '@/components/ui/badge'
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
+import { InputGroup, InputGroupAddon } from '@/components/ui/input-group'
+import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Spinner } from '@/components/ui/spinner'
+import { useSnapshotsQuery } from '@/hooks/queries/useSnapshotsQuery'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
+import { useRegions } from '@/hooks/useRegions'
+import { cn } from '@/lib/utils'
+import { SnapshotState, type SnapshotDto } from '@daytona/api-client'
+import { AnimatePresence, motion } from 'framer-motion'
+import { Check, ChevronDownIcon, SearchIcon } from 'lucide-react'
+import { Ref, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import { Tooltip } from '../Tooltip'
+
+const EMPTY_SNAPSHOTS: SnapshotDto[] = []
+
+const commandInputIconMotion = {
+  initial: { opacity: 0, y: 4, scale: 0.95 },
+  animate: { opacity: 1, y: 0, scale: 1 },
+  exit: { opacity: 0, y: -4, scale: 0.95 },
+  transition: { duration: 0.14, ease: 'easeOut' },
+} as const
+
+function CommandInputStatusIcon({ fetching }: { fetching: boolean }) {
+  return (
+    <span className="relative flex size-4 shrink-0 items-center justify-center opacity-50">
+      <AnimatePresence initial={false} mode="wait">
+        {fetching ? (
+          <motion.span
+            key="fetching"
+            className="absolute inset-0 flex items-center justify-center"
+            {...commandInputIconMotion}
+          >
+            <Spinner className="size-4" />
+          </motion.span>
+        ) : (
+          <motion.span
+            key="search"
+            className="absolute inset-0 flex items-center justify-center"
+            {...commandInputIconMotion}
+          >
+            <SearchIcon className="size-4" />
+          </motion.span>
+        )}
+      </AnimatePresence>
+    </span>
+  )
+}
+
+function SnapshotRegionInline({
+  regionIds,
+  getRegionName,
+}: {
+  regionIds?: string[]
+  getRegionName: (regionId: string) => string | undefined
+}) {
+  if (!regionIds?.length) {
+    return <span className="ml-auto shrink-0 text-xs text-muted-foreground">-</span>
+  }
+
+  const regionNames = regionIds.map((regionId) => getRegionName(regionId) ?? regionId)
+  const firstRegion = regionNames[0]
+  const remainingCount = regionNames.length - 1
+
+  if (remainingCount === 0) {
+    return (
+      <span
+        className="ml-auto block max-w-[150px] shrink-0 truncate text-right text-xs text-muted-foreground"
+        title={firstRegion}
+      >
+        {firstRegion}
+      </span>
+    )
+  }
+
+  return (
+    <Tooltip
+      label={
+        <div className="ml-auto flex shrink-0 items-center gap-1.5">
+          <span className="max-w-[150px] truncate text-xs text-muted-foreground">{firstRegion}</span>
+          <Badge variant="secondary" className="h-5 px-1.5 py-0 text-xs">
+            +{remainingCount}
+          </Badge>
+        </div>
+      }
+      content={
+        <div className="flex flex-col gap-1">
+          {regionNames.map((regionName, index) => (
+            <span key={`${regionName}-${index}`}>{regionName}</span>
+          ))}
+        </div>
+      }
+    />
+  )
+}
+
+function getSnapshotSearchValue(snapshot: SnapshotDto, getRegionName: (regionId: string) => string | undefined) {
+  const regions = (snapshot.regionIds ?? []).map((regionId) => getRegionName(regionId) ?? regionId).join(' ')
+  return `${snapshot.name} ${regions}`
+}
+
+export interface SnapshotSelectProps {
+  ref?: Ref<SnapshotSelectRef>
+  id?: string
+  name?: string
+  value?: string
+  disabled?: boolean
+  placeholder?: string
+  pageSize?: number
+  className?: string
+  popoverContainer?: HTMLElement | null
+  onOpenChange?: (open: boolean) => void
+  onValueChange?: (snapshot: SnapshotDto) => void
+}
+
+export interface SnapshotSelectRef {
+  open: () => void
+}
+
+export function SnapshotSelect({
+  ref,
+  id,
+  name,
+  value,
+  disabled,
+  placeholder = 'Select snapshot',
+  pageSize = 100,
+  className,
+  popoverContainer,
+  onOpenChange,
+  onValueChange,
+}: SnapshotSelectProps) {
+  const [open, setOpen] = useState(false)
+  const [searchValue, setSearchValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  const debouncedSearchValue = useDebouncedValue(searchValue, 300)
+  const searchTerm = debouncedSearchValue.trim()
+  const { getRegionName } = useRegions()
+
+  const {
+    data: snapshotsData,
+    isLoading: snapshotsLoading,
+    isFetching: snapshotsFetching,
+  } = useSnapshotsQuery(
+    {
+      page: 1,
+      pageSize,
+    },
+    { enabled: !disabled },
+  )
+
+  const canSearchServer = Boolean(snapshotsData && snapshotsData.total > pageSize)
+  const shouldFetchSearchResults = open && canSearchServer && Boolean(searchTerm)
+  const { data: searchedSnapshotsData, isFetching: searchedSnapshotsFetching } = useSnapshotsQuery(
+    {
+      page: 1,
+      pageSize,
+      filters: { name: searchTerm },
+    },
+    { enabled: !disabled && shouldFetchSearchResults },
+  )
+
+  const sourceSnapshots = shouldFetchSearchResults ? searchedSnapshotsData?.items : snapshotsData?.items
+  const snapshots = useMemo(
+    () => sourceSnapshots?.filter((snapshot) => snapshot.state === SnapshotState.ACTIVE) ?? EMPTY_SNAPSHOTS,
+    [sourceSnapshots],
+  )
+  const selectedSnapshot = useMemo(() => snapshots.find((snapshot) => snapshot.name === value), [snapshots, value])
+
+  const loading = snapshotsLoading && !snapshotsData
+  const searchPending = open && canSearchServer && searchValue.trim() !== searchTerm
+  const fetching =
+    searchPending || (shouldFetchSearchResults ? searchedSnapshotsFetching : snapshotsFetching && !loading)
+  const selectedLabel = selectedSnapshot?.name ?? value ?? placeholder
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      onOpenChange?.(nextOpen)
+      setOpen(nextOpen)
+      if (nextOpen) {
+        setSearchValue('')
+      }
+    },
+    [onOpenChange],
+  )
+
+  useEffect(() => {
+    if (open) {
+      inputRef.current?.focus()
+    }
+  }, [open])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      open: () => handleOpenChange(true),
+    }),
+    [handleOpenChange],
+  )
+
+  const handleChange = (snapshot: SnapshotDto) => {
+    onValueChange?.(snapshot)
+    setSearchValue(snapshot.name)
+    handleOpenChange(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      {name && <input type="hidden" name={name} value={value ?? ''} />}
+      <PopoverAnchor asChild>
+        <InputGroup
+          className={cn(
+            'h-8 overflow-hidden',
+            {
+              'opacity-50': loading,
+            },
+            className,
+          )}
+          data-disabled={loading || disabled ? true : undefined}
+        >
+          <PopoverTrigger asChild>
+            <button
+              id={id}
+              type="button"
+              disabled={loading || disabled}
+              data-slot="input-group-control"
+              className="absolute inset-0 z-10 rounded-md outline-none disabled:cursor-not-allowed"
+              aria-label={loading ? 'Loading snapshots' : selectedLabel}
+            />
+          </PopoverTrigger>
+          <span
+            aria-hidden="true"
+            className={cn('min-w-0 flex-1 truncate px-3 text-sm', {
+              'text-muted-foreground': !value,
+            })}
+          >
+            {loading ? 'Loading snapshots...' : selectedLabel}
+          </span>
+          <InputGroupAddon align="inline-end">
+            <ChevronDownIcon aria-hidden="true" className="size-4 text-muted-foreground" />
+          </InputGroupAddon>
+        </InputGroup>
+      </PopoverAnchor>
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start" container={popoverContainer}>
+        <Command shouldFilter={!shouldFetchSearchResults}>
+          <CommandInput
+            ref={inputRef}
+            value={searchValue}
+            onValueChange={setSearchValue}
+            placeholder="Search snapshots..."
+            icon={<CommandInputStatusIcon fetching={fetching} />}
+          />
+          <CommandList className="max-h-64 overscroll-contain">
+            {loading ? (
+              <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
+                <Spinner className="size-4" />
+                Loading snapshots...
+              </div>
+            ) : (
+              <>
+                <CommandEmpty>{fetching ? 'Searching snapshots...' : 'No active snapshots found.'}</CommandEmpty>
+                <CommandGroup
+                  className={cn('transition-opacity duration-150 ease-out', {
+                    'opacity-50': fetching && snapshots.length > 0,
+                  })}
+                >
+                  {snapshots.map((snapshot) => (
+                    <CommandItem
+                      key={snapshot.id}
+                      value={getSnapshotSearchValue(snapshot, getRegionName)}
+                      onSelect={() => handleChange(snapshot)}
+                      className="cursor-pointer gap-2"
+                    >
+                      <Check
+                        className={cn('size-4 shrink-0', {
+                          'opacity-100': value === snapshot.name,
+                          'opacity-0': value !== snapshot.name,
+                        })}
+                      />
+                      <div className="flex min-w-0 flex-1 items-center gap-2">
+                        <span className="truncate">{snapshot.name}</span>
+                        {snapshot.general && (
+                          <Badge variant="secondary" className="shrink-0">
+                            System
+                          </Badge>
+                        )}
+                      </div>
+                      <SnapshotRegionInline regionIds={snapshot.regionIds} getRegionName={getRegionName} />
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/dashboard/src/components/SearchInput.tsx
+++ b/apps/dashboard/src/components/SearchInput.tsx
@@ -27,7 +27,7 @@ function SearchInput({
   containerClassName,
   clearButtonAriaLabel = 'Clear search',
   debounced = false,
-  debounceMs = 500,
+  debounceMs = 300,
   onClear,
   onValueChange,
   value,

--- a/apps/dashboard/src/components/ui/popover.tsx
+++ b/apps/dashboard/src/components/ui/popover.tsx
@@ -22,10 +22,11 @@ function PopoverContent({
   className,
   align = 'center',
   sideOffset = 4,
+  container,
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+}: React.ComponentProps<typeof PopoverPrimitive.Content> & { container?: HTMLElement | null }) {
   return (
-    <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Portal container={container}>
       <PopoverPrimitive.Content
         data-slot="popover-content"
         align={align}

--- a/apps/dashboard/src/components/ui/select.tsx
+++ b/apps/dashboard/src/components/ui/select.tsx
@@ -26,7 +26,7 @@ const SelectTrigger = React.forwardRef<
     ref={ref}
     data-size={size}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground disabled:opacity-50 [&>span]:line-clamp-1 data-[size=sm]:h-8 data-[size=xs]:h-7 outline-none',
+      'flex h-10 w-full items-center justify-between rounded-md border border-input dark:bg-input/30 px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground disabled:opacity-50 [&>span]:line-clamp-1 data-[size=sm]:h-8 data-[size=xs]:h-7 outline-none',
       'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
       loading ? 'disabled:cursor-progress' : 'disabled:cursor-not-allowed',
       className,

--- a/apps/dashboard/src/components/ui/select.tsx
+++ b/apps/dashboard/src/components/ui/select.tsx
@@ -26,7 +26,7 @@ const SelectTrigger = React.forwardRef<
     ref={ref}
     data-size={size}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input dark:bg-input/30 px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground disabled:opacity-50 [&>span]:line-clamp-1 data-[size=sm]:h-8 data-[size=xs]:h-7 outline-none',
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-transparent dark:bg-input/30 px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground disabled:opacity-50 [&>span]:line-clamp-1 data-[size=sm]:h-8 data-[size=xs]:h-7 outline-none',
       'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
       loading ? 'disabled:cursor-progress' : 'disabled:cursor-not-allowed',
       className,

--- a/apps/dashboard/src/hooks/queries/useSnapshotsQuery.ts
+++ b/apps/dashboard/src/hooks/queries/useSnapshotsQuery.ts
@@ -80,7 +80,7 @@ export function useSnapshotQuery(
   })
 }
 
-export function useSnapshotsQuery(params: SnapshotQueryParams) {
+export function useSnapshotsQuery(params: SnapshotQueryParams, { enabled = true }: { enabled?: boolean } = {}) {
   const { snapshotApi } = useApi()
   const { selectedOrganization } = useSelectedOrganization()
 
@@ -104,7 +104,7 @@ export function useSnapshotsQuery(params: SnapshotQueryParams) {
 
       return response.data
     },
-    enabled: !!selectedOrganization,
+    enabled: enabled && !!selectedOrganization,
     placeholderData: keepPreviousData,
     staleTime: 1000 * 10,
     gcTime: 1000 * 60 * 5,

--- a/apps/dashboard/src/hooks/useDebouncedValue.ts
+++ b/apps/dashboard/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { useEffect, useState } from 'react'
+
+export function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => window.clearTimeout(timeout)
+  }, [delay, value])
+
+  return debouncedValue
+}

--- a/apps/dashboard/src/hooks/useDocsSearchCommands.tsx
+++ b/apps/dashboard/src/hooks/useDocsSearchCommands.tsx
@@ -11,11 +11,12 @@ import {
   useRegisterPage,
   type CommandConfig,
 } from '@/components/CommandPalette'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { cn } from '@/lib/utils'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { liteClient as algoliasearch } from 'algoliasearch/lite'
 import { BookOpen, Code2, Container, Layers, Terminal } from 'lucide-react'
-import { ReactNode, useEffect, useMemo, useState } from 'react'
+import { ReactNode, useEffect, useMemo } from 'react'
 
 const ALGOLIA_APP_ID = import.meta.env.VITE_ALGOLIA_APP_ID
 const ALGOLIA_API_KEY = import.meta.env.VITE_ALGOLIA_API_KEY
@@ -73,15 +74,6 @@ export const searchDocumentation = async (query: string): Promise<SearchResults>
     cli: getHits(1),
     sdk: getHits(2),
   }
-}
-
-function useDebounce<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState(value)
-  useEffect(() => {
-    const handler = setTimeout(() => setDebouncedValue(value), delay)
-    return () => clearTimeout(handler)
-  }, [value, delay])
-  return debouncedValue
 }
 
 export const useDocsSearchQuery = ({ search, enabled }: { search: string; enabled: boolean }) => {
@@ -156,7 +148,7 @@ export function useDocsSearchCommands() {
 
   const { setShouldFilter, setIsLoading } = useCommandPaletteActions()
   const enabled = activePageId === 'search-docs' && docSearchEnabled
-  const debouncedQuery = useDebounce(search, 300)
+  const debouncedQuery = useDebouncedValue(search, 300)
 
   const { data, isError, isFetching } = useDocsSearchQuery({
     search: debouncedQuery,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Syncs the Region options to the selected Snapshot in Create Sandbox and adds an async Snapshot selector with 300ms debounced search. Improves defaults, empty states, and validation when no regions are available.

- **New Features**
  - Async Snapshot combobox with 300ms debounced server search, loading indicator, selection checkmarks, System badge, and inline snapshot regions with tooltip; shows ACTIVE snapshots only and supports clearing to use the default snapshot.
  - Region options sync to the selected snapshot’s regionIds; when Source=Snapshot and none is selected, shows SHARED regions; disables Region select or shows “No regions available” with validation; auto-selects a valid region on snapshot change (prefers org default); regions stay unfiltered when Source=Image.

- **Refactors**
  - `Popover` supports optional `container` to portal within the sheet; added `useDebouncedValue`; set docs search and `SearchInput` default debounce to 300ms; minor `SelectTrigger` style tweak; `useSnapshotsQuery` supports `enabled`.

<sup>Written for commit a0d0b12127e2b975fe3fc2b4482f566ac54bf02f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

