### PR TITLE
fix(dashboard): close api key revoke dialog on success

### DIFF
--- a/apps/dashboard/src/pages/Keys.tsx
+++ b/apps/dashboard/src/pages/Keys.tsx
@@ -64,6 +64,8 @@ const Keys: React.FC = () => {
         organizationId: selectedOrganization.id,
       })
       toast.success('API key revoked successfully')
+      setShowRevokeDialog(false)
+      setApiKeyToRevoke(null)
     } catch (error) {
       handleApiError(error, 'Failed to revoke API key')
     } finally {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Closes the API key revoke dialog after a successful revoke and clears the selected API key to prevent stale state.

<sup>Written for commit 14d059360ef39bb173404b04839b10c8957bff42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

