### PR TITLE
fix(api): backfill org super admin role with missing resource permissions

### DIFF
--- a/apps/api/src/migrations/pre-deploy/1781267138889-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1781267138889-migration.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+import { GlobalOrganizationRolesIds } from '../../organization/constants/global-organization-roles.constant'
+import { OrganizationResourcePermission } from '../../organization/enums/organization-resource-permission.enum'
+
+export class Migration1781267138889 implements MigrationInterface {
+  name = 'Migration1781267138889'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE "organization_role"
+      SET "permissions" = ARRAY[
+        '${OrganizationResourcePermission.WRITE_REGISTRIES}',
+        '${OrganizationResourcePermission.DELETE_REGISTRIES}',
+        '${OrganizationResourcePermission.WRITE_SNAPSHOTS}',
+        '${OrganizationResourcePermission.DELETE_SNAPSHOTS}',
+        '${OrganizationResourcePermission.WRITE_SANDBOXES}',
+        '${OrganizationResourcePermission.DELETE_SANDBOXES}',
+        '${OrganizationResourcePermission.READ_VOLUMES}',
+        '${OrganizationResourcePermission.WRITE_VOLUMES}',
+        '${OrganizationResourcePermission.DELETE_VOLUMES}',
+        '${OrganizationResourcePermission.WRITE_REGIONS}',
+        '${OrganizationResourcePermission.DELETE_REGIONS}',
+        '${OrganizationResourcePermission.READ_RUNNERS}',
+        '${OrganizationResourcePermission.WRITE_RUNNERS}',
+        '${OrganizationResourcePermission.DELETE_RUNNERS}',
+        '${OrganizationResourcePermission.READ_AUDIT_LOGS}'
+      ]::organization_role_permissions_enum[]
+      WHERE "id" = '${GlobalOrganizationRolesIds.SUPER_ADMIN}'
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE "organization_role"
+      SET "permissions" = ARRAY[
+        '${OrganizationResourcePermission.WRITE_REGISTRIES}',
+        '${OrganizationResourcePermission.DELETE_REGISTRIES}',
+        '${OrganizationResourcePermission.WRITE_SNAPSHOTS}',
+        '${OrganizationResourcePermission.DELETE_SNAPSHOTS}',
+        '${OrganizationResourcePermission.WRITE_SANDBOXES}',
+        '${OrganizationResourcePermission.DELETE_SANDBOXES}'
+      ]::organization_role_permissions_enum[]
+      WHERE "id" = '${GlobalOrganizationRolesIds.SUPER_ADMIN}'
+    `)
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Backfills missing permissions for the organization Super Admin role via a pre-deploy migration. Restores expected full access, including volumes, regions, runners, and audit logs.

- **Bug Fixes**
  - Updates `organization_role.permissions` for `SUPER_ADMIN` to include volumes (read/write/delete), regions (write/delete), runners (read/write/delete), and audit logs (read).
  - Provides a down migration to revert to the prior minimal set (registries, snapshots, sandboxes).

<sup>Written for commit b0bf49479d82499ab04e9552d1cd26aa15c8497a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

