### PR TITLE
docs: add TealTiger governed sandbox guide

### DIFF
--- a/apps/docs/src/content/docs/en/guides/tealtiger/tealtiger-governed-sandbox.mdx
+++ b/apps/docs/src/content/docs/en/guides/tealtiger/tealtiger-governed-sandbox.mdx
@@ -1,0 +1,106 @@
+---
+title: Govern AI-Generated Code With TealTiger and Daytona
+description: Add a pre-execution governance check before running AI-generated code in Daytona sandboxes.
+---
+
+This guide demonstrates how to place a TealTiger governance step before `sandbox.process.code_run()`. TealTiger evaluates LLM output for logic-layer policy concerns such as secrets, prompt injection, and session budget before the generated code is passed to Daytona. Daytona then provides the isolated runtime for code that passes governance.
+
+Use this pattern when an agent creates code dynamically and your application needs to decide whether the code should run before it enters the sandbox environment.
+
+### 1. Workflow Overview
+
+The application calls TealTiger's OpenAI wrapper to generate code with guardrails enabled. If that governed generation call succeeds, the application creates a Daytona sandbox and runs the generated code. If the governance step raises an error, the application records a blocked receipt and never creates the sandbox. The example prints an execution receipt that links the governance provider, the sandbox ID, the exit code, and a preview of the result.
+
+The important boundary is simple: the application does not call `sandbox.process.code_run()` until the governed code generation step has completed successfully.
+
+### 2. Project Setup
+
+Clone the Daytona repository and navigate to the example directory:
+
+```bash
+git clone https://github.com/daytonaio/daytona
+cd daytona/guides/python/tealtiger/governed-sandbox
+```
+
+Install the dependencies:
+
+```bash
+python3.10 -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+pip install -e .
+```
+
+Create a `.env` file with your API keys:
+
+```bash
+DAYTONA_API_KEY=dtn_***
+OPENAI_API_KEY=sk-***
+```
+
+### 3. Run the Example
+
+```bash
+python governed_sandbox.py
+```
+
+The script will:
+
+1. Ask TealTiger-wrapped OpenAI generation for a short Python script
+2. Print the approved code
+3. Create a Daytona Python sandbox
+4. Execute the approved code with `sandbox.process.code_run(code)`
+5. Print an execution receipt
+6. Delete the sandbox
+
+### 4. Core Pattern
+
+```python
+import os
+
+from daytona import CreateSandboxFromSnapshotParams, Daytona
+from tealtiger import TealOpenAI
+
+try:
+    client = TealOpenAI(
+        api_key=os.environ["OPENAI_API_KEY"],
+        guardrails={
+            "secret_detection": True,
+            "prompt_injection": True,
+        },
+        budget={
+            "max_cost_per_session": 2.00,
+        },
+    )
+
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": "Return only executable Python code."},
+            {"role": "user", "content": "Print the first 10 Fibonacci numbers."},
+        ],
+    )
+except Exception as exc:
+    print(f"Governance blocked code before Daytona execution: {exc}")
+else:
+    code = response.choices[0].message.content or ""
+
+    daytona = Daytona()
+    sandbox = None
+
+    try:
+        sandbox = daytona.create(CreateSandboxFromSnapshotParams(language="python"))
+        result = sandbox.process.code_run(code)
+        print(result.result)
+    finally:
+        if sandbox is not None:
+            daytona.delete(sandbox)
+```
+
+### 5. Complete Code
+
+See the complete runnable example in [`guides/python/tealtiger/governed-sandbox`](https://github.com/daytonaio/daytona/tree/main/guides/python/tealtiger/governed-sandbox).
+
+### 6. References
+
+- [TealTiger](https://github.com/agentguard-ai/tealtiger)
+- [Daytona Documentation](https://www.daytona.io/docs)

--- a/apps/docs/src/content/i18n/en.json
+++ b/apps/docs/src/content/i18n/en.json
@@ -155,6 +155,7 @@
   "sidebarconfig.googleAdk": "Google ADK",
   "sidebarconfig.lettacode": "Letta Code",
   "sidebarconfig.ag2": "AG2",
+  "sidebarconfig.tealtiger": "TealTiger",
   "sidebarconfig.flue": "Flue",
   "sidebarconfig.trl": "TRL",
   "sidebarconfig.openenv": "OpenEnv",

--- a/apps/docs/src/content/i18n/ja.json
+++ b/apps/docs/src/content/i18n/ja.json
@@ -102,5 +102,6 @@
   "sidebarconfig.verl": "veRL",
   "sidebarconfig.pty": "擬似ターミナル (PTY)",
   "sidebarconfig.ptyDescription": "DaytonaのTS SDK / Python SDKを使用して、サンドボックス（Daytonaが管理する隔離された一時的な実行環境）でPTYセッションを管理する方法を学びます。",
-  "sidebarconfig.amp": "Amp Code"
+  "sidebarconfig.amp": "Amp Code",
+  "sidebarconfig.tealtiger": "TealTiger"
 }

--- a/apps/docs/src/sidebar-config.ts
+++ b/apps/docs/src/sidebar-config.ts
@@ -679,6 +679,18 @@ export const getSidebarConfig = (
         {
           type: 'link',
           href: localizePath(
+            '/docs/guides/tealtiger/tealtiger-governed-sandbox',
+            locale
+          ),
+          label: t('sidebarconfig.tealtiger'),
+          disablePagination: true,
+          attrs: {
+            icon: 'shield.svg',
+          },
+        },
+        {
+          type: 'link',
+          href: localizePath(
             '/docs/guides/flue/flue-autonomous-bug-fix-agent',
             locale
           ),

--- a/guides/python/tealtiger/governed-sandbox/.env.example
+++ b/guides/python/tealtiger/governed-sandbox/.env.example
@@ -1,0 +1,2 @@
+DAYTONA_API_KEY=dtn_***
+OPENAI_API_KEY=sk-***

--- a/guides/python/tealtiger/governed-sandbox/.gitignore
+++ b/guides/python/tealtiger/governed-sandbox/.gitignore
@@ -1,0 +1,5 @@
+.env
+.venv
+venv
+__pycache__
+*.pyc

--- a/guides/python/tealtiger/governed-sandbox/README.md
+++ b/guides/python/tealtiger/governed-sandbox/README.md
@@ -1,0 +1,66 @@
+# TealTiger Governed Sandbox Example
+
+## Overview
+
+This example demonstrates a pre-execution governance pattern for AI-generated code. TealTiger evaluates the LLM output before the code reaches `sandbox.process.code_run()`, while Daytona provides the isolated runtime for code that passes the governance checks.
+
+Use this pattern when an agent generates code dynamically and you want a policy decision before the code can enter the sandbox filesystem, process logs, or network path.
+
+## Features
+
+- **Pre-execution governance:** TealTiger guardrails run before Daytona execution
+- **Sandbox isolation:** Approved code runs inside a Daytona sandbox, not on your machine
+- **Audit-friendly logging:** The example prints a receipt that links the governance step to the sandbox result
+- **Guaranteed cleanup:** The sandbox is deleted even when code generation or execution fails
+
+## Requirements
+
+- **Python:** Version 3.10 or higher
+- `DAYTONA_API_KEY`: Required for access to Daytona sandboxes. Get it from [Daytona Dashboard](https://app.daytona.io/dashboard/keys)
+- `OPENAI_API_KEY`: Required for the TealTiger OpenAI wrapper
+
+## Getting Started
+
+1. Create and activate a virtual environment:
+
+   ```bash
+   python3.10 -m venv venv
+   source venv/bin/activate  # On Windows: venv\Scripts\activate
+   ```
+
+2. Install dependencies:
+
+   ```bash
+   pip install -e .
+   ```
+
+3. Copy `.env.example` to `.env` and fill in your keys:
+
+   ```bash
+   DAYTONA_API_KEY=dtn_***
+   OPENAI_API_KEY=sk-***
+   ```
+
+4. Run the example:
+
+   ```bash
+   python governed_sandbox.py
+   ```
+
+## How It Works
+
+1. `generate_governed_code()` calls `TealOpenAI` with secret and prompt-injection guardrails enabled.
+2. TealTiger evaluates the generated code before the application passes it to Daytona.
+3. If governance raises an error, the script records a blocked receipt and never creates a Daytona sandbox.
+4. `run_in_daytona()` creates a Python sandbox and calls `sandbox.process.code_run(code)` only after the governed generation step succeeds.
+5. The script prints an execution receipt containing the governance provider, decision reason, sandbox ID, exit code, and whether execution was allowed.
+6. The sandbox is deleted in a `finally` block.
+
+## License
+
+See the main project LICENSE file for details.
+
+## References
+
+- [TealTiger](https://github.com/agentguard-ai/tealtiger)
+- [Daytona Documentation](https://www.daytona.io/docs)

--- a/guides/python/tealtiger/governed-sandbox/governed_sandbox.py
+++ b/guides/python/tealtiger/governed-sandbox/governed_sandbox.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Daytona Platforms Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, dataclass
+
+from dotenv import load_dotenv
+
+# pylint: disable=import-error
+from daytona import CreateSandboxFromSnapshotParams, Daytona
+from tealtiger import TealOpenAI
+
+MODEL = "gpt-4o-mini"
+
+
+@dataclass
+class ExecutionReceipt:
+    governance_provider: str
+    allowed: bool
+    reason: str
+    sandbox_id: str | None
+    exit_code: int | None
+    result_preview: str
+
+
+def generate_governed_code(prompt: str) -> str:
+    client = TealOpenAI(
+        api_key=os.environ["OPENAI_API_KEY"],
+        guardrails={
+            "secret_detection": True,
+            "prompt_injection": True,
+        },
+        budget={
+            "max_cost_per_session": 2.00,
+        },
+    )
+
+    response = client.chat.completions.create(
+        model=MODEL,
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Generate a short, self-contained Python script. "
+                    "Return only executable Python code, with no markdown fences."
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ],
+    )
+
+    return response.choices[0].message.content or ""
+
+
+def run_in_daytona(code: str) -> ExecutionReceipt:
+    daytona = Daytona()
+    sandbox = None
+
+    try:
+        sandbox = daytona.create(CreateSandboxFromSnapshotParams(language="python"))
+        result = sandbox.process.code_run(code)
+        return ExecutionReceipt(
+            governance_provider="tealtiger",
+            allowed=True,
+            reason="Governed generation succeeded before Daytona execution",
+            sandbox_id=sandbox.id,
+            exit_code=result.exit_code,
+            result_preview=result.result[:500],
+        )
+    finally:
+        if sandbox is not None:
+            daytona.delete(sandbox)
+
+
+def print_receipt(receipt: ExecutionReceipt) -> None:
+    print("\nExecution receipt")
+    for key, value in asdict(receipt).items():
+        print(f"{key}: {value}")
+
+
+def main() -> None:
+    load_dotenv()
+
+    prompt = "Write Python code that calculates the first 10 Fibonacci numbers and prints them."
+    print("Generating governed code...")
+    try:
+        code = generate_governed_code(prompt)
+    except Exception as exc:
+        print_receipt(
+            ExecutionReceipt(
+                governance_provider="tealtiger",
+                allowed=False,
+                reason=f"Governance blocked code before Daytona execution: {exc}",
+                sandbox_id=None,
+                exit_code=None,
+                result_preview="",
+            )
+        )
+        return
+
+    print("\nApproved code")
+    print("-" * 60)
+    print(code)
+    print("-" * 60)
+
+    print("\nRunning approved code in Daytona...")
+    receipt = run_in_daytona(code)
+    print_receipt(receipt)
+
+
+if __name__ == "__main__":
+    main()

--- a/guides/python/tealtiger/governed-sandbox/pyproject.toml
+++ b/guides/python/tealtiger/governed-sandbox/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tealtiger-governed-sandbox"
+version = "0.1.0"
+description = "Pre-execution governance for Daytona sandbox code with TealTiger"
+authors = [
+    {name = "Daytona Team", email = "support@daytona.io"}
+]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "daytona>=0.1.0,<1.0.0",
+    "openai>=1.3.0,<2.0.0",
+    "python-dotenv>=1.0.0,<2.0.0",
+    "tealtiger>=1.3.0,<2.0.0"
+]


### PR DESCRIPTION
## Summary

Addresses #5036.

Adds a TealTiger + Daytona governed sandbox guide showing how to place a pre-execution governance step before `sandbox.process.code_run()`.

## Changes

- Add a runnable Python guide under `guides/python/tealtiger/governed-sandbox`
- Demonstrate TealTiger guarded code generation before Daytona sandbox execution
- Record a blocked receipt when governance fails before sandbox creation
- Add the docs page and sidebar/i18n entries for the new guide

## Testing

- `python -m py_compile guides/python/tealtiger/governed-sandbox/governed_sandbox.py`
- `python -m json.tool apps/docs/src/content/i18n/en.json`
- `python -m json.tool apps/docs/src/content/i18n/ja.json`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TealTiger + Daytona governed sandbox guide and runnable Python example. Adds a pre-execution governance step before `sandbox.process.code_run()` to block unsafe code and emit an execution receipt, addressing #5036.

- New Features
  - New docs page: Govern AI-generated code with TealTiger + Daytona, including workflow and core pattern.
  - Runnable example in `guides/python/tealtiger/governed-sandbox` using `tealtiger`, `daytona`, `openai`, and `python-dotenv`, with `pyproject.toml` and `.env.example`.
  - Governance checks for secret detection, prompt injection, and session budget; records a blocked receipt and skips sandbox creation on failure.
  - Adds sidebar link and i18n keys for the TealTiger guide.

<sup>Written for commit 7cf99cf99ad2e08f12f84aeb14199b53b99e4e11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

