### PR TITLE
feat(daemon,sdk): add depth-aware recursive file listing

### DIFF
--- a/apps/daemon/pkg/toolbox/docs/docs.go
+++ b/apps/daemon/pkg/toolbox/docs/docs.go
@@ -1382,7 +1382,7 @@ const docTemplate = `{
         },
         "/files": {
             "get": {
-                "description": "List files and directories in the specified path",
+                "description": "List files and directories in the specified path. Use the optional depth\nparameter to list recursively: depth=1 (default) lists the directory's\nentries, depth=2 also includes their children, and so on.",
                 "produces": [
                     "application/json"
                 ],
@@ -1396,6 +1396,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Directory path to list (defaults to working directory)",
                         "name": "path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "How many levels deep to list (default: 1, must be \u003e= 1)",
+                        "name": "depth",
                         "in": "query"
                     }
                 ],
@@ -3809,6 +3815,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "owner": {
+                    "type": "string"
+                },
+                "path": {
+                    "description": "Full path of the entry",
                     "type": "string"
                 },
                 "permissions": {

--- a/apps/daemon/pkg/toolbox/docs/swagger.json
+++ b/apps/daemon/pkg/toolbox/docs/swagger.json
@@ -1218,7 +1218,7 @@
     },
     "/files": {
       "get": {
-        "description": "List files and directories in the specified path",
+        "description": "List files and directories in the specified path. Use the optional depth\nparameter to list recursively: depth=1 (default) lists the directory's\nentries, depth=2 also includes their children, and so on.",
         "produces": ["application/json"],
         "tags": ["file-system"],
         "summary": "List files and directories",
@@ -1228,6 +1228,12 @@
             "type": "string",
             "description": "Directory path to list (defaults to working directory)",
             "name": "path",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "How many levels deep to list (default: 1, must be \u003e= 1)",
+            "name": "depth",
             "in": "query"
           }
         ],
@@ -3336,6 +3342,10 @@
           "type": "string"
         },
         "owner": {
+          "type": "string"
+        },
+        "path": {
+          "description": "Full path of the entry",
           "type": "string"
         },
         "permissions": {

--- a/apps/daemon/pkg/toolbox/docs/swagger.yaml
+++ b/apps/daemon/pkg/toolbox/docs/swagger.yaml
@@ -326,6 +326,9 @@ definitions:
         type: string
       owner:
         type: string
+      path:
+        description: Full path of the entry
+        type: string
       permissions:
         type: string
       size:
@@ -2073,13 +2076,20 @@ paths:
       tags:
         - file-system
     get:
-      description: List files and directories in the specified path
+      description: |-
+        List files and directories in the specified path. Use the optional depth
+        parameter to list recursively: depth=1 (default) lists the directory's
+        entries, depth=2 also includes their children, and so on.
       operationId: ListFiles
       parameters:
         - description: Directory path to list (defaults to working directory)
           in: query
           name: path
           type: string
+        - description: 'How many levels deep to list (default: 1, must be >= 1)'
+          in: query
+          name: depth
+          type: integer
       produces:
         - application/json
       responses:

--- a/apps/daemon/pkg/toolbox/fs/list_files.go
+++ b/apps/daemon/pkg/toolbox/fs/list_files.go
@@ -4,52 +4,149 @@
 package fs
 
 import (
+	"errors"
+	iofs "io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
+	"github.com/daytonaio/daemon/internal/util"
 	"github.com/gin-gonic/gin"
 )
 
 // ListFiles godoc
 //
 //	@Summary		List files and directories
-//	@Description	List files and directories in the specified path
+//	@Description	List files and directories in the specified path. Use the optional depth
+//	@Description	parameter to list recursively: depth=1 (default) lists the directory's
+//	@Description	entries, depth=2 also includes their children, and so on.
 //	@Tags			file-system
 //	@Produce		json
 //	@Param			path	query	string	false	"Directory path to list (defaults to working directory)"
+//	@Param			depth	query	int		false	"How many levels deep to list (default: 1, must be >= 1)"
 //	@Success		200		{array}	FileInfo
 //	@Router			/files [get]
 //
 //	@id				ListFiles
 func ListFiles(c *gin.Context) {
-	path := c.Query("path")
-	if path == "" {
-		path = "."
+	root := c.Query("path")
+	if root == "" {
+		root = "."
 	}
 
+	depth := 1
+	if depthStr := c.Query("depth"); depthStr != "" {
+		parsed, err := strconv.Atoi(depthStr)
+		if err != nil || parsed < 1 {
+			c.AbortWithError(http.StatusBadRequest, errors.New("depth must be an integer >= 1"))
+			return
+		}
+		depth = parsed
+	}
+
+	stripPath := util.ClientRejectsUnknownResponseFields(c.Request.Header)
+
+	// depth=1 uses the original os.ReadDir code path to avoid behavioural
+	// regressions for the default (most common) case.
+	if depth == 1 {
+		listFilesShallow(c, root, stripPath)
+		return
+	}
+	listFilesRecursive(c, root, depth, stripPath)
+}
+
+func listFilesShallow(c *gin.Context, path string, stripPath bool) {
 	files, err := os.ReadDir(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			c.AbortWithError(http.StatusNotFound, err)
-			return
-		}
-		if os.IsPermission(err) {
-			c.AbortWithError(http.StatusForbidden, err)
-			return
-		}
-		c.AbortWithError(http.StatusBadRequest, err)
+		abortWithFsError(c, err)
 		return
 	}
 
-	var fileInfos = make([]FileInfo, 0)
+	fileInfos := make([]FileInfo, 0)
 	for _, file := range files {
-		info, err := getFileInfo(filepath.Join(path, file.Name()))
+		fullPath := filepath.Join(path, file.Name())
+		info, err := getFileInfo(fullPath)
 		if err != nil {
 			continue
+		}
+		if !stripPath {
+			info.Path = fullPath
 		}
 		fileInfos = append(fileInfos, info)
 	}
 
 	c.JSON(http.StatusOK, fileInfos)
+}
+
+// listFilesRecursive returns a flat listing up to depth levels below root;
+// unreadable subtrees are skipped and symlinks are not followed.
+func listFilesRecursive(c *gin.Context, root string, depth int, stripPath bool) {
+	if _, err := os.ReadDir(root); err != nil {
+		abortWithFsError(c, err)
+		return
+	}
+
+	// filepath.WalkDir lstats its root and refuses to descend into a symlinked
+	// root directory, while the depth=1 os.ReadDir path follows it. Resolve a
+	// symlinked root so both depths list the same tree; reported paths stay
+	// under the requested root.
+	walkRoot := root
+	if info, err := os.Lstat(root); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		if resolved, err := filepath.EvalSymlinks(root); err == nil {
+			walkRoot = resolved
+		}
+	}
+
+	fileInfos := make([]FileInfo, 0)
+	_ = filepath.WalkDir(walkRoot, func(entryPath string, d iofs.DirEntry, err error) error {
+		if err != nil {
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entryPath == walkRoot {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(walkRoot, entryPath)
+		if relErr != nil {
+			return nil
+		}
+		entryDepth := strings.Count(rel, string(os.PathSeparator)) + 1
+		if entryDepth > depth {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if info, infoErr := getFileInfo(entryPath); infoErr == nil {
+			if !stripPath {
+				info.Path = filepath.Join(root, rel)
+			}
+			fileInfos = append(fileInfos, info)
+		}
+
+		if d.IsDir() && entryDepth >= depth {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+
+	c.JSON(http.StatusOK, fileInfos)
+}
+
+func abortWithFsError(c *gin.Context, err error) {
+	if os.IsNotExist(err) {
+		c.AbortWithError(http.StatusNotFound, err)
+		return
+	}
+	if os.IsPermission(err) {
+		c.AbortWithError(http.StatusForbidden, err)
+		return
+	}
+	c.AbortWithError(http.StatusBadRequest, err)
 }

--- a/apps/daemon/pkg/toolbox/fs/list_files_test.go
+++ b/apps/daemon/pkg/toolbox/fs/list_files_test.go
@@ -1,0 +1,188 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package fs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func listFilesContext(t *testing.T, path string, extraQuery string) *httptest.ResponseRecorder {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	target := "/files?path=" + url.QueryEscape(path)
+	if extraQuery != "" {
+		target += "&" + extraQuery
+	}
+	ctx.Request = httptest.NewRequest(http.MethodGet, target, nil)
+	ListFiles(ctx)
+	return recorder
+}
+
+func decodeFileInfos(t *testing.T, recorder *httptest.ResponseRecorder) []FileInfo {
+	t.Helper()
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var infos []FileInfo
+	if err := json.Unmarshal(recorder.Body.Bytes(), &infos); err != nil {
+		t.Fatalf("decoding response: %v (body: %s)", err, recorder.Body.String())
+	}
+	return infos
+}
+
+func fileNames(infos []FileInfo) []string {
+	names := make([]string, 0, len(infos))
+	for _, info := range infos {
+		names = append(names, info.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func createListFilesTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "top.txt"), []byte("top"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "sub", "nested"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "sub", "child.txt"), []byte("child"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "sub", "nested", "deep.txt"), []byte("deep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func TestListFilesDepth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("default depth lists only direct entries", func(t *testing.T) {
+		root := createListFilesTree(t)
+
+		infos := decodeFileInfos(t, listFilesContext(t, root, ""))
+
+		want := []string{"sub", "top.txt"}
+		if got := fileNames(infos); !equalStrings(got, want) {
+			t.Errorf("names = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("depth=2 includes children one level down", func(t *testing.T) {
+		root := createListFilesTree(t)
+
+		infos := decodeFileInfos(t, listFilesContext(t, root, "depth=2"))
+
+		want := []string{"child.txt", "nested", "sub", "top.txt"}
+		if got := fileNames(infos); !equalStrings(got, want) {
+			t.Errorf("names = %v, want %v", got, want)
+		}
+		for _, info := range infos {
+			if !strings.HasPrefix(info.Path, root+string(os.PathSeparator)) {
+				t.Errorf("path %q not under root %q", info.Path, root)
+			}
+		}
+	})
+
+	t.Run("depth below 1 is rejected", func(t *testing.T) {
+		root := createListFilesTree(t)
+
+		recorder := listFilesContext(t, root, "depth=0")
+
+		if recorder.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("non-integer depth is rejected", func(t *testing.T) {
+		root := createListFilesTree(t)
+
+		recorder := listFilesContext(t, root, "depth=1.5")
+
+		if recorder.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+		}
+	})
+}
+
+func TestListFilesSymlinkRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on windows")
+	}
+	gin.SetMode(gin.TestMode)
+
+	newSymlinkRoot := func(t *testing.T) (string, string) {
+		t.Helper()
+		root := createListFilesTree(t)
+		link := filepath.Join(t.TempDir(), "link")
+		if err := os.Symlink(root, link); err != nil {
+			t.Fatal(err)
+		}
+		return root, link
+	}
+
+	t.Run("recursive listing matches the real root", func(t *testing.T) {
+		root, link := newSymlinkRoot(t)
+
+		realInfos := decodeFileInfos(t, listFilesContext(t, root, "depth=2"))
+		linkInfos := decodeFileInfos(t, listFilesContext(t, link, "depth=2"))
+
+		if got, want := fileNames(linkInfos), fileNames(realInfos); !equalStrings(got, want) {
+			t.Errorf("symlink root names = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("recursive listing reports paths under the symlink root", func(t *testing.T) {
+		_, link := newSymlinkRoot(t)
+
+		infos := decodeFileInfos(t, listFilesContext(t, link, "depth=2"))
+
+		if len(infos) == 0 {
+			t.Fatal("expected entries for symlinked root, got none")
+		}
+		for _, info := range infos {
+			if !strings.HasPrefix(info.Path, link+string(os.PathSeparator)) {
+				t.Errorf("path %q not under symlink root %q", info.Path, link)
+			}
+		}
+	})
+
+	t.Run("shallow listing of symlink root is unchanged", func(t *testing.T) {
+		_, link := newSymlinkRoot(t)
+
+		infos := decodeFileInfos(t, listFilesContext(t, link, ""))
+
+		want := []string{"sub", "top.txt"}
+		if got := fileNames(infos); !equalStrings(got, want) {
+			t.Errorf("names = %v, want %v", got, want)
+		}
+	})
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/apps/daemon/pkg/toolbox/fs/types.go
+++ b/apps/daemon/pkg/toolbox/fs/types.go
@@ -7,6 +7,8 @@ import "time"
 
 type FileInfo struct {
 	Name string `json:"name" validate:"required"`
+	// Full path of the entry
+	Path string `json:"path,omitempty"`
 	Size int64  `json:"size" validate:"required"`
 	Mode string `json:"mode" validate:"required"`
 	// Deprecated: ModTime uses Go's time.String() layout which is not a standard format.

--- a/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
@@ -149,7 +149,7 @@ result, err := sandbox.Process.ExecuteCommand(ctx, "ls -la")
   - [func \(f \*FileSystemService\) DownloadFileStream\(ctx context.Context, remotePath string, opts ...DownloadStreamOption\) \(io.ReadCloser, error\)](<#FileSystemService.DownloadFileStream>)
   - [func \(f \*FileSystemService\) FindFiles\(ctx context.Context, path, pattern string\) \(any, error\)](<#FileSystemService.FindFiles>)
   - [func \(f \*FileSystemService\) GetFileInfo\(ctx context.Context, path string\) \(\*types.FileInfo, error\)](<#FileSystemService.GetFileInfo>)
-  - [func \(f \*FileSystemService\) ListFiles\(ctx context.Context, path string\) \(\[\]\*types.FileInfo, error\)](<#FileSystemService.ListFiles>)
+  - [func \(f \*FileSystemService\) ListFiles\(ctx context.Context, path string, opts ...func\(\*options.ListFiles\)\) \(\[\]\*types.FileInfo, error\)](<#FileSystemService.ListFiles>)
   - [func \(f \*FileSystemService\) MoveFiles\(ctx context.Context, source, destination string\) error](<#FileSystemService.MoveFiles>)
   - [func \(f \*FileSystemService\) ReplaceInFiles\(ctx context.Context, files \[\]string, pattern, newValue string\) \(any, error\)](<#FileSystemService.ReplaceInFiles>)
   - [func \(f \*FileSystemService\) SearchFiles\(ctx context.Context, path, pattern string\) \(any, error\)](<#FileSystemService.SearchFiles>)
@@ -1737,7 +1737,7 @@ Returns an error if the path doesn't exist.
 ### func \(\*FileSystemService\) ListFiles
 
 ```go
