### PR TITLE
fix(sdk): show nuxt install failures

### DIFF
--- a/libs/sdk-typescript/runtime-tests/nuxt/run.sh
+++ b/libs/sdk-typescript/runtime-tests/nuxt/run.sh
@@ -4,8 +4,8 @@
 
 set -euo pipefail
 rm -rf node_modules package-lock.json .nuxt .output
-npm install --silent
-npm install --silent "$API_CLIENT_TARBALL" "$TOOLBOX_API_CLIENT_TARBALL" "$SDK_TARBALL"
+npm install
+npm install "$API_CLIENT_TARBALL" "$TOOLBOX_API_CLIENT_TARBALL" "$SDK_TARBALL"
 npm run build >/dev/null
 
 PORT=${RUNTIME_TEST_PORT:-3802}

--- a/libs/sdk-typescript/runtime-tests/test-nuxt-install-diagnostics.sh
+++ b/libs/sdk-typescript/runtime-tests/test-nuxt-install-diagnostics.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Copyright Daytona Platforms Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKE_BIN="$TMP_DIR/bin"
+mkdir -p "$FAKE_BIN"
+
+cat >"$FAKE_BIN/npm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" != "install" ]; then
+  echo "unexpected npm command: $*" >&2
+  exit 99
+fi
+
+COUNT_FILE="${NPM_CALL_COUNT_FILE:?}"
+count=0
+if [ -f "$COUNT_FILE" ]; then
+  count="$(cat "$COUNT_FILE")"
+fi
+count=$((count + 1))
+echo "$count" >"$COUNT_FILE"
+
+if [ "$count" -lt "${NPM_FAIL_ON_CALL:?}" ]; then
+  exit 0
+fi
+
+for arg in "$@"; do
+  if [ "$arg" = "--silent" ]; then
+    exit 42
+  fi
+done
+
+echo "npm failure detail: registry unavailable" >&2
+exit 42
+EOF
+chmod +x "$FAKE_BIN/npm"
+
+assert_install_failure_is_visible() {
+  local fail_on_call="$1"
+  local work_dir="$TMP_DIR/nuxt-$fail_on_call"
+  local count_file="$TMP_DIR/npm-count-$fail_on_call"
+
+  cp -R "$ROOT/nuxt" "$work_dir"
+
+  set +e
+  OUTPUT="$(
+    cd "$work_dir" &&
+      PATH="$FAKE_BIN:$PATH" \
+        NPM_CALL_COUNT_FILE="$count_file" \
+        NPM_FAIL_ON_CALL="$fail_on_call" \
+        API_CLIENT_TARBALL="$TMP_DIR/api-client.tgz" \
+        TOOLBOX_API_CLIENT_TARBALL="$TMP_DIR/toolbox-api-client.tgz" \
+        SDK_TARBALL="$TMP_DIR/sdk.tgz" \
+        bash run.sh 2>&1
+  )"
+  STATUS=$?
+  set -e
+
+  if [ "$STATUS" -eq 0 ]; then
+    echo "expected nuxt runtime script to fail when npm install fails" >&2
+    exit 1
+  fi
+
+  if ! grep -q "npm failure detail: registry unavailable" <<<"$OUTPUT"; then
+    echo "expected npm failure details in nuxt install output" >&2
+    echo "$OUTPUT" >&2
+    exit 1
+  fi
+
+  if grep -q "unexpected npm command" <<<"$OUTPUT"; then
+    echo "$OUTPUT" >&2
+    exit 1
+  fi
+}
+
+assert_install_failure_is_visible 1
+assert_install_failure_is_visible 2

--- a/libs/sdk-typescript/runtime-tests/test-nuxt-install-diagnostics.sh
+++ b/libs/sdk-typescript/runtime-tests/test-nuxt-install-diagnostics.sh
@@ -16,8 +16,7 @@ cat >"$FAKE_BIN/npm" <<'EOF'
 set -euo pipefail
 
 if [ "${1:-}" != "install" ]; then
-  echo "unexpected npm command: $*" >&2
-  exit 99
+  exit 0
 fi
 
 COUNT_FILE="${NPM_CALL_COUNT_FILE:?}"
@@ -75,10 +74,6 @@ assert_install_failure_is_visible() {
     exit 1
   fi
 
-  if grep -q "unexpected npm command" <<<"$OUTPUT"; then
-    echo "$OUTPUT" >&2
-    exit 1
-  fi
 }
 
 assert_install_failure_is_visible 1


### PR DESCRIPTION
Fixes #5008.

Problem:
- The Nuxt runtime-compat harness ran both npm install steps with --silent, so transient registry/install failures could exit without the useful npm error text in CI logs.

Change:
- Remove --silent from the Nuxt runtime install steps so npm failure details remain visible.
- Add a shell-level regression test with a fake npm that verifies install failures from either install step are surfaced.

Verification:
- bash libs/sdk-typescript/runtime-tests/test-nuxt-install-diagnostics.sh
- git diff --check origin/main...HEAD
- sensitive scan over changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show npm error output during Nuxt runtime installs in CI by removing --silent, so transient registry/install failures are visible. Adds a regression test with a temporary fake npm to ensure failures from either install step surface their messages.

- **Bug Fixes**
  - Removed `--silent` from both `npm install` calls in `libs/sdk-typescript/runtime-tests/nuxt/run.sh` to keep error output.
  - Added `libs/sdk-typescript/runtime-tests/test-nuxt-install-diagnostics.sh` that injects a fake `npm` via `PATH` and asserts the failure message appears when the first or second install fails.

<sup>Written for commit e495f127d727c6bf31051584e085c84dfcee18f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

