### PR TITLE
chore(docs): add curl install alternative for macOS

### DIFF
--- a/apps/docs/src/content/docs/en/getting-started.mdx
+++ b/apps/docs/src/content/docs/en/getting-started.mdx
@@ -39,6 +39,20 @@ To upgrade the Daytona CLI to the latest version:
 brew upgrade daytonaio/cli/daytona
 ```
 
+Alternatively, install directly without Homebrew:
+
+For Apple Silicon (`arm64`):
+
+  ```bash
+  sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-darwin-arm64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+  ```
+
+For Intel (`amd64`):
+
+  ```bash
+  sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-darwin-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+  ```
+
 </TabItem>
 <TabItem label="Linux">
 

--- a/apps/docs/src/content/docs/en/tools/cli.mdx
+++ b/apps/docs/src/content/docs/en/tools/cli.mdx
@@ -36,6 +36,20 @@ To upgrade the Daytona CLI to the latest version:
 brew upgrade daytonaio/cli/daytona
 ```
 
+Alternatively, install directly without Homebrew:
+
+For Apple Silicon (`arm64`):
+
+  ```bash
+  sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-darwin-arm64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+  ```
+
+For Intel (`amd64`):
+
+  ```bash
+  sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-darwin-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+  ```
+
 </TabItem>
 <TabItem label="Linux">
 

--- a/apps/docs/tools/update-cli-reference.js
+++ b/apps/docs/tools/update-cli-reference.js
@@ -49,6 +49,20 @@ To upgrade the Daytona CLI to the latest version:
 brew upgrade daytonaio/cli/daytona
 \`\`\`
 
+Alternatively, install directly without Homebrew:
+
+For Apple Silicon (\`arm64\`):
+
+  \`\`\`bash
+  sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-darwin-arm64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+  \`\`\`
+
+For Intel (\`amd64\`):
+
+  \`\`\`bash
+  sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-darwin-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+  \`\`\`
+
 </TabItem>
 <TabItem label="Linux">
 


### PR DESCRIPTION
## Add curl install alternative for macOS

Adds a direct `curl` installation option to the Mac tab in the CLI docs, giving users a
fallback that doesn't depend on Homebrew.

### Why

A recent Homebrew sandbox regression ([Homebrew/brew#22699](https://github.com/Homebrew/brew/issues/22699))
broke `brew install` / `brew upgrade` for all third-party taps, leaving users with no
documented way to install or update the Daytona CLI on macOS. The bug is fixed upstream,
but having a single-dependency alternative (`curl`) means future Homebrew issues won't
strand users.

### Changes

- **`apps/docs/src/content/docs/en/tools/cli.mdx`** — added "Alternatively, install
  directly without Homebrew" section to the Mac tab with per-arch `curl` commands
  (Apple Silicon + Intel).
- **`apps/docs/src/content/docs/en/getting-started.mdx`** — same change (identical
  install section).

Linux and Windows tabs are unchanged.

### Related

- Homebrew bug: https://github.com/Homebrew/brew/issues/22699
- Homebrew fix: https://github.com/Homebrew/brew/pull/22700
- Daytona CLI issues: https://github.com/daytonaio/homebrew-cli/issues/7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a curl-based install option for macOS in the CLI docs as a Homebrew-free fallback, with per-arch commands for `arm64` and `amd64`. Also updated `apps/docs/tools/update-cli-reference.js` to embed the same Mac install snippet so generated CLI docs stay in sync; Linux and Windows are unchanged.

<sup>Written for commit 5990d1b657e0b513c2b031e9ed7e7d57ee722e47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