-func (f *FileSystemService) ListFiles(ctx context.Context, path string) ([]*types.FileInfo, error)
+func (f *FileSystemService) ListFiles(ctx context.Context, path string, opts ...func(*options.ListFiles)) ([]*types.FileInfo, error)
 ```
 
 ListFiles lists files and directories in the specified path.

--- a/apps/docs/src/content/docs/en/go-sdk/options.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/options.mdx
@@ -52,6 +52,7 @@ opts := options.Apply(
 - [func WithCreatePtySize\(ptySize types.PtySize\) func\(\*CreatePty\)](<#WithCreatePtySize>)
 - [func WithCustomContext\(contextID string\) func\(\*RunCode\)](<#WithCustomContext>)
 - [func WithCwd\(cwd string\) func\(\*ExecuteCommand\)](<#WithCwd>)
+- [func WithDepth\(depth int32\) func\(\*ListFiles\)](<#WithDepth>)
 - [func WithEnv\(env map\[string\]string\) func\(\*RunCode\)](<#WithEnv>)
 - [func WithExecuteTimeout\(timeout time.Duration\) func\(\*ExecuteCommand\)](<#WithExecuteTimeout>)
 - [func WithExtraIndexURLs\(urls ...string\) func\(\*PipInstall\)](<#WithExtraIndexURLs>)
@@ -87,6 +88,7 @@ opts := options.Apply(
 - [type GitDeleteBranch](<#GitDeleteBranch>)
 - [type GitPull](<#GitPull>)
 - [type GitPush](<#GitPush>)
+- [type ListFiles](<#ListFiles>)
 - [type PipInstall](<#PipInstall>)
 - [type PtySession](<#PtySession>)
 - [type RunCode](<#RunCode>)
@@ -286,6 +288,23 @@ Example:
 ```
 result, err := sandbox.Process.ExecuteCommand(ctx, "ls -la",
     options.WithCwd("/home/user/project"),
+)
+```
+
+<a name="WithDepth"></a>
+## func WithDepth
+
+```go
+func WithDepth(depth int32) func(*ListFiles)
+```
+
+WithDepth sets how many levels deep to list. Depth 1 \(the default\) lists the directory's entries, depth 2 also includes their children, and so on.
+
+Example:
+
+```
+files, err := sandbox.FileSystem.ListFiles(ctx, "/home/user",
+    options.WithDepth(3),
 )
 ```
 
@@ -888,6 +907,17 @@ GitPush holds optional parameters for \[daytona.GitService.Push\].
 type GitPush struct {
     Username *string // Username for HTTPS authentication
     Password *string // Password or token for HTTPS authentication
+}
+```
+
+<a name="ListFiles"></a>
+## type ListFiles
+
+ListFiles holds optional parameters for \[daytona.FileSystemService.ListFiles\].
+
+```go
+type ListFiles struct {
+    Depth *int32 // How many levels deep to list (default: 1, must be >= 1)
 }
 ```
 

--- a/apps/docs/src/content/docs/en/go-sdk/types.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/types.mdx
@@ -231,6 +231,7 @@ FileInfo represents file metadata
 ```go
 type FileInfo struct {
     Name         string
+    Path         string
     Size         int64
     Mode         string
     ModifiedTime time.Time

--- a/apps/docs/src/content/docs/en/java-sdk/file-system.mdx
+++ b/apps/docs/src/content/docs/en/java-sdk/file-system.mdx
@@ -194,6 +194,26 @@ Lists files and directories under a path.
 
 - `io.daytona.sdk.exception.DaytonaException` - if listing fails
 
+#### listFiles()
+```java
+public List<FileInfo> listFiles(String path, Integer depth)
+```
+
+Lists files and directories under a path, optionally recursing into subdirectories.
+
+**Parameters**:
+
+- `path` _String_ - directory path
+- `depth` _Integer_ - how many levels deep to list: depth=1 (default) lists the directory's entries, depth=2 also includes their children, and so on; must be >= 1. Each returned entry carries a full path field.
+
+**Returns**:
+
+- `List\<FileInfo\>` - file metadata entries
+
+**Throws**:
+
+- `io.daytona.sdk.exception.DaytonaException` - if listing fails
+
 #### getFileDetails()
 ```java
 public FileInfo getFileDetails(String path)

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-file-system.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-file-system.mdx
@@ -333,7 +333,7 @@ if info.is_dir:
 ```python
 @intercept_errors(message_prefix="Failed to list files: ")
 @with_instrumentation()
-async def list_files(path: str) -> list[FileInfo]
+async def list_files(path: str, depth: int | None = None) -> list[FileInfo]
 ```
 
 Lists files and directories in a given path and returns their information, similar to the ls -l command.
@@ -342,6 +342,9 @@ Lists files and directories in a given path and returns their information, simil
 
 - `path` _str_ - Path to the directory to list contents from. Relative paths are resolved
   based on the sandbox working directory.
+- `depth` _int | None_ - How many levels deep to list. depth=1 (default) lists the
+  directory's entries, depth=2 also includes their children, and so on. Must be >= 1.
+  Each returned FileInfo carries a full `path` field.
   
 
 **Returns**:
@@ -361,9 +364,9 @@ for file in files:
     if not file.is_dir:
         print(f"{file.name}: {file.size} bytes")
 
-# List only directories
-dirs = [f for f in files if f.is_dir]
-print("Subdirectories:", ", ".join(d.name for d in dirs))
+# List recursively two levels deep
+tree = await sandbox.fs.list_files("workspace/data", depth=2)
+print("Paths:", ", ".join(f.path for f in tree))
 ```
 
 #### AsyncFileSystem.move\_files

--- a/apps/docs/src/content/docs/en/python-sdk/sync/file-system.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/file-system.mdx
@@ -330,7 +330,7 @@ if info.is_dir:
 ```python
 @intercept_errors(message_prefix="Failed to list files: ")
 @with_instrumentation()
-def list_files(path: str) -> list[FileInfo]
+def list_files(path: str, depth: int | None = None) -> list[FileInfo]
 ```
 
 Lists files and directories in a given path and returns their information, similar to the ls -l command.
@@ -339,6 +339,9 @@ Lists files and directories in a given path and returns their information, simil
 
 - `path` _str_ - Path to the directory to list contents from. Relative paths are resolved
   based on the sandbox working directory.
+- `depth` _int | None_ - How many levels deep to list. depth=1 (default) lists the
+  directory's entries, depth=2 also includes their children, and so on. Must be >= 1.
+  Each returned FileInfo carries a full `path` field.
   
 
 **Returns**:
@@ -358,9 +361,9 @@ for file in files:
     if not file.is_dir:
         print(f"{file.name}: {file.size} bytes")
 
-# List only directories
-dirs = [f for f in files if f.is_dir]
-print("Subdirectories:", ", ".join(d.name for d in dirs))
+# List recursively two levels deep
+tree = sandbox.fs.list_files("workspace/data", depth=2)
+print("Paths:", ", ".join(f.path for f in tree))
 ```
 
 #### FileSystem.move\_files

--- a/apps/docs/src/content/docs/en/ruby-sdk/charts.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/charts.mdx
@@ -12,7 +12,7 @@ Chart class for Daytona SDK.
 #### new Chart()
 
 ```ruby
-def initialize(type:, title:, png:, elements:)
+def initialize(type: nil, title: nil, png: nil, elements: [])
 
 ```
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/computer-use.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/computer-use.mdx
@@ -12,7 +12,7 @@ Initialize a new ComputerUse instance.
 #### new ComputerUse()
 
 ```ruby
-def initialize(sandbox_id:, toolbox_api:, otel_state:)
+def initialize(sandbox_id:, toolbox_api:, otel_state: nil)
 
 ```
 
@@ -318,7 +318,7 @@ Accessibility operations for computer use functionality.
 #### new Accessibility()
 
 ```ruby
-def initialize(sandbox_id:, toolbox_api:, otel_state:)
+def initialize(sandbox_id:, toolbox_api:, otel_state: nil)
 
 ```
 
@@ -359,7 +359,7 @@ def toolbox_api()
 #### get_tree()
 
 ```ruby
-def get_tree(scope:, pid:, max_depth:)
+def get_tree(scope: nil, pid: nil, max_depth: nil)
 
 ```
 
@@ -390,7 +390,7 @@ puts tree.root.name
 #### find_nodes()
 
 ```ruby
-def find_nodes(scope:, pid:, role:, name:, name_match:, states:, limit:)
+def find_nodes(scope: nil, pid: nil, role: nil, name: nil, name_match: nil, states: nil, limit: nil)
 
 ```
 
