### PR TITLE
fix(api): invalidate proxy preview-token cache on auth token rotation

### DIFF
--- a/apps/api/src/sandbox/constants/sandbox-events.constants.ts
+++ b/apps/api/src/sandbox/constants/sandbox-events.constants.ts
@@ -12,6 +12,7 @@ export const SandboxEvents = {
   STOPPED: 'sandbox.stopped',
   DESTROYED: 'sandbox.destroyed',
   PUBLIC_STATUS_UPDATED: 'sandbox.public-status.updated',
+  AUTH_TOKEN_ROTATED: 'sandbox.auth-token.rotated',
   ORGANIZATION_UPDATED: 'sandbox.organization.updated',
   BACKUP_CREATED: 'sandbox.backup.created',
 } as const

--- a/apps/api/src/sandbox/events/sandbox-auth-token-rotated.event.ts
+++ b/apps/api/src/sandbox/events/sandbox-auth-token-rotated.event.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Daytona Platforms Inc.
+ * Copyright Daytona Platforms Inc.
  * SPDX-License-Identifier: AGPL-3.0
  */
 

--- a/apps/api/src/sandbox/events/sandbox-auth-token-rotated.event.ts
+++ b/apps/api/src/sandbox/events/sandbox-auth-token-rotated.event.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Sandbox } from '../entities/sandbox.entity'
+
+export class SandboxAuthTokenRotatedEvent {
+  constructor(
+    public readonly sandbox: Sandbox,
+    public readonly previousAuthToken: string,
+    public readonly newAuthToken: string,
+  ) {}
+}

--- a/apps/api/src/sandbox/repositories/sandbox.repository.ts
+++ b/apps/api/src/sandbox/repositories/sandbox.repository.ts
@@ -15,6 +15,7 @@ import { SandboxEvents } from '../constants/sandbox-events.constants'
 import { SandboxStateUpdatedEvent } from '../events/sandbox-state-updated.event'
 import { SandboxDesiredStateUpdatedEvent } from '../events/sandbox-desired-state-updated.event'
 import { SandboxPublicStatusUpdatedEvent } from '../events/sandbox-public-status-updated.event'
+import { SandboxAuthTokenRotatedEvent } from '../events/sandbox-auth-token-rotated.event'
 import { SandboxOrganizationUpdatedEvent } from '../events/sandbox-organization-updated.event'
 import { SandboxLookupCacheInvalidationService } from '../services/sandbox-lookup-cache-invalidation.service'
 import { SandboxFork } from '../entities/sandbox-fork.entity'
