### PR TITLE
fix(api): restore sandbox runner id rc

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -877,7 +877,7 @@ export class SandboxStartAction extends SandboxAction {
       undefined,
       undefined,
       undefined,
-      excludedRunnerId || undefined,
+      excludedRunnerId,
     )
 
     const metadata = {

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -484,17 +484,6 @@ export class SandboxStartAction extends SandboxAction {
       if (shouldMoveToNewRunner) {
         sandbox.prevRunnerId = originalRunnerId
         sandbox.runnerId = null
-
-        await this.sandboxRepository.update(
-          sandbox.id,
-          {
-            updateData: {
-              prevRunnerId: originalRunnerId,
-              runnerId: null,
-            },
-          },
-          true,
-        )
       }
 
       // If the sandbox is on a runner and its backupState is COMPLETED
@@ -514,16 +503,6 @@ export class SandboxStartAction extends SandboxAction {
             sandbox.prevRunnerId = originalRunnerId
             sandbox.runnerId = null
 
-            await this.sandboxRepository.update(
-              sandbox.id,
-              {
-                updateData: {
-                  prevRunnerId: originalRunnerId,
-                  runnerId: null,
-                },
-              },
-              true,
-            )
             try {
               const runnerAdapter = await this.runnerAdapterFactory.create(runner)
               await runnerAdapter.destroySandbox(sandbox.id)
@@ -889,7 +868,17 @@ export class SandboxStartAction extends SandboxAction {
     // Clear the retry counter on success
     await this.redis.del(restoreBackupSnapshotRetryKey)
 
-    await this.updateSandboxState(sandbox, SandboxState.RESTORING, lockCode, runner.id)
+    await this.updateSandboxState(
+      sandbox,
+      SandboxState.RESTORING,
+      lockCode,
+      runner.id,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      excludedRunnerId || undefined,
+    )
 
     const metadata = {
       ...organization?.sandboxMetadata,

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox.action.ts
@@ -39,6 +39,7 @@ export abstract class SandboxAction {
     daemonVersion?: string,
     backupState?: BackupState,
     recoverable?: boolean,
+    prevRunnerId?: string | null | undefined,
   ) {
     //  check if the lock code is still valid
     const lockKey = getStateChangeLockKey(sandbox.id)
@@ -70,6 +71,10 @@ export abstract class SandboxAction {
 
     if (runnerId !== undefined) {
       updateData.runnerId = runnerId
+    }
+
+    if (prevRunnerId !== undefined) {
+      updateData.prevRunnerId = prevRunnerId
     }
 
     if (errorReason !== undefined) {


### PR DESCRIPTION
## Description

Fixes the handling of moving the value of `runnerId` to `prevRunnerId` when restoring sandboxes on unresponsive runners. Previously, the v2 runner would update the state to started leading to a sandbox having no `runnerId` entry

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sandbox restore flow so `runnerId` stays set while moving off an unresponsive runner. We now persist `prevRunnerId` with the new `runnerId` during RESTORING to avoid empty `runnerId` states.

- **Bug Fixes**
  - `updateSandboxState` now accepts and persists `prevRunnerId`.
  - Passes `excludedRunnerId` as `prevRunnerId` when setting RESTORING.
  - Removes early DB writes that nulled `runnerId` during restore.

<sup>Written for commit 75877749e86fe115029b9dde30b96c11346fd222. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