@@ -454,7 +454,7 @@ sandbox.computer_use.accessibility.focus_node(id: node.id)
 #### invoke_node()
 
 ```ruby
-def invoke_node(id:, action:)
+def invoke_node(id:, action: nil)
 
 ```
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/config.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/config.mdx
@@ -12,7 +12,7 @@ Main class for a new Daytona::Config object.
 #### new Config()
 
 ```ruby
-def initialize(api_key:, jwt_token:, api_url:, organization_id:, target:, otel_enabled:, _experimental:)
+def initialize(api_key: nil, jwt_token: nil, api_url: nil, organization_id: nil, target: nil, otel_enabled: nil, _experimental: nil)
 
 ```
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/daytona.mdx
@@ -12,7 +12,7 @@ Daytona class for Daytona SDK.
 #### new Daytona()
 
 ```ruby
-def initialize(config)
+def initialize(config = Config.new)
 
 ```
 
@@ -119,7 +119,7 @@ Shuts down OTel providers, flushing any pending telemetry data.
 #### create()
 
 ```ruby
-def create(params, on_snapshot_create_logs:)
+def create(params = nil, on_snapshot_create_logs: nil)
 
 ```
 
@@ -174,7 +174,7 @@ Gets a Sandbox by its ID.
 #### list()
 
 ```ruby
-def list(query)
+def list(query = nil)
 
 ```
 
@@ -204,7 +204,7 @@ end
 #### start()
 
 ```ruby
-def start(sandbox, timeout)
+def start(sandbox, timeout = Sandbox::DEFAULT_TIMEOUT)
 
 ```
 
@@ -222,7 +222,7 @@ Starts a Sandbox and waits for it to be ready.
 #### stop()
 
 ```ruby
-def stop(sandbox, timeout)
+def stop(sandbox, timeout = Sandbox::DEFAULT_TIMEOUT)
 
 ```
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/file-system.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/file-system.mdx
@@ -12,7 +12,7 @@ Main class for a new FileSystem instance.
 #### new FileSystem()
 
 ```ruby
-def initialize(sandbox_id:, toolbox_api:, otel_state:)
+def initialize(sandbox_id:, toolbox_api:, otel_state: nil)
 
 ```
 
@@ -90,7 +90,7 @@ sandbox.fs.create_folder("workspace/secrets", "700")
 #### delete_file()
 
 ```ruby
-def delete_file(path, recursive:)
+def delete_file(path, recursive: false)
 
 ```
 
@@ -161,7 +161,7 @@ puts "Path is a directory" if info.is_dir
 #### list_files()
 
 ```ruby
-def list_files(path)
+def list_files(path, depth: nil)
 
 ```
 
@@ -171,6 +171,9 @@ Lists files and directories in a given path and returns their information, simil
 
 - `path` _String_ - Path to the directory to list contents from. Relative paths are resolved
 based on the sandbox working directory.
+- `depth` _Integer, nil_ - How many levels deep to list. depth=1 (default) lists the
+directory's entries, depth=2 also includes their children, and so on. Must be >= 1.
+Each returned FileInfo carries a full path field.
 
 **Returns**:
 
@@ -200,7 +203,7 @@ puts "Subdirectories: #{dirs.map(&:name).join(', ')}"
 #### download_file()
 
 ```ruby
-def download_file(remote_path, local_path)
+def download_file(remote_path, local_path = nil)
 
 ```
 
@@ -239,7 +242,7 @@ puts "Size of the downloaded file: #{size_mb} MB"
 #### download_file_stream()
 
 ```ruby
-def download_file_stream(remote_path, timeout:, on_progress:, cancel_event:)
+def download_file_stream(remote_path, timeout: 30 * 60, on_progress: nil, cancel_event: nil)
 
 ```
 
@@ -327,7 +330,7 @@ sandbox.fs.upload_file(data, "tmp/config.json")
 #### upload_file_stream()
 
 ```ruby
-def upload_file_stream(source, remote_path, timeout:, on_progress:, cancel_event:)
+def upload_file_stream(source, remote_path, timeout: 30 * 60, on_progress: nil, cancel_event: nil)
 
 ```
 
@@ -569,7 +572,7 @@ end
 #### set_file_permissions()
 
 ```ruby
-def set_file_permissions(path:, mode:, owner:, group:)
+def set_file_permissions(path:, mode: nil, owner: nil, group: nil)
 
 ```
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/git.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/git.mdx
@@ -12,7 +12,7 @@ Main class for a new Git handler instance.
 #### new Git()
 
 ```ruby
-def initialize(sandbox_id:, toolbox_api:, otel_state:)
+def initialize(sandbox_id:, toolbox_api:, otel_state: nil)
 
 ```
 
@@ -124,7 +124,7 @@ puts "Branches: #{response.branches}"
 #### clone()
 
 ```ruby
-def clone(url:, path:, branch:, commit_id:, username:, password:, insecure_skip_tls:)
+def clone(url:, path:, branch: nil, commit_id: nil, username: nil, password: nil, insecure_skip_tls: nil)
 
 ```
 
