### PR TITLE
fix(toolbox): register DELETE route without trailing slash

### DIFF
--- a/apps/daemon/pkg/toolbox/server.go
+++ b/apps/daemon/pkg/toolbox/server.go
@@ -187,6 +187,7 @@ func (s *server) Start() error {
 
 		// delete operations
 		fsController.DELETE("/", fs.DeleteFile)
+		fsController.DELETE("", fs.DeleteFile)
 	}
 
 	processLogger := s.logger.With(slog.String("component", "process_controller"))

--- a/apps/daemon/pkg/toolbox/server_test.go
+++ b/apps/daemon/pkg/toolbox/server_test.go
@@ -24,6 +24,8 @@ func TestFilesRoutesAcceptSlashAndNoSlash(t *testing.T) {
 	{
 		fsController.GET("/", fs.ListFiles)
 		fsController.GET("", fs.ListFiles)
+		fsController.DELETE("/", fs.DeleteFile)
+		fsController.DELETE("", fs.DeleteFile)
 	}
 
 	tempDir := t.TempDir()
@@ -44,6 +46,40 @@ func TestFilesRoutesAcceptSlashAndNoSlash(t *testing.T) {
 
 	if statusSlash != http.StatusOK {
 		t.Fatalf("GET /files/ returned status %d, want %d", statusSlash, http.StatusOK)
+	}
+
+	deleteFileNoSlash, err := os.CreateTemp(t.TempDir(), "delete-no-slash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := deleteFileNoSlash.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	deleteFileSlash, err := os.CreateTemp(t.TempDir(), "delete-slash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := deleteFileSlash.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	checkDelete := func(path string) int {
+		req := httptest.NewRequest(http.MethodDelete, path, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	deleteStatusNoSlash := checkDelete("/files?path=" + deleteFileNoSlash.Name())
+	deleteStatusSlash := checkDelete("/files/?path=" + deleteFileSlash.Name())
+
+	if deleteStatusNoSlash != http.StatusNoContent {
+		t.Fatalf("DELETE /files returned status %d, want %d", deleteStatusNoSlash, http.StatusNoContent)
+	}
+
+	if deleteStatusSlash != http.StatusNoContent {
+		t.Fatalf("DELETE /files/ returned status %d, want %d", deleteStatusSlash, http.StatusNoContent)
 	}
 }
 


### PR DESCRIPTION
## Description

The toolbox server registered DELETE /files/ but not DELETE /files. The TypeScript SDK sends DELETE /files (no trailing slash) when deleting files with recursive=true, resulting in a 404.

This adds fsController.DELETE("", fs.DeleteFile) alongside the existing slash variant, matching the pattern already used for GET routes (which register both /files and /files/).

### Changes
- apps/daemon/pkg/toolbox/server.go: add DELETE empty-path route
- apps/daemon/pkg/toolbox/server_test.go: extend TestFilesRoutesAcceptSlashAndNoSlash with DELETE coverage

## Documentation

- [x] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Fixes #5029

## Notes

Regression test added. Go toolchain not available locally; CI will verify.