### PR TITLE
feat(docs): add default snapshots

### DIFF
--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -1062,13 +1062,20 @@ Sandboxes have **1 vCPU**, **1GB RAM**, and **3GiB disk** by default. Organizati
 
 ##### Pre-built snapshots
 
-Daytona provides pre-built [default snapshots](/docs/en/snapshots#default-snapshots) with fixed resource sizes for creating sandboxes.
+Daytona provides [pre-built snapshots](/docs/en/snapshots#default-snapshots) with fixed resource sizes for creating sandboxes.
 
-| **Snapshot**         | **vCPU** | **Memory** | **Storage** |
-| -------------------- | -------- | ---------- | ----------- |
-| **`daytona-small`**  | 1        | 1GiB       | 3GiB        |
-| **`daytona-medium`** | 2        | 4GiB       | 8GiB        |
-| **`daytona-large`**  | 4        | 8GiB       | 10GiB       |
+| **Snapshot**         | **vCPU** | **Memory** | **Storage** | **GPU** |
+| -------------------- | -------- | ---------- | ----------- | ------- |
+| **`daytona-small`**  | 1        | 1GiB       | 3GiB        |         |
+| **`daytona-medium`** | 2        | 4GiB       | 8GiB        |         |
+| **`daytona-large`**  | 4        | 8GiB       | 10GiB       |         |
+| **`daytona-gpu`**    | 1        | 1GiB       | 1GiB        | 1       |
+| **`windows`**        | 2        | 8GiB       | 30GiB       |         |
+| **`android-12`**     | 4        | 8GiB       | 30GiB       |         |
+| **`android-13`**     | 4        | 8GiB       | 30GiB       |         |
+| **`android-14`**     | 4        | 8GiB       | 30GiB       |         |
+| **`android-15`**     | 4        | 8GiB       | 30GiB       |         |
+| **`android-16`**     | 4        | 8GiB       | 30GiB       |         |
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -1071,11 +1071,6 @@ Daytona provides [pre-built snapshots](/docs/en/snapshots#default-snapshots) wit
 | **`daytona-large`**  | 4        | 8GiB       | 10GiB       |         |
 | **`daytona-gpu`**    | 1        | 1GiB       | 1GiB        | 1       |
 | **`windows`**        | 2        | 8GiB       | 30GiB       |         |
-| **`android-12`**     | 4        | 8GiB       | 30GiB       |         |
-| **`android-13`**     | 4        | 8GiB       | 30GiB       |         |
-| **`android-14`**     | 4        | 8GiB       | 30GiB       |         |
-| **`android-15`**     | 4        | 8GiB       | 30GiB       |         |
-| **`android-16`**     | 4        | 8GiB       | 30GiB       |         |
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -1270,11 +1270,6 @@ Daytona provides pre-built snapshots with fixed resource sizes for creating sand
 | **`daytona-large`**  | 4        | 8GiB       | 10GiB       |         |
 | **`daytona-gpu`**    | 1        | 1GiB       | 1GiB        | 1       |
 | **`windows`**        | 2        | 8GiB       | 30GiB       |         |
-| **`android-12`**     | 4        | 8GiB       | 30GiB       |         |
-| **`android-13`**     | 4        | 8GiB       | 30GiB       |         |
-| **`android-14`**     | 4        | 8GiB       | 30GiB       |         |
-| **`android-15`**     | 4        | 8GiB       | 30GiB       |         |
-| **`android-16`**     | 4        | 8GiB       | 30GiB       |         |
 
 Snapshots are based on the `daytonaio/sandbox:<version>` image.
 

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -1261,15 +1261,22 @@ console.log(pods.result)
 
 ## Default Snapshots
 
-When a sandbox is created with no snapshot specified, Daytona uses a default snapshot that includes `python`, `node`, their language servers, and several common pip packages. Daytona provides three default snapshot sizes:
+Daytona provides pre-built snapshots with fixed resource sizes for creating sandboxes.
 
-| **Snapshot**         | **vCPU** | **Memory** | **Storage** |
-| -------------------- | -------- | ---------- | ----------- |
-| **`daytona-small`**  | 1        | 1GiB       | 3GiB        |
-| **`daytona-medium`** | 2        | 4GiB       | 8GiB        |
-| **`daytona-large`**  | 4        | 8GiB       | 10GiB       |
+| **Snapshot**         | **vCPU** | **Memory** | **Storage** | **GPU** |
+| -------------------- | -------- | ---------- | ----------- | ------- |
+| **`daytona-small`**  | 1        | 1GiB       | 3GiB        |         |
+| **`daytona-medium`** | 2        | 4GiB       | 8GiB        |         |
+| **`daytona-large`**  | 4        | 8GiB       | 10GiB       |         |
+| **`daytona-gpu`**    | 1        | 1GiB       | 1GiB        | 1       |
+| **`windows`**        | 2        | 8GiB       | 30GiB       |         |
+| **`android-12`**     | 4        | 8GiB       | 30GiB       |         |
+| **`android-13`**     | 4        | 8GiB       | 30GiB       |         |
+| **`android-14`**     | 4        | 8GiB       | 30GiB       |         |
+| **`android-15`**     | 4        | 8GiB       | 30GiB       |         |
+| **`android-16`**     | 4        | 8GiB       | 30GiB       |         |
 
-All default snapshots are based on the `daytonaio/sandbox:<version>` image. For more information, see the [Dockerfile](https://github.com/daytonaio/daytona/blob/main/images/sandbox/Dockerfile).
+Snapshots are based on the `daytonaio/sandbox:<version>` image.
 
 ### Python packages (pip)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated docs to list pre-built snapshots with vCPU, memory, storage, and GPU columns; adds `daytona-gpu` and `windows`, and removes Android. Aligns the Sandboxes and Snapshots pages and clarifies snapshots are based on `daytonaio/sandbox:<version>`.

<sup>Written for commit 6a7dd76dbc87a0a15a945607ef198b6f46bd1209. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