@@ -185,7 +185,7 @@ sandbox.git.clone(
 #### commit()
 
 ```ruby
-def commit(path:, message:, author:, email:, allow_empty:)
+def commit(path:, message:, author:, email:, allow_empty: false)
 
 ```
 
@@ -228,7 +228,7 @@ puts "Commit SHA: #{commit_response.sha}"
 #### push()
 
 ```ruby
-def push(path:, username:, password:)
+def push(path:, username: nil, password: nil)
 
 ```
 
@@ -269,7 +269,7 @@ sandbox.git.push(
 #### pull()
 
 ```ruby
-def pull(path:, username:, password:)
+def pull(path:, username: nil, password: nil)
 
 ```
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/image.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/image.mdx
@@ -14,7 +14,7 @@ such as `Image.base()`, `Image.debian_slim()`, or `Image.from_dockerfile()`.
 #### new Image()
 
 ```ruby
-def initialize(dockerfile:, context_list:)
+def initialize(dockerfile: nil, context_list: [])
 
 ```
 
@@ -54,7 +54,7 @@ def context_list()
 #### pip_install()
 
 ```ruby
-def pip_install(*packages, find_links:, index_url:, extra_index_urls:, pre:, extra_options:)
+def pip_install(*packages, find_links: nil, index_url: nil, extra_index_urls: nil, pre: false, extra_options: '')
 
 ```
 
@@ -83,7 +83,7 @@ image = Image.debian_slim("3.12").pip_install("requests", "pandas")
 #### pip_install_from_requirements()
 
 ```ruby
-def pip_install_from_requirements(requirements_txt, find_links:, index_url:, extra_index_urls:, pre:, extra_options:)
+def pip_install_from_requirements(requirements_txt, find_links: nil, index_url: nil, extra_index_urls: nil, pre: false, extra_options: '')
 
 ```
 
@@ -116,7 +116,7 @@ image = Image.debian_slim("3.12").pip_install_from_requirements("requirements.tx
 #### pip_install_from_pyproject()
 
 ```ruby
-def pip_install_from_pyproject(pyproject_toml, optional_dependencies:, find_links:, index_url:, extra_index_url:, pre:, extra_options:)
+def pip_install_from_pyproject(pyproject_toml, optional_dependencies: [], find_links: nil, index_url: nil, extra_index_url: nil, pre: false, extra_options: '')
 
 ```
 
@@ -324,7 +324,7 @@ image = Image.debian_slim("3.12").cmd(["/bin/bash"])
 #### dockerfile_commands()
 
 ```ruby
-def dockerfile_commands(dockerfile_commands, context_dir:)
+def dockerfile_commands(dockerfile_commands, context_dir: nil)
 
 ```
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/lsp-server.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/lsp-server.mdx
@@ -12,7 +12,7 @@ LspServer class for Daytona SDK.
 #### new LspServer()
 
 ```ruby
-def initialize(language_id:, path_to_project:, toolbox_api:, sandbox_id:, otel_state:)
+def initialize(language_id:, path_to_project:, toolbox_api:, sandbox_id:, otel_state: nil)
 
 ```
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/object-storage.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/object-storage.mdx
@@ -12,7 +12,7 @@ Initialize ObjectStorage with S3-compatible credentials
 #### new ObjectStorage()
 
 ```ruby
-def initialize(endpoint_url:, aws_access_key_id:, aws_secret_access_key:, aws_session_token:, bucket_name:, region:)
+def initialize(endpoint_url:, aws_access_key_id:, aws_secret_access_key:, aws_session_token:, bucket_name: DEFAULT_BUCKET_NAME, region: DEFAULT_REGION)
 
 ```
 
@@ -58,7 +58,7 @@ def s3_client()
 #### upload()
 
 ```ruby
-def upload(path, organization_id, archive_base_path)
+def upload(path, organization_id, archive_base_path = nil)
 
 ```
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/process.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/process.mdx
@@ -12,7 +12,7 @@ Initialize a new Process instance
 #### new Process()
 
 ```ruby
-def initialize(sandbox_id:, toolbox_api:, get_preview_link:, language:, otel_state:)
+def initialize(sandbox_id:, toolbox_api:, get_preview_link:, language: 'python', otel_state: nil)
 
 ```
 
@@ -79,7 +79,7 @@ def language()
 #### exec()
 
 ```ruby
-def exec(command:, cwd:, env:, timeout:)
+def exec(command:, cwd: nil, env: nil, timeout: nil)
 
 ```
 
@@ -115,7 +115,7 @@ result = sandbox.process.exec("sleep 10", timeout: 5)
 #### code_run()
 
 ```ruby
-def code_run(code:, params:, timeout:)
+def code_run(code:, params: nil, timeout: nil)
 
 ```
 
@@ -475,7 +475,7 @@ sandbox.process.delete_session("temp-session")
 #### create_pty_session()
 
 ```ruby
-def create_pty_session(id:, cwd:, envs:, pty_size:)
+def create_pty_session(id:, cwd: nil, envs: nil, pty_size: nil)
 
 ```
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx
@@ -12,7 +12,7 @@ Sandbox class for Daytona SDK.
 #### new Sandbox()
 
 ```ruby
-def initialize(sandbox_dto:, config:, sandbox_api:, otel_state:)
+def initialize(sandbox_dto:, config:, sandbox_api:, otel_state: nil)
 
 ```
 
@@ -480,7 +480,7 @@ The Sandbox will automatically delete after being continuously stopped for the s
 #### update_network_settings()
 
 ```ruby
-def update_network_settings(network_block_all:, network_allow_list:)
+def update_network_settings(network_block_all: nil, network_allow_list: nil)
 
 ```
 
@@ -633,7 +633,7 @@ to the URL.
 #### create_signed_preview_url()
 
 ```ruby
-def create_signed_preview_url(port, expires_in_seconds)
+def create_signed_preview_url(port, expires_in_seconds = nil)
 
 ```
 
@@ -739,7 +739,7 @@ Revokes an SSH access token for the sandbox.
 #### start()
 
 ```ruby
-def start(timeout)
+def start(timeout = DEFAULT_TIMEOUT)
 
 ```
 
@@ -756,7 +756,7 @@ Starts the Sandbox and waits for it to be ready.
 #### recover()
 
 ```ruby
-def recover(timeout)
+def recover(timeout = DEFAULT_TIMEOUT)
 
 ```
 
@@ -782,7 +782,7 @@ puts 'Sandbox recovered successfully'
 #### stop()
 
 ```ruby
-def stop(timeout, force:)
+def stop(timeout = DEFAULT_TIMEOUT, force: false)
 
 ```
 
@@ -800,7 +800,7 @@ Stops the Sandbox and waits for it to be stopped.
 #### resize()
 
 ```ruby
-def resize(resources, timeout)
+def resize(resources, timeout = DEFAULT_TIMEOUT)
 
 ```
 
@@ -839,7 +839,7 @@ sandbox.resize(Daytona::Resources.new(cpu: 2, memory: 4, disk: 30))
 #### wait_for_resize_complete()
 
 ```ruby
-def wait_for_resize_complete(_timeout)
+def wait_for_resize_complete(_timeout = DEFAULT_TIMEOUT)
 
 ```
 
@@ -895,7 +895,7 @@ Validates an SSH access token for the sandbox.
 #### wait_for_sandbox_start()
 
 ```ruby
-def wait_for_sandbox_start(_timeout)
+def wait_for_sandbox_start(_timeout = DEFAULT_TIMEOUT)
 
 ```
 
@@ -913,7 +913,7 @@ reaches the 'started' state or encounters an error.
 #### wait_for_sandbox_stop()
 
 ```ruby
-def wait_for_sandbox_stop(_timeout)
+def wait_for_sandbox_stop(_timeout = DEFAULT_TIMEOUT)
 
 ```
 
@@ -932,7 +932,7 @@ Treats destroyed as stopped to cover ephemeral sandboxes that are automatically 
 #### experimental_fork()
 
 ```ruby
-def experimental_fork(name:, timeout:)
+def experimental_fork(name: nil, timeout: DEFAULT_TIMEOUT)
 
 ```
 
@@ -952,7 +952,7 @@ with the same disk contents but operates independently from that point on.
 #### experimental_create_snapshot()
 
 ```ruby
-def experimental_create_snapshot(name:, timeout:)
+def experimental_create_snapshot(name:, timeout: DEFAULT_TIMEOUT)
 
 ```
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/snapshot.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/snapshot.mdx
@@ -12,7 +12,7 @@ SnapshotService class for Daytona SDK.
 #### new SnapshotService()
 
 ```ruby
-def initialize(snapshots_api:, object_storage_api:, default_region_id:, otel_state:)
+def initialize(snapshots_api:, object_storage_api:, default_region_id: nil, otel_state: nil)
 
 ```
 
@@ -32,7 +32,7 @@ def initialize(snapshots_api:, object_storage_api:, default_region_id:, otel_sta
 #### list()
 
 ```ruby
-def list(page:, limit:)
+def list(page: nil, limit: nil)
 
 ```
 
@@ -116,7 +116,7 @@ puts "#{snapshot.name} (#{snapshot.image_name})"
 #### create()
 
 ```ruby
-def create(params, on_logs:)
+def create(params, on_logs: nil)
 
 ```
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/volume-service.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/volume-service.mdx
@@ -12,7 +12,7 @@ Service for managing Daytona Volumes. Can be used to list, get, create and delet
 #### new VolumeService()
 
 ```ruby
-def initialize(volumes_api, otel_state:)
+def initialize(volumes_api, otel_state: nil)
 
 ```
 
@@ -66,7 +66,7 @@ Delete a Volume.
 #### get()
 
 ```ruby
-def get(name, create:)
+def get(name, create: false)
 
 ```
 

--- a/apps/docs/src/content/docs/en/typescript-sdk/file-system.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/file-system.mdx
@@ -333,7 +333,9 @@ console.log(`Size: ${info.size}, Modified: ${info.modTime}`);
 #### listFiles()
 
 ```ts
-listFiles(path: string): Promise<FileInfo[]>
+listFiles(path: string, options?: {
+  depth: number;
+}): Promise<FileInfo[]>
 ```
 
 Lists contents of a directory in the Sandbox.
@@ -341,6 +343,10 @@ Lists contents of a directory in the Sandbox.
 **Parameters**:
 
 - `path` _string_ - Directory path to list. Relative paths are resolved based on the sandbox working directory.
+- `options?` _Listing options_
+- `depth?` _number_ - How many levels deep to list. depth=1 (default) lists the
+    directory's entries, depth=2 also includes their children, and so on. Must be an integer >= 1.
+    Each returned FileInfo carries a full `path` field.
 
 
 **Returns**:
@@ -355,6 +361,10 @@ const files = await fs.listFiles('app/src');
 files.forEach(file => {
   console.log(`${file.name} (${file.size} bytes)`);
 });
+
+// List recursively two levels deep
+const tree = await fs.listFiles('app/src', { depth: 2 });
+tree.forEach(file => console.log(file.path));
 ```
 
 ***

--- a/libs/sdk-go/pkg/daytona/filesystem.go
+++ b/libs/sdk-go/pkg/daytona/filesystem.go
@@ -113,9 +113,22 @@ func (f *FileSystemService) CreateFolder(ctx context.Context, path string, opts 
 //	}
 //
 // Returns an error if the path doesn't exist or isn't accessible.
-func (f *FileSystemService) ListFiles(ctx context.Context, path string) ([]*types.FileInfo, error) {
+func (f *FileSystemService) ListFiles(ctx context.Context, path string, opts ...func(*options.ListFiles)) ([]*types.FileInfo, error) {
 	return withInstrumentation(ctx, f.otel, "FileSystem", "ListFiles", func(ctx context.Context) ([]*types.FileInfo, error) {
-		files, httpResp, err := f.toolboxClient.FileSystemAPI.ListFiles(ctx).Path(path).Execute()
+		listOpts := &options.ListFiles{}
+		for _, opt := range opts {
+			opt(listOpts)
+		}
+
+		req := f.toolboxClient.FileSystemAPI.ListFiles(ctx).Path(path)
+		if listOpts.Depth != nil {
+			if *listOpts.Depth < 1 {
+				return nil, errors.NewDaytonaValidationError("depth must be at least 1", nil)
+			}
+			req = req.Depth(*listOpts.Depth)
+		}
+
+		files, httpResp, err := req.Execute()
 		if err != nil {
 			return nil, errors.ConvertToolboxError(err, httpResp)
 		}
@@ -126,6 +139,7 @@ func (f *FileSystemService) ListFiles(ctx context.Context, path string) ([]*type
 			modTime, _ := time.Parse(time.RFC3339, file.GetModifiedAt())
 			result[i] = &types.FileInfo{
 				Name:         file.GetName(),
+				Path:         file.GetPath(),
 				Size:         int64(file.GetSize()),
 				Mode:         file.GetMode(),
 				ModifiedTime: modTime,

--- a/libs/sdk-go/pkg/options/filesystem.go
+++ b/libs/sdk-go/pkg/options/filesystem.go
@@ -24,6 +24,25 @@ func WithMode(mode string) func(*CreateFolder) {
 	}
 }
 
+// ListFiles holds optional parameters for [daytona.FileSystemService.ListFiles].
+type ListFiles struct {
+	Depth *int32 // How many levels deep to list (default: 1, must be >= 1)
+}
+
+// WithDepth sets how many levels deep to list. Depth 1 (the default) lists
+// the directory's entries, depth 2 also includes their children, and so on.
+//
+// Example:
+//
+//	files, err := sandbox.FileSystem.ListFiles(ctx, "/home/user",
+//	    options.WithDepth(3),
+//	)
+func WithDepth(depth int32) func(*ListFiles) {
+	return func(opts *ListFiles) {
+		opts.Depth = &depth
+	}
+}
+
 // SetFilePermissions holds optional parameters for [daytona.FileSystemService.SetFilePermissions].
 type SetFilePermissions struct {
 	Mode  *string // Unix file permissions (e.g., "0644")

--- a/libs/sdk-go/pkg/types/types.go
+++ b/libs/sdk-go/pkg/types/types.go
@@ -166,6 +166,7 @@ type Snapshot struct {
 // FileInfo represents file metadata
 type FileInfo struct {
 	Name         string
+	Path         string
 	Size         int64
 	Mode         string
 	ModifiedTime time.Time

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/FileSystem.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/FileSystem.java
@@ -158,7 +158,24 @@ public class FileSystem {
      * @throws io.daytona.sdk.exception.DaytonaException if listing fails
      */
     public List<FileInfo> listFiles(String path) {
-        List<io.daytona.toolbox.client.model.FileInfo> files = ExceptionMapper.callToolbox(() -> fileSystemApi.listFiles(path));
+        return listFiles(path, null);
+    }
+
+    /**
+     * Lists files and directories under a path, optionally recursing into subdirectories.
+     *
+     * @param path directory path
+     * @param depth how many levels deep to list: depth=1 (default) lists the directory's
+     *     entries, depth=2 also includes their children, and so on; must be >= 1.
+     *     Each returned entry carries a full path field.
+     * @return file metadata entries
+     * @throws io.daytona.sdk.exception.DaytonaException if listing fails
+     */
+    public List<FileInfo> listFiles(String path, Integer depth) {
+        if (depth != null && depth < 1) {
+            throw new io.daytona.sdk.exception.DaytonaException("depth must be at least 1");
+        }
+        List<io.daytona.toolbox.client.model.FileInfo> files = ExceptionMapper.callToolbox(() -> fileSystemApi.listFiles(path, depth));
         List<FileInfo> result = new ArrayList<FileInfo>();
         if (files != null) {
             for (io.daytona.toolbox.client.model.FileInfo file : files) {

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/model/FileInfo.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/model/FileInfo.java
@@ -10,6 +10,7 @@ public class FileInfo extends io.daytona.toolbox.client.model.FileInfo {
         super();
         if (source != null) {
             setName(source.getName());
+            setPath(source.getPath());
             setSize(source.getSize());
             setMode(source.getMode());
             setModTime(source.getModTime());

--- a/libs/sdk-java/src/test/java/io/daytona/sdk/FileSystemTest.java
+++ b/libs/sdk-java/src/test/java/io/daytona/sdk/FileSystemTest.java
@@ -436,7 +436,7 @@ class FileSystemTest {
         source.setMode("644");
         source.setModTime("now");
         source.setIsDir(false);
-        when(fileSystemApi.listFiles("/workspace")).thenReturn(Collections.singletonList(source));
+        when(fileSystemApi.listFiles("/workspace", null)).thenReturn(Collections.singletonList(source));
         when(fileSystemApi.getFileInfo("/workspace/a.txt")).thenReturn(source);
 
         List<FileInfo> files = fileSystem.listFiles("/workspace");
@@ -448,7 +448,7 @@ class FileSystemTest {
 
     @Test
     void listAndDetailsHandleNullResponses() {
-        when(fileSystemApi.listFiles("/workspace")).thenReturn(null);
+        when(fileSystemApi.listFiles("/workspace", null)).thenReturn(null);
         when(fileSystemApi.getFileInfo("/workspace/missing.txt")).thenReturn(null);
 
         assertThat(fileSystem.listFiles("/workspace")).isEmpty();

--- a/libs/sdk-python/src/daytona/_async/filesystem.py
+++ b/libs/sdk-python/src/daytona/_async/filesystem.py
@@ -666,12 +666,15 @@ class AsyncFileSystem:
 
     @intercept_errors(message_prefix="Failed to list files: ")
     @with_instrumentation()
-    async def list_files(self, path: str) -> list[FileInfo]:
+    async def list_files(self, path: str, depth: int | None = None) -> list[FileInfo]:
         """Lists files and directories in a given path and returns their information, similar to the ls -l command.
 
         Args:
             path (str): Path to the directory to list contents from. Relative paths are resolved
             based on the sandbox working directory.
+            depth (int | None): How many levels deep to list. depth=1 (default) lists the
+            directory's entries, depth=2 also includes their children, and so on. Must be >= 1.
+            Each returned FileInfo carries a full `path` field.
 
         Returns:
             list[FileInfo]: List of file and directory information. Each FileInfo
@@ -687,12 +690,14 @@ class AsyncFileSystem:
                 if not file.is_dir:
                     print(f"{file.name}: {file.size} bytes")
 
-            # List only directories
-            dirs = [f for f in files if f.is_dir]
-            print("Subdirectories:", ", ".join(d.name for d in dirs))
+            # List recursively two levels deep
+            tree = await sandbox.fs.list_files("workspace/data", depth=2)
+            print("Paths:", ", ".join(f.path for f in tree))
             ```
         """
-        return await self._api_client.list_files(path=path)
+        if depth is not None and depth < 1:
+            raise DaytonaError("depth must be at least 1")
+        return await self._api_client.list_files(path=path, depth=depth)
 
     @intercept_errors(message_prefix="Failed to move files: ")
     @with_instrumentation()

--- a/libs/sdk-python/src/daytona/_sync/filesystem.py
+++ b/libs/sdk-python/src/daytona/_sync/filesystem.py
@@ -628,12 +628,15 @@ class FileSystem:
 
     @intercept_errors(message_prefix="Failed to list files: ")
     @with_instrumentation()
-    def list_files(self, path: str) -> list[FileInfo]:
+    def list_files(self, path: str, depth: int | None = None) -> list[FileInfo]:
         """Lists files and directories in a given path and returns their information, similar to the ls -l command.
 
         Args:
             path (str): Path to the directory to list contents from. Relative paths are resolved
             based on the sandbox working directory.
+            depth (int | None): How many levels deep to list. depth=1 (default) lists the
+            directory's entries, depth=2 also includes their children, and so on. Must be >= 1.
+            Each returned FileInfo carries a full `path` field.
 
         Returns:
             list[FileInfo]: List of file and directory information. Each FileInfo
@@ -649,12 +652,14 @@ class FileSystem:
                 if not file.is_dir:
                     print(f"{file.name}: {file.size} bytes")
 
-            # List only directories
-            dirs = [f for f in files if f.is_dir]
-            print("Subdirectories:", ", ".join(d.name for d in dirs))
+            # List recursively two levels deep
+            tree = sandbox.fs.list_files("workspace/data", depth=2)
+            print("Paths:", ", ".join(f.path for f in tree))
             ```
         """
-        return self._api_client.list_files(path=path)
+        if depth is not None and depth < 1:
+            raise DaytonaError("depth must be at least 1")
+        return self._api_client.list_files(path=path, depth=depth)
 
     @intercept_errors(message_prefix="Failed to move files: ")
     @with_instrumentation()

--- a/libs/sdk-ruby/lib/daytona/file_system.rb
+++ b/libs/sdk-ruby/lib/daytona/file_system.rb
@@ -97,6 +97,9 @@ module Daytona
     #
     # @param path [String] Path to the directory to list contents from. Relative paths are resolved
     #   based on the sandbox working directory.
+    # @param depth [Integer, nil] How many levels deep to list. depth=1 (default) lists the
+    #   directory's entries, depth=2 also includes their children, and so on. Must be >= 1.
+    #   Each returned FileInfo carries a full path field.
     # @return [Array<DaytonaApiClient::FileInfo>] List of file and directory information
     # @raise [Daytona::Sdk::Error] If the operation fails
     #
@@ -112,8 +115,14 @@ module Daytona
     #   # List only directories
     #   dirs = files.select(&:is_dir)
     #   puts "Subdirectories: #{dirs.map(&:name).join(', ')}"
-    def list_files(path)
-      toolbox_api.list_files({ path: })
+    def list_files(path, depth: nil)
+      if !depth.nil? && (!depth.is_a?(Integer) || depth < 1)
+        raise Sdk::Error, 'Failed to list files: depth must be an integer of at least 1'
+      end
+
+      toolbox_api.list_files({ path:, depth: }.compact)
+    rescue Sdk::Error
+      raise
     rescue StandardError => e
       raise Sdk::Error, "Failed to list files: #{e.message}"
     end

--- a/libs/sdk-ruby/scripts/generate-docs.rb
+++ b/libs/sdk-ruby/scripts/generate-docs.rb
@@ -48,6 +48,14 @@ def add_frontmatter(content, class_name)
   frontmatter + content
 end
 
+def format_signature_params(parameters)
+  parameters.map do |name, default|
+    next name if default.nil?
+
+    name.end_with?(':') ? "#{name} #{default}" : "#{name} = #{default}"
+  end.join(', ')
+end
+
 def format_type(types)
   return 'Object' if types.nil? || types.empty?
 
@@ -174,8 +182,7 @@ def generate_markdown_for_object(obj)
 
       # Method signature
       content << '```ruby'
-      params_str = constructor.parameters.map { |p| p[0] }.join(', ')
-      content << "def initialize(#{params_str})"
+      content << "def initialize(#{format_signature_params(constructor.parameters)})"
       content << '```'
       content << ''
 
@@ -243,8 +250,7 @@ def generate_markdown_for_object(obj)
 
         # Method signature
         content << '```ruby'
-        params_str = method.parameters.map { |p| p[0] }.join(', ')
-        content << "def #{method.name}(#{params_str})"
+        content << "def #{method.name}(#{format_signature_params(method.parameters)})"
         content << '```'
         content << ''
 

--- a/libs/sdk-ruby/spec/daytona/file_system_spec.rb
+++ b/libs/sdk-ruby/spec/daytona/file_system_spec.rb
@@ -161,6 +161,22 @@ RSpec.describe Daytona::FileSystem do
 
       expect { fs.list_files('/x') }.to raise_error(Daytona::Sdk::Error, /Failed to list files: err/)
     end
+
+    it 'passes depth to the toolbox api' do
+      allow(toolbox_api).to receive(:list_files).with({ path: '/workspace', depth: 2 }).and_return([])
+
+      expect(fs.list_files('/workspace', depth: 2)).to eq([])
+    end
+
+    it 'rejects depth below 1' do
+      expect { fs.list_files('/workspace', depth: 0) }
+        .to raise_error(Daytona::Sdk::Error, /depth must be an integer of at least 1/)
+    end
+
+    it 'rejects non-integer depth' do
+      expect { fs.list_files('/workspace', depth: 1.5) }
+        .to raise_error(Daytona::Sdk::Error, /depth must be an integer of at least 1/)
+    end
   end
 
   describe '#download_file' do

--- a/libs/sdk-typescript/src/FileSystem.ts
+++ b/libs/sdk-typescript/src/FileSystem.ts
@@ -565,6 +565,10 @@ export class FileSystem {
    * Lists contents of a directory in the Sandbox.
    *
    * @param {string} path - Directory path to list. Relative paths are resolved based on the sandbox working directory.
+   * @param {object} [options] - Listing options
+   * @param {number} [options.depth] - How many levels deep to list. depth=1 (default) lists the
+   * directory's entries, depth=2 also includes their children, and so on. Must be an integer >= 1.
+   * Each returned FileInfo carries a full `path` field.
    * @returns {Promise<FileInfo[]>} Array of file and directory information
    *
    * @example
@@ -573,10 +577,17 @@ export class FileSystem {
    * files.forEach(file => {
    *   console.log(`${file.name} (${file.size} bytes)`);
    * });
+   *
+   * // List recursively two levels deep
+   * const tree = await fs.listFiles('app/src', { depth: 2 });
+   * tree.forEach(file => console.log(file.path));
    */
   @WithInstrumentation()
-  public async listFiles(path: string): Promise<FileInfo[]> {
-    const response = await this.apiClient.listFiles(path)
+  public async listFiles(path: string, options?: { depth?: number }): Promise<FileInfo[]> {
+    if (options?.depth !== undefined && (!Number.isInteger(options.depth) || options.depth < 1)) {
+      throw new DaytonaError('depth must be an integer of at least 1')
+    }
+    const response = await this.apiClient.listFiles(path, options?.depth)
     return response.data
   }
 

--- a/libs/sdk-typescript/src/__tests__/filesystem.test.ts
+++ b/libs/sdk-typescript/src/__tests__/filesystem.test.ts
@@ -55,3 +55,37 @@ describe('FileSystem.downloadFile', () => {
     })
   })
 })
+
+describe('FileSystem.listFiles', () => {
+  function newFileSystem(listFilesMock: jest.Mock) {
+    const fileSystem = Object.create(FileSystem.prototype) as FileSystem
+    Object.defineProperty(fileSystem, 'apiClient', { value: { listFiles: listFilesMock } })
+    return fileSystem
+  }
+
+  it.each([0, -1, 1.5, Number.NaN])('rejects invalid depth %p before calling the api', async (depth) => {
+    const listFilesMock = jest.fn()
+    const fileSystem = newFileSystem(listFilesMock)
+
+    await expect(FileSystem.prototype.listFiles.call(fileSystem, '/workspace', { depth })).rejects.toThrow(
+      'depth must be an integer of at least 1',
+    )
+    expect(listFilesMock).not.toHaveBeenCalled()
+  })
+
+  it('passes depth to the api client', async () => {
+    const listFilesMock = jest.fn().mockResolvedValue({ data: [] })
+    const fileSystem = newFileSystem(listFilesMock)
+
+    await expect(FileSystem.prototype.listFiles.call(fileSystem, '/workspace', { depth: 2 })).resolves.toEqual([])
+    expect(listFilesMock).toHaveBeenCalledWith('/workspace', 2)
+  })
+
+  it('omits depth when not provided', async () => {
+    const listFilesMock = jest.fn().mockResolvedValue({ data: [] })
+    const fileSystem = newFileSystem(listFilesMock)
+
+    await expect(FileSystem.prototype.listFiles.call(fileSystem, '/workspace')).resolves.toEqual([])
+    expect(listFilesMock).toHaveBeenCalledWith('/workspace', undefined)
+  })
+})

--- a/libs/toolbox-api-client-go/api/openapi.yaml
+++ b/libs/toolbox-api-client-go/api/openapi.yaml
@@ -1024,7 +1024,10 @@ paths:
       tags:
       - file-system
     get:
-      description: List files and directories in the specified path
+      description: |-
+        List files and directories in the specified path. Use the optional depth
+        parameter to list recursively: depth=1 (default) lists the directory's
+        entries, depth=2 also includes their children, and so on.
       operationId: ListFiles
       parameters:
       - description: Directory path to list (defaults to working directory)
@@ -1032,6 +1035,11 @@ paths:
         name: path
         schema:
           type: string
+      - description: "How many levels deep to list (default: 1, must be >= 1)"
+        in: query
+        name: depth
+        schema:
+          type: integer
       responses:
         "200":
           content:
@@ -3174,6 +3182,7 @@ components:
       example:
         mode: mode
         owner: owner
+        path: path
         size: 0
         modTime: modTime
         modifiedAt: modifiedAt
@@ -3198,6 +3207,9 @@ components:
         name:
           type: string
         owner:
+          type: string
+        path:
+          description: Full path of the entry
           type: string
         permissions:
           type: string

--- a/libs/toolbox-api-client-go/api_file_system.go
+++ b/libs/toolbox-api-client-go/api_file_system.go
@@ -107,7 +107,9 @@ type FileSystemAPI interface {
 	/*
 	ListFiles List files and directories
 
-	List files and directories in the specified path
+	List files and directories in the specified path. Use the optional depth
+parameter to list recursively: depth=1 (default) lists the directory's
+entries, depth=2 also includes their children, and so on.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@return FileSystemAPIListFilesRequest
@@ -878,11 +880,18 @@ type FileSystemAPIListFilesRequest struct {
 	ctx context.Context
 	ApiService FileSystemAPI
 	path *string
+	depth *int32
 }
 
 // Directory path to list (defaults to working directory)
 func (r FileSystemAPIListFilesRequest) Path(path string) FileSystemAPIListFilesRequest {
 	r.path = &path
+	return r
+}
+
+// How many levels deep to list (default: 1, must be &gt;&#x3D; 1)
+func (r FileSystemAPIListFilesRequest) Depth(depth int32) FileSystemAPIListFilesRequest {
+	r.depth = &depth
 	return r
 }
 
@@ -893,7 +902,9 @@ func (r FileSystemAPIListFilesRequest) Execute() ([]FileInfo, *http.Response, er
 /*
 ListFiles List files and directories
 
-List files and directories in the specified path
+List files and directories in the specified path. Use the optional depth
+parameter to list recursively: depth=1 (default) lists the directory's
+entries, depth=2 also includes their children, and so on.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @return FileSystemAPIListFilesRequest
@@ -928,6 +939,9 @@ func (a *FileSystemAPIService) ListFilesExecute(r FileSystemAPIListFilesRequest)
 
 	if r.path != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "path", r.path, "", "")
+	}
+	if r.depth != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "depth", r.depth, "", "")
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}

--- a/libs/toolbox-api-client-go/model_file_info.go
+++ b/libs/toolbox-api-client-go/model_file_info.go
@@ -28,6 +28,8 @@ type FileInfo struct {
 	ModifiedAt string `json:"modifiedAt"`
 	Name string `json:"name"`
 	Owner string `json:"owner"`
+	// Full path of the entry
+	Path *string `json:"path,omitempty"`
 	Permissions string `json:"permissions"`
 	Size int32 `json:"size"`
 	AdditionalProperties map[string]interface{}
@@ -229,6 +231,38 @@ func (o *FileInfo) SetOwner(v string) {
 	o.Owner = v
 }
 
+// GetPath returns the Path field value if set, zero value otherwise.
+func (o *FileInfo) GetPath() string {
+	if o == nil || IsNil(o.Path) {
+		var ret string
+		return ret
+	}
+	return *o.Path
+}
+
+// GetPathOk returns a tuple with the Path field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *FileInfo) GetPathOk() (*string, bool) {
+	if o == nil || IsNil(o.Path) {
+		return nil, false
+	}
+	return o.Path, true
+}
+
+// HasPath returns a boolean if a field has been set.
+func (o *FileInfo) HasPath() bool {
+	if o != nil && !IsNil(o.Path) {
+		return true
+	}
+
+	return false
+}
+
+// SetPath gets a reference to the given string and assigns it to the Path field.
+func (o *FileInfo) SetPath(v string) {
+	o.Path = &v
+}
+
 // GetPermissions returns the Permissions field value
 func (o *FileInfo) GetPermissions() string {
 	if o == nil {
@@ -294,6 +328,9 @@ func (o FileInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize["modifiedAt"] = o.ModifiedAt
 	toSerialize["name"] = o.Name
 	toSerialize["owner"] = o.Owner
+	if !IsNil(o.Path) {
+		toSerialize["path"] = o.Path
+	}
 	toSerialize["permissions"] = o.Permissions
 	toSerialize["size"] = o.Size
 
@@ -354,6 +391,7 @@ func (o *FileInfo) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "modifiedAt")
 		delete(additionalProperties, "name")
 		delete(additionalProperties, "owner")
+		delete(additionalProperties, "path")
 		delete(additionalProperties, "permissions")
 		delete(additionalProperties, "size")
 		o.AdditionalProperties = additionalProperties

--- a/libs/toolbox-api-client-java/src/main/java/io/daytona/toolbox/client/api/FileSystemApi.java
+++ b/libs/toolbox-api-client-java/src/main/java/io/daytona/toolbox/client/api/FileSystemApi.java
@@ -882,6 +882,7 @@ public class FileSystemApi {
     /**
      * Build call for listFiles
      * @param path Directory path to list (defaults to working directory) (optional)
+     * @param depth How many levels deep to list (default: 1, must be &gt;&#x3D; 1) (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -892,7 +893,7 @@ public class FileSystemApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call listFilesCall(@javax.annotation.Nullable String path, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call listFilesCall(@javax.annotation.Nullable String path, @javax.annotation.Nullable Integer depth, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -921,6 +922,10 @@ public class FileSystemApi {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("path", path));
         }
 
+        if (depth != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("depth", depth));
+        }
+
         final String[] localVarAccepts = {
             "application/json"
         };
@@ -941,15 +946,16 @@ public class FileSystemApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call listFilesValidateBeforeCall(@javax.annotation.Nullable String path, final ApiCallback _callback) throws ApiException {
-        return listFilesCall(path, _callback);
+    private okhttp3.Call listFilesValidateBeforeCall(@javax.annotation.Nullable String path, @javax.annotation.Nullable Integer depth, final ApiCallback _callback) throws ApiException {
+        return listFilesCall(path, depth, _callback);
 
     }
 
     /**
      * List files and directories
-     * List files and directories in the specified path
+     * List files and directories in the specified path. Use the optional depth parameter to list recursively: depth&#x3D;1 (default) lists the directory&#39;s entries, depth&#x3D;2 also includes their children, and so on.
      * @param path Directory path to list (defaults to working directory) (optional)
+     * @param depth How many levels deep to list (default: 1, must be &gt;&#x3D; 1) (optional)
      * @return List&lt;FileInfo&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -959,15 +965,16 @@ public class FileSystemApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public List<FileInfo> listFiles(@javax.annotation.Nullable String path) throws ApiException {
-        ApiResponse<List<FileInfo>> localVarResp = listFilesWithHttpInfo(path);
+    public List<FileInfo> listFiles(@javax.annotation.Nullable String path, @javax.annotation.Nullable Integer depth) throws ApiException {
+        ApiResponse<List<FileInfo>> localVarResp = listFilesWithHttpInfo(path, depth);
         return localVarResp.getData();
     }
 
     /**
      * List files and directories
-     * List files and directories in the specified path
+     * List files and directories in the specified path. Use the optional depth parameter to list recursively: depth&#x3D;1 (default) lists the directory&#39;s entries, depth&#x3D;2 also includes their children, and so on.
      * @param path Directory path to list (defaults to working directory) (optional)
+     * @param depth How many levels deep to list (default: 1, must be &gt;&#x3D; 1) (optional)
      * @return ApiResponse&lt;List&lt;FileInfo&gt;&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -977,16 +984,17 @@ public class FileSystemApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<List<FileInfo>> listFilesWithHttpInfo(@javax.annotation.Nullable String path) throws ApiException {
-        okhttp3.Call localVarCall = listFilesValidateBeforeCall(path, null);
+    public ApiResponse<List<FileInfo>> listFilesWithHttpInfo(@javax.annotation.Nullable String path, @javax.annotation.Nullable Integer depth) throws ApiException {
+        okhttp3.Call localVarCall = listFilesValidateBeforeCall(path, depth, null);
         Type localVarReturnType = new TypeToken<List<FileInfo>>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
      * List files and directories (asynchronously)
-     * List files and directories in the specified path
+     * List files and directories in the specified path. Use the optional depth parameter to list recursively: depth&#x3D;1 (default) lists the directory&#39;s entries, depth&#x3D;2 also includes their children, and so on.
      * @param path Directory path to list (defaults to working directory) (optional)
+     * @param depth How many levels deep to list (default: 1, must be &gt;&#x3D; 1) (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -997,9 +1005,9 @@ public class FileSystemApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call listFilesAsync(@javax.annotation.Nullable String path, final ApiCallback<List<FileInfo>> _callback) throws ApiException {
+    public okhttp3.Call listFilesAsync(@javax.annotation.Nullable String path, @javax.annotation.Nullable Integer depth, final ApiCallback<List<FileInfo>> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = listFilesValidateBeforeCall(path, _callback);
+        okhttp3.Call localVarCall = listFilesValidateBeforeCall(path, depth, _callback);
         Type localVarReturnType = new TypeToken<List<FileInfo>>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/libs/toolbox-api-client-java/src/main/java/io/daytona/toolbox/client/model/FileInfo.java
+++ b/libs/toolbox-api-client-java/src/main/java/io/daytona/toolbox/client/model/FileInfo.java
@@ -85,6 +85,11 @@ public class FileInfo {
   @javax.annotation.Nonnull
   private String owner;
 
+  public static final String SERIALIZED_NAME_PATH = "path";
+  @SerializedName(SERIALIZED_NAME_PATH)
+  @javax.annotation.Nullable
+  private String path;
+
   public static final String SERIALIZED_NAME_PERMISSIONS = "permissions";
   @SerializedName(SERIALIZED_NAME_PERMISSIONS)
   @javax.annotation.Nonnull
@@ -231,6 +236,25 @@ public class FileInfo {
   }
 
 
+  public FileInfo path(@javax.annotation.Nullable String path) {
+    this.path = path;
+    return this;
+  }
+
+  /**
+   * Full path of the entry
+   * @return path
+   */
+  @javax.annotation.Nullable
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(@javax.annotation.Nullable String path) {
+    this.path = path;
+  }
+
+
   public FileInfo permissions(@javax.annotation.Nonnull String permissions) {
     this.permissions = permissions;
     return this;
@@ -330,6 +354,7 @@ public class FileInfo {
         Objects.equals(this.modifiedAt, fileInfo.modifiedAt) &&
         Objects.equals(this.name, fileInfo.name) &&
         Objects.equals(this.owner, fileInfo.owner) &&
+        Objects.equals(this.path, fileInfo.path) &&
         Objects.equals(this.permissions, fileInfo.permissions) &&
         Objects.equals(this.size, fileInfo.size)&&
         Objects.equals(this.additionalProperties, fileInfo.additionalProperties);
@@ -337,7 +362,7 @@ public class FileInfo {
 
   @Override
   public int hashCode() {
-    return Objects.hash(group, isDir, modTime, mode, modifiedAt, name, owner, permissions, size, additionalProperties);
+    return Objects.hash(group, isDir, modTime, mode, modifiedAt, name, owner, path, permissions, size, additionalProperties);
   }
 
   @Override
@@ -351,6 +376,7 @@ public class FileInfo {
     sb.append("    modifiedAt: ").append(toIndentedString(modifiedAt)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    owner: ").append(toIndentedString(owner)).append("\n");
+    sb.append("    path: ").append(toIndentedString(path)).append("\n");
     sb.append("    permissions: ").append(toIndentedString(permissions)).append("\n");
     sb.append("    size: ").append(toIndentedString(size)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
@@ -372,7 +398,7 @@ public class FileInfo {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("group", "isDir", "modTime", "mode", "modifiedAt", "name", "owner", "permissions", "size"));
+    openapiFields = new HashSet<String>(Arrays.asList("group", "isDir", "modTime", "mode", "modifiedAt", "name", "owner", "path", "permissions", "size"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("group", "isDir", "modTime", "mode", "modifiedAt", "name", "owner", "permissions", "size"));
@@ -415,6 +441,9 @@ public class FileInfo {
       }
       if (!jsonObj.get("owner").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `owner` to be a primitive type in the JSON string but got `%s`", jsonObj.get("owner").toString()));
+      }
+      if ((jsonObj.get("path") != null && !jsonObj.get("path").isJsonNull()) && !jsonObj.get("path").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `path` to be a primitive type in the JSON string but got `%s`", jsonObj.get("path").toString()));
       }
       if (!jsonObj.get("permissions").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `permissions` to be a primitive type in the JSON string but got `%s`", jsonObj.get("permissions").toString()));

--- a/libs/toolbox-api-client-java/src/test/java/io/daytona/toolbox/client/api/FileSystemApiTest.java
+++ b/libs/toolbox-api-client-java/src/test/java/io/daytona/toolbox/client/api/FileSystemApiTest.java
@@ -127,14 +127,15 @@ public class FileSystemApiTest {
     /**
      * List files and directories
      *
-     * List files and directories in the specified path
+     * List files and directories in the specified path. Use the optional depth parameter to list recursively: depth&#x3D;1 (default) lists the directory&#39;s entries, depth&#x3D;2 also includes their children, and so on.
      *
      * @throws ApiException if the Api call fails
      */
     @Test
     public void listFilesTest() throws ApiException {
         String path = null;
-        List<FileInfo> response = api.listFiles(path);
+        Integer depth = null;
+        List<FileInfo> response = api.listFiles(path, depth);
         // TODO: test validations
     }
 

--- a/libs/toolbox-api-client-java/src/test/java/io/daytona/toolbox/client/model/FileInfoTest.java
+++ b/libs/toolbox-api-client-java/src/test/java/io/daytona/toolbox/client/model/FileInfoTest.java
@@ -94,6 +94,14 @@ public class FileInfoTest {
     }
 
     /**
+     * Test the property 'path'
+     */
+    @Test
+    public void pathTest() {
+        // TODO: test path
+    }
+
+    /**
      * Test the property 'permissions'
      */
     @Test

--- a/libs/toolbox-api-client-python-async/daytona_toolbox_api_client_async/api/file_system_api.py
+++ b/libs/toolbox-api-client-python-async/daytona_toolbox_api_client_async/api/file_system_api.py
@@ -15,7 +15,7 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictBool, StrictBytes, StrictStr
+from pydantic import Field, StrictBool, StrictBytes, StrictInt, StrictStr
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 from daytona_toolbox_api_client_async.models.file_info import FileInfo
@@ -1667,6 +1667,7 @@ class FileSystemApi:
     async def list_files(
         self,
         path: Annotated[Optional[StrictStr], Field(description="Directory path to list (defaults to working directory)")] = None,
+        depth: Annotated[Optional[StrictInt], Field(description="How many levels deep to list (default: 1, must be >= 1)")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1682,10 +1683,12 @@ class FileSystemApi:
     ) -> List[FileInfo]:
         """List files and directories
 
-        List files and directories in the specified path
+        List files and directories in the specified path. Use the optional depth parameter to list recursively: depth=1 (default) lists the directory's entries, depth=2 also includes their children, and so on.
 
         :param path: Directory path to list (defaults to working directory)
         :type path: str
+        :param depth: How many levels deep to list (default: 1, must be >= 1)
+        :type depth: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1710,6 +1713,7 @@ class FileSystemApi:
 
         _param = self._list_files_serialize(
             path=path,
+            depth=depth,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1734,6 +1738,7 @@ class FileSystemApi:
     async def list_files_with_http_info(
         self,
         path: Annotated[Optional[StrictStr], Field(description="Directory path to list (defaults to working directory)")] = None,
+        depth: Annotated[Optional[StrictInt], Field(description="How many levels deep to list (default: 1, must be >= 1)")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1749,10 +1754,12 @@ class FileSystemApi:
     ) -> ApiResponse[List[FileInfo]]:
         """List files and directories
 
-        List files and directories in the specified path
+        List files and directories in the specified path. Use the optional depth parameter to list recursively: depth=1 (default) lists the directory's entries, depth=2 also includes their children, and so on.
 
         :param path: Directory path to list (defaults to working directory)
         :type path: str
+        :param depth: How many levels deep to list (default: 1, must be >= 1)
+        :type depth: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1777,6 +1784,7 @@ class FileSystemApi:
 
         _param = self._list_files_serialize(
             path=path,
+            depth=depth,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1801,6 +1809,7 @@ class FileSystemApi:
     async def list_files_without_preload_content(
         self,
         path: Annotated[Optional[StrictStr], Field(description="Directory path to list (defaults to working directory)")] = None,
+        depth: Annotated[Optional[StrictInt], Field(description="How many levels deep to list (default: 1, must be >= 1)")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1816,10 +1825,12 @@ class FileSystemApi:
     ) -> RESTResponseType:
         """List files and directories
 
-        List files and directories in the specified path
+        List files and directories in the specified path. Use the optional depth parameter to list recursively: depth=1 (default) lists the directory's entries, depth=2 also includes their children, and so on.
 
         :param path: Directory path to list (defaults to working directory)
         :type path: str
+        :param depth: How many levels deep to list (default: 1, must be >= 1)
+        :type depth: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1844,6 +1855,7 @@ class FileSystemApi:
 
         _param = self._list_files_serialize(
             path=path,
+            depth=depth,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1863,6 +1875,7 @@ class FileSystemApi:
     def _list_files_serialize(
         self,
         path,
+        depth,
         _request_auth,
         _content_type,
         _headers,
@@ -1888,6 +1901,10 @@ class FileSystemApi:
         if path is not None:
             
             _query_params.append(('path', path))
+            
+        if depth is not None:
+            
+            _query_params.append(('depth', depth))
             
         # process the header parameters
         # process the form parameters

--- a/libs/toolbox-api-client-python-async/daytona_toolbox_api_client_async/models/file_info.py
+++ b/libs/toolbox-api-client-python-async/daytona_toolbox_api_client_async/models/file_info.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -36,10 +36,11 @@ class FileInfo(BaseModel):
     modified_at: StrictStr = Field(serialization_alias="modifiedAt")
     name: StrictStr
     owner: StrictStr
+    path: Optional[StrictStr] = Field(default=None, description="Full path of the entry")
     permissions: StrictStr
     size: StrictInt
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["group", "isDir", "modTime", "mode", "modifiedAt", "name", "owner", "permissions", "size"]
+    __properties: ClassVar[List[str]] = ["group", "isDir", "modTime", "mode", "modifiedAt", "name", "owner", "path", "permissions", "size"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -105,6 +106,7 @@ class FileInfo(BaseModel):
             "modified_at": obj.get("modifiedAt"),
             "name": obj.get("name"),
             "owner": obj.get("owner"),
+            "path": obj.get("path"),
             "permissions": obj.get("permissions"),
             "size": obj.get("size")
         })

--- a/libs/toolbox-api-client-python/daytona_toolbox_api_client/api/file_system_api.py
+++ b/libs/toolbox-api-client-python/daytona_toolbox_api_client/api/file_system_api.py
@@ -15,7 +15,7 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictBool, StrictBytes, StrictStr
+from pydantic import Field, StrictBool, StrictBytes, StrictInt, StrictStr
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 from daytona_toolbox_api_client.models.file_info import FileInfo
@@ -1667,6 +1667,7 @@ class FileSystemApi:
     def list_files(
         self,
         path: Annotated[Optional[StrictStr], Field(description="Directory path to list (defaults to working directory)")] = None,
+        depth: Annotated[Optional[StrictInt], Field(description="How many levels deep to list (default: 1, must be >= 1)")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1682,10 +1683,12 @@ class FileSystemApi:
     ) -> List[FileInfo]:
         """List files and directories
 
-        List files and directories in the specified path
+        List files and directories in the specified path. Use the optional depth parameter to list recursively: depth=1 (default) lists the directory's entries, depth=2 also includes their children, and so on.
 
         :param path: Directory path to list (defaults to working directory)
         :type path: str
+        :param depth: How many levels deep to list (default: 1, must be >= 1)
+        :type depth: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1710,6 +1713,7 @@ class FileSystemApi:
 
         _param = self._list_files_serialize(
             path=path,
+            depth=depth,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1734,6 +1738,7 @@ class FileSystemApi:
     def list_files_with_http_info(
         self,
         path: Annotated[Optional[StrictStr], Field(description="Directory path to list (defaults to working directory)")] = None,
+        depth: Annotated[Optional[StrictInt], Field(description="How many levels deep to list (default: 1, must be >= 1)")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1749,10 +1754,12 @@ class FileSystemApi:
     ) -> ApiResponse[List[FileInfo]]:
         """List files and directories
 
-        List files and directories in the specified path
+        List files and directories in the specified path. Use the optional depth parameter to list recursively: depth=1 (default) lists the directory's entries, depth=2 also includes their children, and so on.
 
         :param path: Directory path to list (defaults to working directory)
         :type path: str
+        :param depth: How many levels deep to list (default: 1, must be >= 1)
+        :type depth: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1777,6 +1784,7 @@ class FileSystemApi:
 
         _param = self._list_files_serialize(
             path=path,
+            depth=depth,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1801,6 +1809,7 @@ class FileSystemApi:
     def list_files_without_preload_content(
         self,
         path: Annotated[Optional[StrictStr], Field(description="Directory path to list (defaults to working directory)")] = None,
+        depth: Annotated[Optional[StrictInt], Field(description="How many levels deep to list (default: 1, must be >= 1)")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1816,10 +1825,12 @@ class FileSystemApi:
     ) -> RESTResponseType:
         """List files and directories
 
-        List files and directories in the specified path
+        List files and directories in the specified path. Use the optional depth parameter to list recursively: depth=1 (default) lists the directory's entries, depth=2 also includes their children, and so on.
 
         :param path: Directory path to list (defaults to working directory)
         :type path: str
+        :param depth: How many levels deep to list (default: 1, must be >= 1)
+        :type depth: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1844,6 +1855,7 @@ class FileSystemApi:
 
         _param = self._list_files_serialize(
             path=path,
+            depth=depth,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1863,6 +1875,7 @@ class FileSystemApi:
     def _list_files_serialize(
         self,
         path,
+        depth,
         _request_auth,
         _content_type,
         _headers,
@@ -1888,6 +1901,10 @@ class FileSystemApi:
         if path is not None:
             
             _query_params.append(('path', path))
+            
+        if depth is not None:
+            
+            _query_params.append(('depth', depth))
             
         # process the header parameters
         # process the form parameters

--- a/libs/toolbox-api-client-python/daytona_toolbox_api_client/models/file_info.py
+++ b/libs/toolbox-api-client-python/daytona_toolbox_api_client/models/file_info.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -36,10 +36,11 @@ class FileInfo(BaseModel):
     modified_at: StrictStr = Field(serialization_alias="modifiedAt")
     name: StrictStr
     owner: StrictStr
+    path: Optional[StrictStr] = Field(default=None, description="Full path of the entry")
     permissions: StrictStr
     size: StrictInt
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["group", "isDir", "modTime", "mode", "modifiedAt", "name", "owner", "permissions", "size"]
+    __properties: ClassVar[List[str]] = ["group", "isDir", "modTime", "mode", "modifiedAt", "name", "owner", "path", "permissions", "size"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -105,6 +106,7 @@ class FileInfo(BaseModel):
             "modified_at": obj.get("modifiedAt"),
             "name": obj.get("name"),
             "owner": obj.get("owner"),
+            "path": obj.get("path"),
             "permissions": obj.get("permissions"),
             "size": obj.get("size")
         })

--- a/libs/toolbox-api-client-ruby/lib/daytona_toolbox_api_client/api/file_system_api.rb
+++ b/libs/toolbox-api-client-ruby/lib/daytona_toolbox_api_client/api/file_system_api.rb
@@ -421,9 +421,10 @@ module DaytonaToolboxApiClient
     end
 
     # List files and directories
-    # List files and directories in the specified path
+    # List files and directories in the specified path. Use the optional depth parameter to list recursively: depth=1 (default) lists the directory's entries, depth=2 also includes their children, and so on.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :path Directory path to list (defaults to working directory)
+    # @option opts [Integer] :depth How many levels deep to list (default: 1, must be &gt;&#x3D; 1)
     # @return [Array<FileInfo>]
     def list_files(opts = {})
       data, _status_code, _headers = list_files_with_http_info(opts)
@@ -431,9 +432,10 @@ module DaytonaToolboxApiClient
     end
 
     # List files and directories
-    # List files and directories in the specified path
+    # List files and directories in the specified path. Use the optional depth parameter to list recursively: depth&#x3D;1 (default) lists the directory&#39;s entries, depth&#x3D;2 also includes their children, and so on.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :path Directory path to list (defaults to working directory)
+    # @option opts [Integer] :depth How many levels deep to list (default: 1, must be &gt;&#x3D; 1)
     # @return [Array<(Array<FileInfo>, Integer, Hash)>] Array<FileInfo> data, response status code and response headers
     def list_files_with_http_info(opts = {})
       if @api_client.config.debugging
@@ -445,6 +447,7 @@ module DaytonaToolboxApiClient
       # query parameters
       query_params = opts[:query_params] || {}
       query_params[:'path'] = opts[:'path'] if !opts[:'path'].nil?
+      query_params[:'depth'] = opts[:'depth'] if !opts[:'depth'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/libs/toolbox-api-client-ruby/lib/daytona_toolbox_api_client/models/file_info.rb
+++ b/libs/toolbox-api-client-ruby/lib/daytona_toolbox_api_client/models/file_info.rb
@@ -30,6 +30,9 @@ module DaytonaToolboxApiClient
 
     attr_accessor :owner
 
+    # Full path of the entry
+    attr_accessor :path
+
     attr_accessor :permissions
 
     attr_accessor :size
@@ -44,6 +47,7 @@ module DaytonaToolboxApiClient
         :'modified_at' => :'modifiedAt',
         :'name' => :'name',
         :'owner' => :'owner',
+        :'path' => :'path',
         :'permissions' => :'permissions',
         :'size' => :'size'
       }
@@ -69,6 +73,7 @@ module DaytonaToolboxApiClient
         :'modified_at' => :'String',
         :'name' => :'String',
         :'owner' => :'String',
+        :'path' => :'String',
         :'permissions' => :'String',
         :'size' => :'Integer'
       }
@@ -136,6 +141,10 @@ module DaytonaToolboxApiClient
         self.owner = attributes[:'owner']
       else
         self.owner = nil
+      end
+
+      if attributes.key?(:'path')
+        self.path = attributes[:'path']
       end
 
       if attributes.key?(:'permissions')
@@ -313,6 +322,7 @@ module DaytonaToolboxApiClient
           modified_at == o.modified_at &&
           name == o.name &&
           owner == o.owner &&
+          path == o.path &&
           permissions == o.permissions &&
           size == o.size
     end
@@ -326,7 +336,7 @@ module DaytonaToolboxApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [group, is_dir, mod_time, mode, modified_at, name, owner, permissions, size].hash
+      [group, is_dir, mod_time, mode, modified_at, name, owner, path, permissions, size].hash
     end
 
     # Builds the object from hash

--- a/libs/toolbox-api-client/src/api/file-system-api.ts
+++ b/libs/toolbox-api-client/src/api/file-system-api.ts
@@ -276,13 +276,14 @@ export const FileSystemApiAxiosParamCreator = function (configuration?: Configur
             };
         },
         /**
-         * List files and directories in the specified path
+         * List files and directories in the specified path. Use the optional depth parameter to list recursively: depth=1 (default) lists the directory\'s entries, depth=2 also includes their children, and so on.
          * @summary List files and directories
          * @param {string} [path] Directory path to list (defaults to working directory)
+         * @param {number} [depth] How many levels deep to list (default: 1, must be &gt;&#x3D; 1)
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listFiles: async (path?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        listFiles: async (path?: string, depth?: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/files`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -297,6 +298,10 @@ export const FileSystemApiAxiosParamCreator = function (configuration?: Configur
 
             if (path !== undefined) {
                 localVarQueryParameter['path'] = path;
+            }
+
+            if (depth !== undefined) {
+                localVarQueryParameter['depth'] = depth;
             }
 
             localVarHeaderParameter['Accept'] = 'application/json';
@@ -650,14 +655,15 @@ export const FileSystemApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * List files and directories in the specified path
+         * List files and directories in the specified path. Use the optional depth parameter to list recursively: depth=1 (default) lists the directory\'s entries, depth=2 also includes their children, and so on.
          * @summary List files and directories
          * @param {string} [path] Directory path to list (defaults to working directory)
+         * @param {number} [depth] How many levels deep to list (default: 1, must be &gt;&#x3D; 1)
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async listFiles(path?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<FileInfo>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.listFiles(path, options);
+        async listFiles(path?: string, depth?: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<FileInfo>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listFiles(path, depth, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['FileSystemApi.listFiles']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
@@ -818,14 +824,15 @@ export const FileSystemApiFactory = function (configuration?: Configuration, bas
             return localVarFp.getFileInfo(path, options).then((request) => request(axios, basePath));
         },
         /**
-         * List files and directories in the specified path
+         * List files and directories in the specified path. Use the optional depth parameter to list recursively: depth=1 (default) lists the directory\'s entries, depth=2 also includes their children, and so on.
          * @summary List files and directories
          * @param {string} [path] Directory path to list (defaults to working directory)
+         * @param {number} [depth] How many levels deep to list (default: 1, must be &gt;&#x3D; 1)
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listFiles(path?: string, options?: RawAxiosRequestConfig): AxiosPromise<Array<FileInfo>> {
-            return localVarFp.listFiles(path, options).then((request) => request(axios, basePath));
+        listFiles(path?: string, depth?: number, options?: RawAxiosRequestConfig): AxiosPromise<Array<FileInfo>> {
+            return localVarFp.listFiles(path, depth, options).then((request) => request(axios, basePath));
         },
         /**
          * Move or rename a file or directory from source to destination
@@ -969,14 +976,15 @@ export class FileSystemApi extends BaseAPI {
     }
 
     /**
-     * List files and directories in the specified path
+     * List files and directories in the specified path. Use the optional depth parameter to list recursively: depth=1 (default) lists the directory\'s entries, depth=2 also includes their children, and so on.
      * @summary List files and directories
      * @param {string} [path] Directory path to list (defaults to working directory)
+     * @param {number} [depth] How many levels deep to list (default: 1, must be &gt;&#x3D; 1)
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public listFiles(path?: string, options?: RawAxiosRequestConfig) {
-        return FileSystemApiFp(this.configuration).listFiles(path, options).then((request) => request(this.axios, this.basePath));
+    public listFiles(path?: string, depth?: number, options?: RawAxiosRequestConfig) {
+        return FileSystemApiFp(this.configuration).listFiles(path, depth, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/libs/toolbox-api-client/src/models/file-info.ts
+++ b/libs/toolbox-api-client/src/models/file-info.ts
@@ -25,6 +25,10 @@ export interface FileInfo {
     'modifiedAt': string;
     'name': string;
     'owner': string;
+    /**
+     * Full path of the entry
+     */
+    'path'?: string;
     'permissions': string;
     'size': number;
 }


### PR DESCRIPTION
### Summary

Adds an optional `depth` parameter to `GET /files` (and all SDK `listFiles` / `list_files` wrappers) for recursive directory listing. When omitted, behavior is identical to the current shallow listing.

### Changes

**Daemon** (`apps/daemon/pkg/toolbox/fs/`)
- New `depth` query parameter on `GET /files` (integer, default 1, must be ≥ 1)
- `depth=1` preserves the original `os.ReadDir` code path (no behavioral change for default case)
- `depth > 1` uses `filepath.WalkDir` with depth-bounded descent, returning a flat list
- New `path` field on `FileInfo` (full entry path, `omitempty` for backward compat)
- Unreadable subtrees are skipped (partial results), symlinks are listed but not followed
- Uses `ClientRejectsUnknownResponseFields` to omit the new `path` field for older Go SDK clients that reject unknown JSON fields

**SDKs** (all 5 languages)
- `listFiles(path, depth?)` / `list_files(path, depth=None)` with client-side validation (`depth must be at least 1`)
- TypeScript: `listFiles(path, { depth?: number })`
- Python: `list_files(path, depth: int | None = None)` (sync + async)
- Go: `ListFiles(ctx, path, options.WithDepth(n))`
- Ruby: `list_files(path, depth: nil)`
- Java: `listFiles(path)` + `listFiles(path, Integer depth)` overload
- Go SDK: `FileInfo.Path` field added to types + mapped from generated client

**Generated clients** — all 6 toolbox API clients regenerated with the new `depth` param and `path` model field.

### Behavior

| Request | Result |
|---|---|
| `GET /files?path=/tmp/x` | Shallow listing (unchanged from before) |
| `GET /files?path=/tmp/x&depth=1` | Identical to above |
| `GET /files?path=/tmp/x&depth=3` | Flat list including entries up to 3 levels deep |
| `GET /files?path=/tmp/x&depth=0` | 400 Bad Request |
| Nonexistent path | 404 |
| Unreadable subdirectory mid-walk | Skipped, rest of tree returned (200) |
| Symlink to directory | Listed once, never descended into (no cycle risk) |
| Dangling symlink | Omitted (stat fails) |

### Backward Compatibility

- Default behavior unchanged — `depth` is optional, defaults to 1
- `path` field uses `omitempty` — absent when empty, old clients ignore it
- Daemon uses `ClientRejectsUnknownResponseFields` to strip `path` for Go SDK clients below v0.188.0 (whose generated client rejects unknown JSON fields)
- Verified against published 0.185.0 SDKs (Python, TypeScript, Ruby, Go) on preprod

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds depth-aware recursive file listing to `GET /files` and all SDK `listFiles` methods. Default stays shallow; responses now include a `path` field with the full entry path.

- **New Features**
  - API: new `depth` query (default 1, must be ≥1). `depth=1` uses the original shallow path; `>1` returns a flat list up to N levels. Symlinks are listed but not followed; unreadable subtrees are skipped; invalid `depth` returns 400. Recursive listing handles a symlinked root by resolving it for walking while reporting `path` under the requested root.
  - Response: `FileInfo.path` added (full path). Older Go SDKs have this field stripped automatically for compatibility.
  - SDKs:
    - TypeScript: `listFiles(path, { depth?: number })` with client-side validation.
    - Python: `list_files(path, depth: int | None = None)` (sync/async) with validation.
    - Go: `ListFiles(ctx, path, options.WithDepth(n))`.
    - Ruby: `list_files(path, depth: nil)` with validation.
    - Java: `listFiles(path)` and `listFiles(path, Integer depth)` with validation.
  - Regenerated toolbox API clients (Go/TS/Java/Python/Ruby) and updated docs across all languages.

<sup>Written for commit 2ce4ac6edef426649dd72aabaffe04c956f8a49f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

