### PR TITLE
fix(proxy): return upstream conns to pool in retryTransport

### DIFF
--- a/libs/common-go/pkg/proxy/retry_transport.go
+++ b/libs/common-go/pkg/proxy/retry_transport.go
@@ -35,21 +35,55 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	if canReplay(req) && isMultipart(resp) {
-		var peek [1]byte
-		n, readErr := resp.Body.Read(peek[:])
-		if n == 0 && readErr != nil {
+		// Buffer up to maxRetryBodySize+1 instead of peek-reading the live
+		// body: peeking a single byte and re-wrapping leaves net/http's body
+		// half-read, so the persistConn is never drained and returned to the
+		// idle pool. Reading one byte past the cap lets us tell whether the
+		// whole body fits in the buffer.
+		buf, readErr := io.ReadAll(io.LimitReader(resp.Body, maxRetryBodySize+1))
+		if readErr != nil {
+			// The body broke mid-read. Serving buf as-is would hand the client
+			// a truncated body with a clean EOF, so either replay (nothing read
+			// yet, stale conn) or surface the prefix followed by the error.
+			resp.Body.Close()
+			if len(buf) == 0 && isStaleConnError(readErr) {
+				slog.Warn("proxy: retrying after body read error",
+					"method", req.Method, "path", req.URL.Path, "error", readErr)
+				rewindBody(req)
+				return t.base.RoundTrip(req)
+			}
+			resp.Body = io.NopCloser(io.MultiReader(bytes.NewReader(buf), errReader{readErr}))
+			return resp, nil
+		}
+		if len(buf) == 0 {
+			// Empty multipart body (stale conn returned headers only): drain
+			// and close so the connection returns to the pool, then replay.
+			drainClose(resp.Body)
 			slog.Warn("proxy: retrying after empty multipart body",
 				"method", req.Method, "path", req.URL.Path)
-			resp.Body.Close()
 			rewindBody(req)
 			return t.base.RoundTrip(req)
 		}
-		if n > 0 {
-			resp.Body = &prefixedBody{prefix: peek[:n], rest: resp.Body}
+		if len(buf) <= maxRetryBodySize {
+			// Whole body fit in the buffer, so the upstream body is at EOF;
+			// release its connection to the pool and serve from memory.
+			drainClose(resp.Body)
+			resp.Body = io.NopCloser(bytes.NewReader(buf))
+		} else {
+			// Body exceeds the buffer: non-empty for certain, so stream the
+			// remainder. prefixedBody.Close drains the rest on completion.
+			resp.Body = &prefixedBody{prefix: buf, rest: resp.Body}
 		}
 	}
 
 	return resp, nil
+}
+
+// drainClose reads any unread bytes from body and closes it, so the underlying
+// connection is returned to the idle pool instead of being discarded.
+func drainClose(body io.ReadCloser) {
+	io.Copy(io.Discard, body)
+	body.Close()
 }
 
 // bufferSmallBody captures small request bodies for replay; large uploads are skipped.
@@ -95,6 +129,12 @@ func isMultipart(resp *http.Response) bool {
 	return strings.HasPrefix(resp.Header.Get("Content-Type"), "multipart/")
 }
 
+// errReader yields err on every read, so a buffered prefix can be followed by
+// the original mid-body failure instead of a clean EOF.
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }
+
 // prefixedBody prepends already-read bytes back onto a ReadCloser.
 type prefixedBody struct {
 	prefix []byte
@@ -111,4 +151,9 @@ func (r *prefixedBody) Read(p []byte) (int, error) {
 	return r.rest.Read(p)
 }
 
-func (r *prefixedBody) Close() error { return r.rest.Close() }
+// Close drains any unread remainder before closing so the underlying
+// connection can return to the idle pool rather than being discarded.
+func (r *prefixedBody) Close() error {
+	io.Copy(io.Discard, r.rest)
+	return r.rest.Close()
+}

--- a/libs/common-go/pkg/proxy/retry_transport_test.go
+++ b/libs/common-go/pkg/proxy/retry_transport_test.go
@@ -1,0 +1,161 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// replayableReq builds a request whose GetBody is populated (as net/http does
+// for in-memory bodies), so canReplay reports true and the multipart-retry
+// path is exercised.
+func replayableReq(t *testing.T, method, url, body string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	return req
+}
+
+// TestRetryTransport_MultipartReturnsConnToPool verifies that forwarding a
+// small multipart response fully drains and releases the upstream connection,
+// so subsequent requests reuse it instead of dialing fresh — the regression
+// for the heap leak where each forwarded request orphaned its connection.
+func TestRetryTransport_MultipartReturnsConnToPool(t *testing.T) {
+	body := strings.Repeat("x", 1024)
+	var newConns int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "multipart/form-data; boundary=abc")
+		io.WriteString(w, body)
+	}))
+	srv.Config.ConnState = func(_ net.Conn, s http.ConnState) {
+		if s == http.StateNew {
+			atomic.AddInt64(&newConns, 1)
+		}
+	}
+	defer srv.Close()
+
+	rt := &retryTransport{base: &http.Transport{MaxIdleConns: 10, MaxIdleConnsPerHost: 10}}
+	for i := 0; i < 5; i++ {
+		resp, err := rt.RoundTrip(replayableReq(t, http.MethodPost, srv.URL, "hello"))
+		if err != nil {
+			t.Fatalf("RoundTrip: %v", err)
+		}
+		got, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if string(got) != body {
+			t.Fatalf("body mismatch: got %d bytes, want %d", len(got), len(body))
+		}
+	}
+	if c := atomic.LoadInt64(&newConns); c != 1 {
+		t.Errorf("expected connection reuse (1 new conn), got %d", c)
+	}
+}
+
+// TestRetryTransport_LargeMultipartDrainsOnClose verifies the over-cap
+// streaming path: a partial read followed by Close must drain the remainder so
+// the connection still returns to the pool. Before the fix, prefixedBody.Close
+// closed without draining, discarding the connection on every request.
+func TestRetryTransport_LargeMultipartDrainsOnClose(t *testing.T) {
+	big := strings.Repeat("y", maxRetryBodySize*2)
+	var newConns int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "multipart/mixed; boundary=z")
+		io.WriteString(w, big)
+	}))
+	srv.Config.ConnState = func(_ net.Conn, s http.ConnState) {
+		if s == http.StateNew {
+			atomic.AddInt64(&newConns, 1)
+		}
+	}
+	defer srv.Close()
+
+	rt := &retryTransport{base: &http.Transport{MaxIdleConns: 10, MaxIdleConnsPerHost: 10}}
+	for i := 0; i < 3; i++ {
+		resp, err := rt.RoundTrip(replayableReq(t, http.MethodPost, srv.URL, "x"))
+		if err != nil {
+			t.Fatalf("RoundTrip: %v", err)
+		}
+		var p [16]byte
+		resp.Body.Read(p[:]) // partial read only
+		resp.Body.Close()    // Close must drain the rest
+	}
+	if c := atomic.LoadInt64(&newConns); c != 1 {
+		t.Errorf("expected drain-on-close to reuse conn (1 new conn), got %d", c)
+	}
+}
+
+// TestRetryTransport_TruncatedMultipartSurfacesError verifies that a body cut
+// off mid-read is not silently served from the buffer as a complete response:
+// the client must receive the buffered prefix followed by a read error, not a
+// clean EOF on truncated data.
+func TestRetryTransport_TruncatedMultipartSurfacesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(io.Discard, r.Body)
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			t.Errorf("Hijack: %v", err)
+			return
+		}
+		// Promise 100 bytes but deliver 7, then drop the connection.
+		io.WriteString(conn, "HTTP/1.1 200 OK\r\n"+
+			"Content-Type: multipart/form-data; boundary=abc\r\n"+
+			"Content-Length: 100\r\n\r\npartial")
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	rt := &retryTransport{base: &http.Transport{MaxIdleConns: 10, MaxIdleConnsPerHost: 10}}
+	resp, err := rt.RoundTrip(replayableReq(t, http.MethodPost, srv.URL, "x"))
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	got, readErr := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if readErr == nil {
+		t.Fatalf("expected read error for truncated body, got clean EOF with %d bytes", len(got))
+	}
+	if string(got) != "partial" {
+		t.Errorf("buffered prefix: got %q, want %q", got, "partial")
+	}
+}
+
+// TestRetryTransport_EmptyMultipartRetries verifies that an empty multipart
+// body (stale conn returned headers only) triggers a single replay and the
+// caller receives the second, non-empty response.
+func TestRetryTransport_EmptyMultipartRetries(t *testing.T) {
+	var calls int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "multipart/form-data; boundary=abc")
+		if atomic.AddInt64(&calls, 1) == 1 {
+			return // empty body on first attempt
+		}
+		io.WriteString(w, "second-try-body")
+	}))
+	defer srv.Close()
+
+	rt := &retryTransport{base: &http.Transport{MaxIdleConns: 10, MaxIdleConnsPerHost: 10}}
+	resp, err := rt.RoundTrip(replayableReq(t, http.MethodPost, srv.URL, "x"))
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if string(got) != "second-try-body" {
+		t.Fatalf("got %q, want %q", got, "second-try-body")
+	}
+	if c := atomic.LoadInt64(&calls); c != 2 {
+		t.Fatalf("expected 2 upstream calls (retry), got %d", c)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a connection leak in proxy `retryTransport` for multipart responses by draining/closing upstream bodies so `net/http` returns connections to the idle pool. Prevents heap growth and OOM under load, and correctly handles retries and truncated bodies.

- **Bug Fixes**
  - Buffer multipart bodies (up to `maxRetryBodySize+1`) instead of peeking; empty bodies trigger a single retry; small bodies are served from memory after releasing the upstream connection.
  - Always return upstream connections to the pool by draining/closing (`drainClose`, draining in `prefixedBody.Close`) including the streamed over-cap path.
  - Preserve failure semantics: on mid-body read errors, send the buffered prefix then the original error; only retry when nothing was read and the connection is stale. Tests cover small/large connection reuse, empty-body retry, and truncated-body error propagation.

<sup>Written for commit 125688eb671898f74125f79a3f36a68acab57c39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

