### PR TITLE
feat(api): immediately create snapshot entry for snapshotting sandbox

### DIFF
--- a/apps/api/src/migrations/pre-deploy/1781262090000-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1781262090000-migration.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1781262090000 implements MigrationInterface {
+  name = 'Migration1781262090000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TYPE "public"."snapshot_state_enum" ADD VALUE IF NOT EXISTS 'snapshotting'`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Move any in-flight snapshot-from-sandbox entries to a state the old enum knows about
+    await queryRunner.query(`UPDATE "snapshot" SET "state" = 'error' WHERE "state" = 'snapshotting'`)
+
+    await queryRunner.query(`ALTER TYPE "public"."snapshot_state_enum" RENAME TO "snapshot_state_enum_old"`)
+    await queryRunner.query(
+      `CREATE TYPE "public"."snapshot_state_enum" AS ENUM('pending', 'pulling', 'active', 'inactive', 'building', 'error', 'build_failed', 'removing')`,
+    )
+    await queryRunner.query(`ALTER TABLE "snapshot" ALTER COLUMN "state" DROP DEFAULT`)
+    await queryRunner.query(
+      `ALTER TABLE "snapshot" ALTER COLUMN "state" TYPE "public"."snapshot_state_enum" USING "state"::"text"::"public"."snapshot_state_enum"`,
+    )
+    await queryRunner.query(`ALTER TABLE "snapshot" ALTER COLUMN "state" SET DEFAULT 'pending'`)
+    await queryRunner.query(`DROP TYPE "public"."snapshot_state_enum_old"`)
+  }
+}

--- a/apps/api/src/organization/constants/snapshot-states-consuming-resources.constant.ts
+++ b/apps/api/src/organization/constants/snapshot-states-consuming-resources.constant.ts
@@ -9,5 +9,6 @@ export const SNAPSHOT_STATES_CONSUMING_RESOURCES: SnapshotState[] = [
   SnapshotState.BUILDING,
   SnapshotState.PENDING,
   SnapshotState.PULLING,
+  SnapshotState.SNAPSHOTTING,
   SnapshotState.ACTIVE,
 ]

--- a/apps/api/src/sandbox/enums/snapshot-state.enum.ts
+++ b/apps/api/src/sandbox/enums/snapshot-state.enum.ts
@@ -7,6 +7,8 @@ export enum SnapshotState {
   BUILDING = 'building',
   PENDING = 'pending',
   PULLING = 'pulling',
+  //  snapshot is being created from a sandbox (sandbox is in the SNAPSHOTTING state)
+  SNAPSHOTTING = 'snapshotting',
   ACTIVE = 'active',
   INACTIVE = 'inactive',
   ERROR = 'error',

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -889,6 +889,9 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
         case SnapshotState.BUILDING:
           syncState = await this.handleCheckInitialRunnerSnapshot(snapshot)
           break
+        case SnapshotState.SNAPSHOTTING:
+          syncState = await this.handleSnapshotStateSnapshotting(snapshot)
+          break
         case SnapshotState.REMOVING:
           syncState = await this.handleSnapshotStateRemoving(snapshot)
           break
@@ -947,6 +950,24 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
         this.logger.warn(errorMessage)
       })
     }