@@ -253,7 +254,7 @@ export class SandboxRepository extends BaseRepository<Sandbox> {
    */
   private emitUpdateEvents(
     updatedSandbox: Sandbox,
-    previousSandbox: Pick<Sandbox, 'state' | 'desiredState' | 'public' | 'organizationId'>,
+    previousSandbox: Pick<Sandbox, 'state' | 'desiredState' | 'public' | 'organizationId' | 'authToken'>,
   ): void {
     if (previousSandbox.state !== updatedSandbox.state) {
       this.eventEmitter.emit(
@@ -273,6 +274,13 @@ export class SandboxRepository extends BaseRepository<Sandbox> {
       this.eventEmitter.emit(
         SandboxEvents.PUBLIC_STATUS_UPDATED,
         new SandboxPublicStatusUpdatedEvent(updatedSandbox, previousSandbox.public, updatedSandbox.public),
+      )
+    }
+
+    if (previousSandbox.authToken !== updatedSandbox.authToken) {
+      this.eventEmitter.emit(
+        SandboxEvents.AUTH_TOKEN_ROTATED,
+        new SandboxAuthTokenRotatedEvent(updatedSandbox, previousSandbox.authToken, updatedSandbox.authToken),
       )
     }
 

--- a/apps/api/src/sandbox/services/proxy-cache-invalidation.service.spec.ts
+++ b/apps/api/src/sandbox/services/proxy-cache-invalidation.service.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Daytona Platforms Inc.
+ * Copyright Daytona Platforms Inc.
  * SPDX-License-Identifier: AGPL-3.0
  */
 

--- a/apps/api/src/sandbox/services/proxy-cache-invalidation.service.spec.ts
+++ b/apps/api/src/sandbox/services/proxy-cache-invalidation.service.spec.ts
@@ -17,17 +17,42 @@ describe('[SANDBOX] preview auth token rotation cache invalidation', () => {
       return { service, redis }
     }
 
-    it('evicts the proxy auth-key cache entry for the PREVIOUS token, not the new one', async () => {
+    it('evicts both the API-side and proxy-side caches for the PREVIOUS token, not the new one', async () => {
       const { service, redis } = createService()
 
       await service.handleSandboxAuthTokenRotated(
         new SandboxAuthTokenRotatedEvent({ id: 'sandbox-1' } as Sandbox, 'old-token', 'new-token'),
       )
 
-      // Must target the rotated-out token so it stops authorizing immediately.
+      // Must target the rotated-out token on BOTH cache layers so it stops authorizing immediately.
+      // The API-side preview:token cache re-poisons the proxy cache on the next miss if left in place.
+      expect(redis.del).toHaveBeenCalledWith('preview:token:sandbox-1:old-token')
       expect(redis.del).toHaveBeenCalledWith('proxy:sandbox-auth-key-valid:sandbox-1:old-token')
       // Deleting the new token would be a no-op and leave the stale entry alive.
       expect(redis.del).not.toHaveBeenCalledWith(expect.stringContaining('new-token'))
+    })
+
+    // Ordering is the correctness property: the proxy only re-queries the API on a cache miss,
+    // and a miss can only happen after the proxy key is gone. If the proxy key were evicted first,
+    // a request landing in the gap would re-validate against the still-cached API decision and
+    // re-poison the proxy's longer-lived cache. The API-side key must be evicted first.
+    it('evicts the API-side cache before the proxy-side cache', async () => {
+      const { service, redis } = createService()
+
+      await service.handleSandboxAuthTokenRotated(
+        new SandboxAuthTokenRotatedEvent({ id: 'sandbox-1' } as Sandbox, 'old-token', 'new-token'),
+      )
+
+      const apiKey = 'preview:token:sandbox-1:old-token'
+      const proxyKey = 'proxy:sandbox-auth-key-valid:sandbox-1:old-token'
+      const apiCallIndex = redis.del.mock.calls.findIndex((args) => args[0] === apiKey)
+      const proxyCallIndex = redis.del.mock.calls.findIndex((args) => args[0] === proxyKey)
+
+      expect(apiCallIndex).toBeGreaterThanOrEqual(0)
+      expect(proxyCallIndex).toBeGreaterThanOrEqual(0)
+      expect(redis.del.mock.invocationCallOrder[apiCallIndex]).toBeLessThan(
+        redis.del.mock.invocationCallOrder[proxyCallIndex],
+      )
     })
 
     it('does nothing when there is no previous token', async () => {

--- a/apps/api/src/sandbox/services/proxy-cache-invalidation.service.spec.ts
+++ b/apps/api/src/sandbox/services/proxy-cache-invalidation.service.spec.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { SandboxEvents } from '../constants/sandbox-events.constants'
+import { Sandbox } from '../entities/sandbox.entity'
+import { SandboxAuthTokenRotatedEvent } from '../events/sandbox-auth-token-rotated.event'
+import { SandboxRepository } from '../repositories/sandbox.repository'
+import { ProxyCacheInvalidationService } from './proxy-cache-invalidation.service'
+
+describe('[SANDBOX] preview auth token rotation cache invalidation', () => {
+  describe('ProxyCacheInvalidationService', () => {
+    function createService() {
+      const redis = { del: jest.fn().mockResolvedValue(1) }
+      const service = new ProxyCacheInvalidationService(redis as never)
+      return { service, redis }
+    }
+
+    it('evicts the proxy auth-key cache entry for the PREVIOUS token, not the new one', async () => {
+      const { service, redis } = createService()
+
+      await service.handleSandboxAuthTokenRotated(
+        new SandboxAuthTokenRotatedEvent({ id: 'sandbox-1' } as Sandbox, 'old-token', 'new-token'),
+      )
+
+      // Must target the rotated-out token so it stops authorizing immediately.
+      expect(redis.del).toHaveBeenCalledWith('proxy:sandbox-auth-key-valid:sandbox-1:old-token')
+      // Deleting the new token would be a no-op and leave the stale entry alive.
+      expect(redis.del).not.toHaveBeenCalledWith(expect.stringContaining('new-token'))
+    })
+
+    it('does nothing when there is no previous token', async () => {
+      const { service, redis } = createService()
+
+      await service.handleSandboxAuthTokenRotated(
+        new SandboxAuthTokenRotatedEvent({ id: 'sandbox-1' } as Sandbox, '', 'new-token'),
+      )
+
+      expect(redis.del).not.toHaveBeenCalled()
+    })
+
+    it('does not throw if redis fails', async () => {
+      const redis = { del: jest.fn().mockRejectedValue(new Error('redis down')) }
+      const service = new ProxyCacheInvalidationService(redis as never)
+
+      await expect(
+        service.handleSandboxAuthTokenRotated(
+          new SandboxAuthTokenRotatedEvent({ id: 'sandbox-1' } as Sandbox, 'old-token', 'new-token'),
+        ),
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe('SandboxRepository.emitUpdateEvents', () => {
+    function createRepository() {
+      const eventEmitter = { emit: jest.fn() }
+      const dataSource = { getRepository: jest.fn().mockReturnValue({}) }
+      const lookupCache = { invalidate: jest.fn(), invalidateOrgId: jest.fn() }
+      const repository = new SandboxRepository(dataSource as never, eventEmitter as never, lookupCache as never)
+      return { repository, eventEmitter }
+    }
+
+    const base = {
+      id: 'sandbox-1',
+      state: 'started',
+      desiredState: 'started',
+      public: false,
+      organizationId: 'org-1',
+    }
+
+    function rotatedEvents(emit: jest.Mock) {
+      return emit.mock.calls.filter((call) => call[0] === SandboxEvents.AUTH_TOKEN_ROTATED)
+    }
+
+    it('emits AUTH_TOKEN_ROTATED carrying the previous token when authToken changes', () => {
+      const { repository, eventEmitter } = createRepository()
+
+      const previous = { ...base, authToken: 'old-token' }
+      const updated = { ...base, authToken: 'new-token' }
+
+      ;(repository as unknown as { emitUpdateEvents: (u: unknown, p: unknown) => void }).emitUpdateEvents(
+        updated,
+        previous,
+      )
+
+      const calls = rotatedEvents(eventEmitter.emit)
+      expect(calls).toHaveLength(1)
+      const event = calls[0][1] as SandboxAuthTokenRotatedEvent
+      expect(event.previousAuthToken).toBe('old-token')
+      expect(event.newAuthToken).toBe('new-token')
+    })
+
+    it('does not emit AUTH_TOKEN_ROTATED when authToken is unchanged', () => {
+      const { repository, eventEmitter } = createRepository()
+
+      const previous = { ...base, authToken: 'same-token' }
+      const updated = { ...base, authToken: 'same-token' }
+
+      ;(repository as unknown as { emitUpdateEvents: (u: unknown, p: unknown) => void }).emitUpdateEvents(
+        updated,
+        previous,
+      )
+
+      expect(rotatedEvents(eventEmitter.emit)).toHaveLength(0)
+    })
+  })
+})

--- a/apps/api/src/sandbox/services/proxy-cache-invalidation.service.ts
+++ b/apps/api/src/sandbox/services/proxy-cache-invalidation.service.ts
@@ -10,6 +10,7 @@ import Redis from 'ioredis'
 
 import { SandboxEvents } from '../constants/sandbox-events.constants'
 import { SandboxArchivedEvent } from '../events/sandbox-archived.event'
+import { SandboxAuthTokenRotatedEvent } from '../events/sandbox-auth-token-rotated.event'
 import { SandboxPublicStatusUpdatedEvent } from '../events/sandbox-public-status-updated.event'
 
 @Injectable()
@@ -17,6 +18,7 @@ export class ProxyCacheInvalidationService {
   private readonly logger = new Logger(ProxyCacheInvalidationService.name)
   private static readonly RUNNER_INFO_CACHE_PREFIX = 'proxy:sandbox-runner-info:'
   private static readonly PUBLIC_CACHE_PREFIX = 'proxy:sandbox-public:'
+  private static readonly AUTH_KEY_VALID_CACHE_PREFIX = 'proxy:sandbox-auth-key-valid:'
 
   constructor(@InjectRedis() private readonly redis: Redis) {}
 
@@ -28,6 +30,11 @@ export class ProxyCacheInvalidationService {
   @OnEvent(SandboxEvents.PUBLIC_STATUS_UPDATED)
   async handleSandboxPublicStatusUpdated(event: SandboxPublicStatusUpdatedEvent): Promise<void> {
     await this.invalidatePublicCache(event.sandbox.id)
+  }
+
+  @OnEvent(SandboxEvents.AUTH_TOKEN_ROTATED)
+  async handleSandboxAuthTokenRotated(event: SandboxAuthTokenRotatedEvent): Promise<void> {
+    await this.invalidateAuthKeyValidCache(event.sandbox.id, event.previousAuthToken)
   }
 
   private async invalidateRunnerCache(sandboxId: string): Promise<void> {
@@ -45,6 +52,23 @@ export class ProxyCacheInvalidationService {
       this.logger.debug(`Invalidated sandbox public cache for ${sandboxId}`)
     } catch (error) {
       this.logger.warn(`Failed to invalidate public cache for sandbox ${sandboxId}: ${error.message}`)
+    }
+  }
+
+  // The proxy caches a positive (sandboxId, authKey) validation decision for up to two minutes.
+  // When the auth token rotates, evict the stale decision for the previous token so it stops
+  // authorizing immediately instead of remaining valid until the cache entry expires.
+  private async invalidateAuthKeyValidCache(sandboxId: string, previousAuthToken: string): Promise<void> {
+    if (!previousAuthToken) {
+      return
+    }
+    try {
+      await this.redis.del(
+        `${ProxyCacheInvalidationService.AUTH_KEY_VALID_CACHE_PREFIX}${sandboxId}:${previousAuthToken}`,
+      )
+      this.logger.debug(`Invalidated sandbox auth key valid cache for ${sandboxId}`)
+    } catch (error) {
+      this.logger.warn(`Failed to invalidate auth key valid cache for sandbox ${sandboxId}: ${error.message}`)
     }
   }
 }

--- a/apps/api/src/sandbox/services/proxy-cache-invalidation.service.ts
+++ b/apps/api/src/sandbox/services/proxy-cache-invalidation.service.ts
@@ -19,6 +19,7 @@ export class ProxyCacheInvalidationService {
   private static readonly RUNNER_INFO_CACHE_PREFIX = 'proxy:sandbox-runner-info:'
   private static readonly PUBLIC_CACHE_PREFIX = 'proxy:sandbox-public:'
   private static readonly AUTH_KEY_VALID_CACHE_PREFIX = 'proxy:sandbox-auth-key-valid:'
+  private static readonly API_AUTH_TOKEN_CACHE_PREFIX = 'preview:token:'
 
   constructor(@InjectRedis() private readonly redis: Redis) {}
 
@@ -62,6 +63,20 @@ export class ProxyCacheInvalidationService {
     if (!previousAuthToken) {
       return
     }
+    // Evict the API-side decision cache BEFORE the proxy-side cache. The proxy only
+    // re-queries the API on a cache miss, and a miss can only occur after the proxy key
+    // is gone. Deleting the API key first guarantees any such re-query re-validates against
+    // the rotated token (now invalid) instead of reading a stale 'valid' decision and
+    // re-poisoning the proxy's longer-lived cache.
+    try {
+      await this.redis.del(
+        `${ProxyCacheInvalidationService.API_AUTH_TOKEN_CACHE_PREFIX}${sandboxId}:${previousAuthToken}`,
+      )
+      this.logger.debug(`Invalidated API auth-token cache for ${sandboxId}`)
+    } catch (error) {
+      this.logger.warn(`Failed to invalidate API auth-token cache for sandbox ${sandboxId}: ${error.message}`)
+    }
+
     try {
       await this.redis.del(
         `${ProxyCacheInvalidationService.AUTH_KEY_VALID_CACHE_PREFIX}${sandboxId}:${previousAuthToken}`,


### PR DESCRIPTION
## What

The external preview proxy caches a positive `(sandboxId, authToken)` validation decision for up to two minutes (`apps/proxy/pkg/proxy/get_sandbox_target.go`). The API rotates a sandbox's `authToken` on start/recover, but nothing evicted that proxy cache, so a rotated-out preview token kept authorizing the restarted private preview until the cached entry expired (~120s).

## Change

- Emit a `SandboxAuthTokenRotatedEvent` from `SandboxRepository.emitUpdateEvents` whenever `authToken` changes — this is reached by both `update` and `updateWhere`, so it covers all rotation paths (`start`, `recoverFromBackup`, `recoverInPlace`).
- `ProxyCacheInvalidationService` evicts `proxy:sandbox-auth-key-valid:<sandboxId>:<previousToken>` on that event, mirroring the existing public-status cache invalidation (#4918).
- Regression tests assert the **previous** (not new) token is the one carried and evicted, and that no event fires when the token is unchanged.

No proxy-side changes are needed: the proxy already reads this cache from the same Redis the API writes to.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Invalidate both API and proxy preview-token caches when a sandbox auth token rotates so stale tokens stop authorizing right after start/recover. Evict the API cache first to avoid re-poisoning the proxy cache.

- **Bug Fixes**
  - Emit `SandboxAuthTokenRotatedEvent` when `authToken` changes (covers start/recover paths).
  - On that event, delete `preview:token:<sandboxId>:<oldToken>` first, then `proxy:sandbox-auth-key-valid:<sandboxId>:<oldToken>`; skip if no previous token; log on Redis failures.
  - Tests assert previous token targeting, API-before-proxy ordering, and no event when the token is unchanged.

- **Refactors**
  - Use year-less copyright headers in new files.

<sup>Written for commit 30bf6ecbb4f6254519da4f0b9e9e23d0573b3d5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