+  }
+
+  /**
+   * Snapshot-from-sandbox entries are driven to ACTIVE/ERROR by the runner
+   * job state handler (v2) or by the API background driver (v0), not by this
+   * manager. This handler is only a backstop that errors out entries left
+   * behind by an API crash or a lost runner job.
+   */
+  async handleSnapshotStateSnapshotting(snapshot: Snapshot): Promise<SyncState> {
+    // Slightly longer than the SNAPSHOT_SANDBOX job timeout (120 minutes) so
+    // the job state handler always gets the first chance to resolve the entry
+    const timeoutMinutes = 180
+    const timeoutMs = timeoutMinutes * 60 * 1000
+    if (Date.now() - snapshot.updatedAt.getTime() > timeoutMs) {
+      await this.updateSnapshotState(snapshot, SnapshotState.ERROR, 'Timeout while creating snapshot from sandbox')
+    }
+
+    return DONT_SYNC_AGAIN
   }
 
   async handleSnapshotStateRemoving(snapshot: Snapshot): Promise<SyncState> {

--- a/apps/api/src/sandbox/repositories/snapshot.repository.ts
+++ b/apps/api/src/sandbox/repositories/snapshot.repository.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { DataSource } from 'typeorm'
+import { DataSource, FindOptionsWhere } from 'typeorm'
 import { Snapshot } from '../entities/snapshot.entity'
 import { SnapshotRegion } from '../entities/snapshot-region.entity'
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
@@ -84,6 +84,54 @@ export class SnapshotRepository extends BaseRepository<Snapshot> {
         throw new SnapshotConflictError()
       }
       snapshot.updatedAt = new Date()
+    })
+
+    await this.emitUpdateEvents(snapshot, previousSnapshot)
+
+    return snapshot
+  }
+
+  /**
+   * Updates a snapshot only if it still matches the given condition,
+   * locking the row for the duration of the transaction so concurrent
+   * state transitions can't overwrite each other.
+   *
+   * @param id - The ID of the snapshot to update.
+   * @param params.updateData - The partial data to update.
+   * @param params.whereCondition - The condition the snapshot must still satisfy for the update to be applied.
+   *
+   * @returns The updated snapshot.
+   * @throws {SnapshotConflictError} If the snapshot doesn't satisfy the condition.
+   */
+  async updateWhere(
+    id: string,
+    params: { updateData: Partial<Snapshot>; whereCondition: FindOptionsWhere<Snapshot> },
+  ): Promise<Snapshot> {
+    const { updateData, whereCondition } = params
+
+    let previousSnapshot: Snapshot
+
+    const snapshot = await this.dataSource.transaction(async (entityManager) => {
+      // buildInfo is an eager relation; skip it as FOR UPDATE can't be applied
+      // to the nullable side of an outer join
+      const existing = await entityManager.findOne(Snapshot, {
+        where: { ...whereCondition, id },
+        lock: { mode: 'pessimistic_write' },
+        relations: [],
+        loadEagerRelations: false,
+      })
+
+      if (!existing) {
+        throw new SnapshotConflictError()
+      }
+
+      previousSnapshot = { ...existing }
+      Object.assign(existing, updateData)
+
+      await entityManager.update(Snapshot, id, updateData)
+      existing.updatedAt = new Date()
+
+      return existing
     })
 
     await this.emitUpdateEvents(snapshot, previousSnapshot)

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -27,7 +27,7 @@ import { ResourceType } from '../enums/resource-type.enum'
 import { getStateChangeLockKey } from '../utils/lock-key.util'
 import { SandboxEvents } from '../constants/sandbox-events.constants'
 import { SandboxStartedEvent } from '../events/sandbox-started.event'
-import { persistSnapshotFromSandbox } from '../utils/persist-snapshot-from-sandbox.util'
+import { completeSnapshotFromSandbox, failSnapshotFromSandbox } from '../utils/persist-snapshot-from-sandbox.util'
 import { Runner } from '../entities/runner.entity'
 
 /**
@@ -802,78 +802,103 @@ export class JobStateHandlerService {
         entity: sandbox,
       })
 
-      if (job.status === JobStatus.COMPLETED) {
-        const payload = job.getPayload<{ name?: string; registry?: { url?: string; project?: string } }>()
+      const payload = job.getPayload<{ name?: string; registry?: { url?: string; project?: string } }>()
+      const snapshotName = payload?.name
+
+      if (!snapshotName) {
+        this.logger.error(`SNAPSHOT_SANDBOX job ${job.id} payload missing snapshot name`)
+        return
+      }
+
+      if (job.status === JobStatus.FAILED) {
+        try {
+          await failSnapshotFromSandbox(
+            {
+              snapshotRepository: this.snapshotRepository,
+              snapshotRunnerRepository: this.snapshotRunnerRepository,
+              eventEmitter: this.eventEmitter,
+            },
+            {
+              organizationId: sandbox.organizationId,
+              name: snapshotName,
+              errorReason: job.errorMessage || 'Failed to create snapshot from sandbox',
+            },
+          )
+        } catch (error) {
+          this.logger.error(`Failed to mark snapshot as errored for SNAPSHOT_SANDBOX job ${job.id}:`, error)
+        }
+      } else if (job.status === JobStatus.COMPLETED) {
         const metadata = job.getResultMetadata()
-        const snapshotName = payload?.name
         const hash =
           (typeof metadata?.hash === 'string' && metadata.hash) ||
           (typeof metadata?.Hash === 'string' && metadata.Hash) ||
           undefined
 
-        if (!snapshotName) {
-          this.logger.error(`SNAPSHOT_SANDBOX job ${job.id} payload missing snapshot name`)
-        } else {
-          // Prefer the ref the runner actually pushed. Otherwise reconstruct
-          // from `hash`, matching the runner-side canonical form
-          // (apps/runner/cmd/runner/config/config.go): registry-based VM /
-          // container snapshots use `<registry>/<project>/daytona-<hash>:daytona`,
-          // Windows VM snapshots have no registry and use bare `daytona-<hash>`.
-          const refFromRunner =
-            (typeof metadata?.ref === 'string' && metadata.ref) ||
-            (typeof metadata?.Ref === 'string' && metadata.Ref) ||
-            undefined
+        // Prefer the ref the runner actually pushed. Otherwise reconstruct
+        // from `hash`, matching the runner-side canonical form
+        // (apps/runner/cmd/runner/config/config.go): registry-based VM /
+        // container snapshots use `<registry>/<project>/daytona-<hash>:daytona`,
+        // Windows VM snapshots have no registry and use bare `daytona-<hash>`.
+        const refFromRunner =
+          (typeof metadata?.ref === 'string' && metadata.ref) ||
+          (typeof metadata?.Ref === 'string' && metadata.Ref) ||
+          undefined
 
-          let snapshotRef = refFromRunner
-          if (!snapshotRef && hash) {
-            const cleanHash = hash.replace(/^sha256:/, '')
-            if (payload?.registry?.url) {
-              const project = payload.registry.project || 'daytona'
-              snapshotRef = `${payload.registry.url}/${project}/daytona-${cleanHash}:daytona`
-            } else {
-              snapshotRef = `daytona-${cleanHash}`
-            }
+        let snapshotRef = refFromRunner
+        if (!snapshotRef && hash) {
+          const cleanHash = hash.replace(/^sha256:/, '')
+          if (payload?.registry?.url) {
+            const project = payload.registry.project || 'daytona'
+            snapshotRef = `${payload.registry.url}/${project}/daytona-${cleanHash}:daytona`
+          } else {
+            snapshotRef = `daytona-${cleanHash}`
           }
-          if (!snapshotRef) {
-            this.logger.error(
-              `SNAPSHOT_SANDBOX job ${job.id} returned neither ref nor hash; falling back to snapshot name`,
+        }
+        if (!snapshotRef) {
+          this.logger.error(
+            `SNAPSHOT_SANDBOX job ${job.id} returned neither ref nor hash; falling back to snapshot name`,
+          )
+          snapshotRef = snapshotName
+        }
+
+        const rawSnapshotSizeGB = metadata?.sizeGB ?? metadata?.size_gb
+        const snapshotSizeGB =
+          typeof rawSnapshotSizeGB === 'number' && Number.isFinite(rawSnapshotSizeGB)
+            ? rawSnapshotSizeGB
+            : typeof rawSnapshotSizeGB === 'string' && Number.isFinite(Number(rawSnapshotSizeGB))
+              ? Number(rawSnapshotSizeGB)
+              : undefined
+
+        try {
+          const completed = await completeSnapshotFromSandbox(
+            {
+              snapshotRepository: this.snapshotRepository,
+              snapshotRunnerRepository: this.snapshotRunnerRepository,
+              eventEmitter: this.eventEmitter,
+            },
+            {
+              organizationId: sandbox.organizationId,
+              name: snapshotName,
+              ref: snapshotRef,
+              runnerId: job.runnerId,
+              regionId: sandbox.region,
+              sandboxClass: sandbox.sandboxClass,
+              cpu: sandbox.cpu,
+              gpu: sandbox.gpu,
+              gpuType: sandbox.gpuType ?? null,
+              mem: sandbox.mem,
+              disk: sandbox.disk,
+              sizeGB: snapshotSizeGB,
+            },
+          )
+
+          if (!completed) {
+            this.logger.warn(
+              `Snapshot "${snapshotName}" for SNAPSHOT_SANDBOX job ${job.id} is no longer in the snapshotting state; skipping activation`,
             )
-            snapshotRef = snapshotName
           }
-
-          const rawSnapshotSizeGB = metadata?.sizeGB ?? metadata?.size_gb
-          const snapshotSizeGB =
-            typeof rawSnapshotSizeGB === 'number' && Number.isFinite(rawSnapshotSizeGB)
-              ? rawSnapshotSizeGB
-              : typeof rawSnapshotSizeGB === 'string' && Number.isFinite(Number(rawSnapshotSizeGB))
-                ? Number(rawSnapshotSizeGB)
-                : undefined
-
-          try {
-            await persistSnapshotFromSandbox(
-              {
-                snapshotRepository: this.snapshotRepository,
-                snapshotRunnerRepository: this.snapshotRunnerRepository,
-                eventEmitter: this.eventEmitter,
-              },
-              {
-                organizationId: sandbox.organizationId,
-                name: snapshotName,
-                ref: snapshotRef,
-                runnerId: job.runnerId,
-                regionId: sandbox.region,
-                sandboxClass: sandbox.sandboxClass,
-                cpu: sandbox.cpu,
-                gpu: sandbox.gpu,
-                gpuType: sandbox.gpuType ?? null,
-                mem: sandbox.mem,
-                disk: sandbox.disk,
-                sizeGB: snapshotSizeGB,
-              },
-            )
-          } catch (error) {
-            this.logger.error(`Failed to persist snapshot from SNAPSHOT_SANDBOX job ${job.id}:`, error)
-          }
+        } catch (error) {
+          this.logger.error(`Failed to persist snapshot from SNAPSHOT_SANDBOX job ${job.id}:`, error)
         }
       }
     } catch (error) {

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1349,6 +1349,8 @@ export class SandboxService {
         pendingSnapshotCountIncrement = 1
       }
 
+      const runnerAdapter = await this.runnerAdapterFactory.create(runner)
+
       const updatedSandbox = await this.sandboxRepository.updateWhere(sandbox.id, {
         updateData: {
           state: SandboxState.SNAPSHOTTING,
@@ -1360,26 +1362,39 @@ export class SandboxService {
         },
       })
 
-      const runnerAdapter = await this.runnerAdapterFactory.create(runner)
+      // Create the Snapshot row up front in the SNAPSHOTTING state so the
+      // user can track the operation from the start. It is transitioned to
+      // ACTIVE (or ERROR) once the runner finishes producing the image.
+      try {
+        await this.snapshotService.createSnapshotFromSandboxEntry({
+          organizationId: organization.id,
+          name: dto.name,
+          regionId: sandbox.region,
+          sandboxClass: sandbox.sandboxClass,
+          cpu: sandbox.cpu,
+          gpu: sandbox.gpu,
+          gpuType: sandbox.gpuType ?? null,
+          mem: sandbox.mem,
+          disk: sandbox.disk,
+          initialRunnerId: runner.id,
+        })
+      } catch (error) {
+        await this.revertSandboxSnapshottingState(sandbox)
+        throw error
+      }
 
       // v2 runners enqueue a SNAPSHOT_SANDBOX job and resolve immediately
-      // with `undefined`; the job state handler will persist the resulting
-      // Snapshot on completion.
+      // with `undefined`; the job state handler will transition the Snapshot
+      // row to ACTIVE (or ERROR) on completion.
       //
       // v0 runners (Docker, container class) don't have jobs - the adapter
       // performs a synchronous HTTP call to the runner's commit+push
       // endpoint, which can take several minutes. We don't want to block
       // the API request that long, so for v0 we kick the call off in the
       // background and immediately return the SNAPSHOTTING sandbox to the
-      // caller. The background promise persists the snapshot or reverts
-      // sandbox state on failure.
+      // caller. The background promise completes or fails the snapshot
+      // entry and reverts sandbox state.
       if (runner.apiVersion === '0') {
-        // Hand off pending-quota ownership to the background driver - it must
-        // roll back on failure since the outer try/catch returns successfully
-        // here.
-        const inheritedPendingIncrement = pendingSnapshotCountIncrement
-        pendingSnapshotCountIncrement = undefined
-
         void this.runV0SnapshotFromSandbox({
           sandbox,
           previousState: sandbox.state,
@@ -1388,19 +1403,21 @@ export class SandboxService {
           registry,
           runner,
           runnerAdapter,
-          pendingSnapshotCountIncrement: inheritedPendingIncrement,
         })
       } else {
         try {
           await runnerAdapter.createSnapshotFromSandbox(sandbox.id, dto.name, organization.id, registry, includeMemory)
         } catch (error) {
-          await this.sandboxRepository.updateWhere(sandbox.id, {
-            updateData: {
-              state: sandbox.state,
-              pending: false,
-            },
-            whereCondition: { state: SandboxState.SNAPSHOTTING },
-          })
+          await this.revertSandboxSnapshottingState(sandbox)
+          await this.snapshotService
+            .failSnapshotFromSandbox({
+              organizationId: organization.id,
+              name: dto.name,
+              errorReason: error.message || String(error),
+            })
+            .catch((err) =>
+              this.logger.error(`Failed to mark snapshot "${dto.name}" as errored for sandbox ${sandbox.id}:`, err),
+            )
 
           throw error
         }
@@ -1414,6 +1431,20 @@ export class SandboxService {
   }
 
   /**
+   * Reverts a sandbox from SNAPSHOTTING back to its previous state after a
+   * failure to start the snapshot operation.
+   */
+  private async revertSandboxSnapshottingState(sandbox: Sandbox): Promise<void> {
+    await this.sandboxRepository.updateWhere(sandbox.id, {
+      updateData: {
+        state: sandbox.state,
+        pending: false,
+      },
+      whereCondition: { state: SandboxState.SNAPSHOTTING },
+    })
+  }
+
+  /**
    * Background driver for v0 (Docker) sandbox snapshotting.
    *
    * v0 runners expose a synchronous HTTP endpoint for "commit + push" that
@@ -1421,8 +1452,9 @@ export class SandboxService {
    * user-facing API request can return immediately with state=SNAPSHOTTING,
    * mirroring the v2 (job-driven) UX.
    *
-   * Errors are intentionally swallowed - sandbox state is the source of
-   * truth. On any failure we restore state and refund the pending quota.
+   * Errors are intentionally swallowed - entity state is the source of
+   * truth. On any failure we restore the sandbox state and transition the
+   * snapshot entry to ERROR.
    */
   private async runV0SnapshotFromSandbox(params: {
     sandbox: Sandbox
@@ -1432,27 +1464,16 @@ export class SandboxService {
     registry?: DockerRegistry
     runner: Runner
     runnerAdapter: RunnerAdapter
-    pendingSnapshotCountIncrement?: number
   }): Promise<void> {
-    const {
-      sandbox,
-      previousState,
-      snapshotName,
-      organizationId,
-      registry,
-      runner,
-      runnerAdapter,
-      pendingSnapshotCountIncrement,
-    } = params
+    const { sandbox, previousState, snapshotName, organizationId, registry, runner, runnerAdapter } = params
 
-    let succeeded = false
     try {
       const result = await runnerAdapter.createSnapshotFromSandbox(sandbox.id, snapshotName, organizationId, registry)
       if (!result) {
         throw new Error('runner returned no snapshot result')
       }
 
-      await this.snapshotService.persistSnapshotFromSandbox({
+      const completed = await this.snapshotService.completeSnapshotFromSandbox({
         organizationId,
         name: snapshotName,
         ref: result.ref,
@@ -1466,12 +1487,26 @@ export class SandboxService {
         disk: sandbox.disk,
         sizeGB: result.sizeGB,
       })
-      succeeded = true
+
+      if (!completed) {
+        this.logger.warn(
+          `Snapshot "${snapshotName}" for sandbox ${sandbox.id} is no longer in the snapshotting state; skipping activation`,
+        )
+      }
     } catch (error) {
       this.logger.error(`v0 snapshotFromSandbox failed for sandbox ${sandbox.id}:`, error)
+      await this.snapshotService
+        .failSnapshotFromSandbox({
+          organizationId,
+          name: snapshotName,
+          errorReason: error.message || String(error),
+        })
+        .catch((err) =>
+          this.logger.error(`Failed to mark snapshot "${snapshotName}" as errored for sandbox ${sandbox.id}:`, err),
+        )
     }
 
-    // Always clear SNAPSHOTTING - whether the snapshot was persisted or not,
+    // Always clear SNAPSHOTTING - whether the snapshot succeeded or not,
     // the sandbox itself should return to its previous state.
     await this.sandboxRepository
       .updateWhere(sandbox.id, {
@@ -1479,12 +1514,6 @@ export class SandboxService {
         whereCondition: { state: SandboxState.SNAPSHOTTING },
       })
       .catch((err) => this.logger.error(`Failed to clear SNAPSHOTTING state for sandbox ${sandbox.id}:`, err))
-
-    if (!succeeded) {
-      await this.snapshotService
-        .rollbackPendingUsage(organizationId, pendingSnapshotCountIncrement)
-        .catch((err) => this.logger.error(`Failed to roll back pending snapshot quota for org ${organizationId}:`, err))
-    }
   }
 
   async findAllPaginatedDeprecated(

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -59,8 +59,12 @@ import { SnapshotActivatedEvent } from '../events/snapshot-activated.event'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import {
-  persistSnapshotFromSandbox,
-  PersistSnapshotFromSandboxParams,
+  createSnapshotFromSandboxEntry,
+  CreateSnapshotFromSandboxEntryParams,
+  completeSnapshotFromSandbox,
+  CompleteSnapshotFromSandboxParams,
+  failSnapshotFromSandbox,
+  FailSnapshotFromSandboxParams,
 } from '../utils/persist-snapshot-from-sandbox.util'
 import { getRunnerSandboxClass } from '../utils/sandbox-class.util'
 import { resolveGpuTypePreferences } from '../utils/gpu-type-preferences.util'
@@ -405,8 +409,30 @@ export class SnapshotService {
     }
   }
 
-  async persistSnapshotFromSandbox(params: PersistSnapshotFromSandboxParams): Promise<Snapshot> {
-    return persistSnapshotFromSandbox(
+  async createSnapshotFromSandboxEntry(params: CreateSnapshotFromSandboxEntryParams): Promise<Snapshot> {
+    return createSnapshotFromSandboxEntry(
+      {
+        snapshotRepository: this.snapshotRepository,
+        snapshotRunnerRepository: this.snapshotRunnerRepository,
+        eventEmitter: this.eventEmitter,
+      },
+      params,
+    )
+  }
+
+  async completeSnapshotFromSandbox(params: CompleteSnapshotFromSandboxParams): Promise<Snapshot | null> {
+    return completeSnapshotFromSandbox(
+      {
+        snapshotRepository: this.snapshotRepository,
+        snapshotRunnerRepository: this.snapshotRunnerRepository,
+        eventEmitter: this.eventEmitter,
+      },
+      params,
+    )
+  }
+
+  async failSnapshotFromSandbox(params: FailSnapshotFromSandboxParams): Promise<Snapshot | null> {
+    return failSnapshotFromSandbox(
       {
         snapshotRepository: this.snapshotRepository,
         snapshotRunnerRepository: this.snapshotRunnerRepository,

--- a/apps/api/src/sandbox/utils/persist-snapshot-from-sandbox.util.ts
+++ b/apps/api/src/sandbox/utils/persist-snapshot-from-sandbox.util.ts
@@ -14,16 +14,44 @@ import { SnapshotRunnerState } from '../enums/snapshot-runner-state.enum'
 import { SnapshotEvents } from '../constants/snapshot-events'
 import { SnapshotCreatedEvent } from '../events/snapshot-created.event'
 import { SnapshotRepository } from '../repositories/snapshot.repository'
+import { SnapshotConflictError } from '../errors/snapshot-conflict.error'
 import { SandboxClass } from '../enums/sandbox-class.enum'
 import { GpuType } from '../enums/gpu-type.enum'
 
-export interface PersistSnapshotFromSandboxDeps {
+/*
+ * Snapshot-from-sandbox lifecycle helpers.
+ *
+ * A snapshot created from a sandbox gets its Snapshot row inserted in the
+ * SNAPSHOTTING state as soon as the operation starts (createSnapshotFromSandboxEntry),
+ * is transitioned to ACTIVE once the runner has produced and pushed the image
+ * (completeSnapshotFromSandbox), or to ERROR if the operation fails
+ * (failSnapshotFromSandbox).
+ *
+ * Extracted to free functions to avoid a NestJS DI cycle between
+ * SnapshotService and JobStateHandlerService: both can call these without
+ * importing each other.
+ */
+
+export interface SnapshotFromSandboxDeps {
   snapshotRepository: SnapshotRepository
   snapshotRunnerRepository: Repository<SnapshotRunner>
   eventEmitter: EventEmitter2
 }
 
-export interface PersistSnapshotFromSandboxParams {
+export interface CreateSnapshotFromSandboxEntryParams {
+  organizationId: string
+  name: string
+  regionId: string
+  sandboxClass: SandboxClass
+  cpu: number
+  gpu: number
+  gpuType?: GpuType | null
+  mem: number
+  disk: number
+  initialRunnerId?: string
+}
+
+export interface CompleteSnapshotFromSandboxParams {
   organizationId: string
   name: string
   ref: string
@@ -38,41 +66,40 @@ export interface PersistSnapshotFromSandboxParams {
   sizeGB?: number
 }
 
-/**
- * Inserts a Snapshot row in the ACTIVE state for an image that a runner has
- * already produced (snapshot-from-sandbox), wires up the matching
- * SnapshotRunner record, and emits the CREATED event.
- *
- * Extracted to a free function to avoid a NestJS DI cycle between
- * SnapshotService and JobStateHandlerService: both can call this without
- * importing each other.
- */
-export async function persistSnapshotFromSandbox(
-  deps: PersistSnapshotFromSandboxDeps,
-  params: PersistSnapshotFromSandboxParams,
-): Promise<Snapshot> {
-  const { snapshotRepository, snapshotRunnerRepository, eventEmitter } = deps
+export interface FailSnapshotFromSandboxParams {
+  organizationId: string
+  name: string
+  errorReason: string
+}
 
-  const size = typeof params.sizeGB === 'number' && Number.isFinite(params.sizeGB) ? params.sizeGB : undefined
-  const runnerId = params.runnerId || undefined
+/**
+ * Inserts a Snapshot row in the SNAPSHOTTING state before the runner starts
+ * producing the image, so the user can track the operation from the start.
+ * Emits the CREATED event.
+ *
+ * @throws {ConflictException} If a snapshot with the same name already exists
+ * for the organization.
+ */
+export async function createSnapshotFromSandboxEntry(
+  deps: SnapshotFromSandboxDeps,
+  params: CreateSnapshotFromSandboxEntryParams,
+): Promise<Snapshot> {
+  const { snapshotRepository, eventEmitter } = deps
+
   const snapshotId = uuidv4()
 
-  // We should set to active only after a number of snapshot runners had been propagated, leaving as is for now
   const snapshot = snapshotRepository.create({
     id: snapshotId,
     organizationId: params.organizationId,
     name: params.name,
-    ref: params.ref,
-    state: SnapshotState.ACTIVE,
+    state: SnapshotState.SNAPSHOTTING,
     sandboxClass: params.sandboxClass,
     cpu: params.cpu,
     gpu: params.gpu,
     gpuType: params.gpuType ?? null,
     mem: params.mem,
     disk: params.disk,
-    size,
-    initialRunnerId: runnerId,
-    lastUsedAt: new Date(),
+    initialRunnerId: params.initialRunnerId,
     snapshotRegions: [{ snapshotId, regionId: params.regionId }],
   })
 
@@ -86,18 +113,159 @@ export async function persistSnapshotFromSandbox(
     throw error
   }
 
-  // SnapshotRunner is created only after the Snapshot row is committed so a
-  // unique-name conflict above doesn't leave an orphan SnapshotRunner record
-  // pointing at a ref no Snapshot owns.
-  if (runnerId) {
-    const snapshotRunner = snapshotRunnerRepository.create({
-      snapshotRef: params.ref,
-      runnerId,
-      state: SnapshotRunnerState.READY,
-    })
-    await snapshotRunnerRepository.save(snapshotRunner)
-  }
-
   eventEmitter.emit(SnapshotEvents.CREATED, new SnapshotCreatedEvent(inserted))
   return inserted
+}
+
+/**
+ * Transitions a SNAPSHOTTING Snapshot row to ACTIVE once the runner has
+ * produced the image, filling in the ref/size, and wires up the matching
+ * SnapshotRunner record.
+ *
+ * Returns `null` without touching the row if it exists but is no longer in
+ * the SNAPSHOTTING state (e.g. removed or timed out while the runner was
+ * working).
+ *
+ * If no row exists at all, falls back to inserting one directly in the
+ * ACTIVE state — this covers operations that were started before the
+ * entry-first flow was deployed.
+ */
+export async function completeSnapshotFromSandbox(
+  deps: SnapshotFromSandboxDeps,
+  params: CompleteSnapshotFromSandboxParams,
+): Promise<Snapshot | null> {
+  const { snapshotRepository, snapshotRunnerRepository, eventEmitter } = deps
+
+  const size = typeof params.sizeGB === 'number' && Number.isFinite(params.sizeGB) ? params.sizeGB : undefined
+  const runnerId = params.runnerId || undefined
+
+  const existing = await snapshotRepository.findOne({
+    where: { organizationId: params.organizationId, name: params.name },
+  })
+
+  let snapshot: Snapshot
+  if (existing) {
+    if (existing.state !== SnapshotState.SNAPSHOTTING) {
+      return null
+    }
+
+    const updateData: Partial<Snapshot> = {
+      state: SnapshotState.ACTIVE,
+      ref: params.ref,
+      lastUsedAt: new Date(),
+    }
+    if (size !== undefined) {
+      updateData.size = size
+    }
+    if (runnerId && existing.initialRunnerId !== runnerId) {
+      updateData.initialRunnerId = runnerId
+    }
+
+    try {
+      // Guard on the state at write time so a concurrent transition (failure,
+      // timeout, removal) between the read above and this update isn't overwritten
+      snapshot = await snapshotRepository.updateWhere(existing.id, {
+        updateData,
+        whereCondition: { state: SnapshotState.SNAPSHOTTING },
+      })
+    } catch (error) {
+      if (error instanceof SnapshotConflictError) {
+        return null
+      }
+      throw error
+    }
+  } else {
+    const snapshotId = uuidv4()
+
+    const newSnapshot = snapshotRepository.create({
+      id: snapshotId,
+      organizationId: params.organizationId,
+      name: params.name,
+      ref: params.ref,
+      state: SnapshotState.ACTIVE,
+      sandboxClass: params.sandboxClass,
+      cpu: params.cpu,
+      gpu: params.gpu,
+      gpuType: params.gpuType ?? null,
+      mem: params.mem,
+      disk: params.disk,
+      size,
+      initialRunnerId: runnerId,
+      lastUsedAt: new Date(),
+      snapshotRegions: [{ snapshotId, regionId: params.regionId }],
+    })
+
+    try {
+      snapshot = await snapshotRepository.insert(newSnapshot)
+    } catch (error) {
+      if ((error as { code?: string }).code === '23505') {
+        throw new ConflictException(`Snapshot with name "${params.name}" already exists for this organization`)
+      }
+      throw error
+    }
+
+    eventEmitter.emit(SnapshotEvents.CREATED, new SnapshotCreatedEvent(snapshot))
+  }
+
+  // SnapshotRunner is wired up only after the Snapshot row is committed so a
+  // failure above doesn't leave an orphan SnapshotRunner record pointing at a
+  // ref no Snapshot owns. Snapshotting the same sandbox twice can produce the
+  // same content-addressed ref, so reuse an existing record if there is one.
+  if (runnerId) {
+    const existingSnapshotRunner = await snapshotRunnerRepository.findOne({
+      where: { snapshotRef: params.ref, runnerId },
+    })
+    if (existingSnapshotRunner) {
+      if (existingSnapshotRunner.state !== SnapshotRunnerState.READY) {
+        existingSnapshotRunner.state = SnapshotRunnerState.READY
+        existingSnapshotRunner.errorReason = null
+        await snapshotRunnerRepository.save(existingSnapshotRunner)
+      }
+    } else {
+      const snapshotRunner = snapshotRunnerRepository.create({
+        snapshotRef: params.ref,
+        runnerId,
+        state: SnapshotRunnerState.READY,
+      })
+      await snapshotRunnerRepository.save(snapshotRunner)
+    }
+  }
+
+  return snapshot
+}
+
+/**
+ * Transitions a SNAPSHOTTING Snapshot row to ERROR. Returns `null` if the
+ * row doesn't exist or is no longer in the SNAPSHOTTING state.
+ */
+export async function failSnapshotFromSandbox(
+  deps: SnapshotFromSandboxDeps,
+  params: FailSnapshotFromSandboxParams,
+): Promise<Snapshot | null> {
+  const { snapshotRepository } = deps
+
+  const existing = await snapshotRepository.findOne({
+    where: { organizationId: params.organizationId, name: params.name, state: SnapshotState.SNAPSHOTTING },
+  })
+
+  if (!existing) {
+    return null
+  }
+
+  try {
+    // Guard on the state at write time so a concurrent completion between the
+    // read above and this update isn't overwritten
+    return await snapshotRepository.updateWhere(existing.id, {
+      updateData: {
+        state: SnapshotState.ERROR,
+        errorReason: params.errorReason,
+      },
+      whereCondition: { state: SnapshotState.SNAPSHOTTING },
+    })
+  } catch (error) {
+    if (error instanceof SnapshotConflictError) {
+      return null
+    }
+    throw error
+  }
 }

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -14003,6 +14003,7 @@ components:
       - building
       - pending
       - pulling
+      - snapshotting
       - active
       - inactive
       - error

--- a/libs/api-client-go/model_snapshot_state.go
+++ b/libs/api-client-go/model_snapshot_state.go
@@ -23,6 +23,7 @@ const (
 	SNAPSHOTSTATE_BUILDING SnapshotState = "building"
 	SNAPSHOTSTATE_PENDING SnapshotState = "pending"
 	SNAPSHOTSTATE_PULLING SnapshotState = "pulling"
+	SNAPSHOTSTATE_SNAPSHOTTING SnapshotState = "snapshotting"
 	SNAPSHOTSTATE_ACTIVE SnapshotState = "active"
 	SNAPSHOTSTATE_INACTIVE SnapshotState = "inactive"
 	SNAPSHOTSTATE_ERROR SnapshotState = "error"
@@ -36,6 +37,7 @@ var AllowedSnapshotStateEnumValues = []SnapshotState{
 	"building",
 	"pending",
 	"pulling",
+	"snapshotting",
 	"active",
 	"inactive",
 	"error",

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/SnapshotState.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/SnapshotState.java
@@ -35,6 +35,8 @@ public enum SnapshotState {
   
   PULLING("pulling"),
   
+  SNAPSHOTTING("snapshotting"),
+  
   ACTIVE("active"),
   
   INACTIVE("inactive"),

--- a/libs/api-client-python-async/daytona_api_client_async/models/snapshot_state.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/snapshot_state.py
@@ -30,6 +30,7 @@ class SnapshotState(str, Enum):
     BUILDING = 'building'
     PENDING = 'pending'
     PULLING = 'pulling'
+    SNAPSHOTTING = 'snapshotting'
     ACTIVE = 'active'
     INACTIVE = 'inactive'
     ERROR = 'error'

--- a/libs/api-client-python/daytona_api_client/models/snapshot_state.py
+++ b/libs/api-client-python/daytona_api_client/models/snapshot_state.py
@@ -30,6 +30,7 @@ class SnapshotState(str, Enum):
     BUILDING = 'building'
     PENDING = 'pending'
     PULLING = 'pulling'
+    SNAPSHOTTING = 'snapshotting'
     ACTIVE = 'active'
     INACTIVE = 'inactive'
     ERROR = 'error'

--- a/libs/api-client-ruby/lib/daytona_api_client/models/snapshot_state.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/snapshot_state.rb
@@ -18,6 +18,7 @@ module DaytonaApiClient
     BUILDING = "building".freeze
     PENDING = "pending".freeze
     PULLING = "pulling".freeze
+    SNAPSHOTTING = "snapshotting".freeze
     ACTIVE = "active".freeze
     INACTIVE = "inactive".freeze
     ERROR = "error".freeze
@@ -26,7 +27,7 @@ module DaytonaApiClient
     UNKNOWN_DEFAULT_OPEN_API = "unknown_default_open_api".freeze
 
     def self.all_vars
-      @all_vars ||= [BUILDING, PENDING, PULLING, ACTIVE, INACTIVE, ERROR, BUILD_FAILED, REMOVING, UNKNOWN_DEFAULT_OPEN_API].freeze
+      @all_vars ||= [BUILDING, PENDING, PULLING, SNAPSHOTTING, ACTIVE, INACTIVE, ERROR, BUILD_FAILED, REMOVING, UNKNOWN_DEFAULT_OPEN_API].freeze
     end
 
     # Builds the enum from string

--- a/libs/api-client/src/models/snapshot-state.ts
+++ b/libs/api-client/src/models/snapshot-state.ts
@@ -19,6 +19,7 @@ export const SnapshotState = {
     BUILDING: 'building',
     PENDING: 'pending',
     PULLING: 'pulling',
+    SNAPSHOTTING: 'snapshotting',
     ACTIVE: 'active',
     INACTIVE: 'inactive',
     ERROR: 'error',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Immediately create a Snapshot record when starting snapshot-from-sandbox so users can track progress from the start. Adds a new snapshot state and moves it to ACTIVE or ERROR via the runner, with a 180‑minute timeout and race-safe updates.

- **New Features**
  - Insert Snapshot row in SNAPSHOTTING at operation start; v2 job handler completes to ACTIVE with ref/size or marks ERROR on FAILED; v0 background flow completes/fails the entry and always restores sandbox state.
  - Backstop: manager marks stuck SNAPSHOTTING entries as ERROR after 180 minutes.
  - Race-safety: conditional, locked updates prevent concurrent overwrites; skip activation if the state changed; fallback inserts ACTIVE if no entry exists (pre-deploy ops).
  - Count SNAPSHOTTING as resource-consuming; update OpenAPI and client SDKs (Go, Java, Python, Ruby, TypeScript) to include "snapshotting".

- **Migration**
  - Pre-deploy migration adds `snapshotting` to `snapshot_state_enum`; down-migration maps it to `error`.

<sup>Written for commit e101d03b1cd1121dc779233f5bf82729360dcfd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

