### PR TITLE
fix(proxy): bound preview auth cookie acceptance to its 1h lifetime

### DIFF
--- a/apps/proxy/pkg/proxy/auth.go
+++ b/apps/proxy/pkg/proxy/auth.go
@@ -134,7 +134,7 @@ func (p *Proxy) getSandboxIdFromSignedPreviewUrlToken(ctx *gin.Context, sandboxI
 		return "", fmt.Errorf("failed to encode cookie: %w", err)
 	}
 
-	ctx.SetCookie(SANDBOX_AUTH_COOKIE_NAME+sandboxIdOrSignedToken, encoded, 3600, "/", cookieDomain, p.config.EnableTLS, true)
+	ctx.SetCookie(SANDBOX_AUTH_COOKIE_NAME+sandboxIdOrSignedToken, encoded, SANDBOX_AUTH_COOKIE_MAX_AGE_SECONDS, "/", cookieDomain, p.config.EnableTLS, true)
 
 	return sandboxId, nil
 }

--- a/apps/proxy/pkg/proxy/auth_callback.go
+++ b/apps/proxy/pkg/proxy/auth_callback.go
@@ -124,7 +124,7 @@ func (p *Proxy) AuthCallback(ctx *gin.Context) {
 		return
 	}
 
-	ctx.SetCookie(SANDBOX_AUTH_COOKIE_NAME+sandboxId, encoded, 3600, "/", cookieDomain, p.config.EnableTLS, true)
+	ctx.SetCookie(SANDBOX_AUTH_COOKIE_NAME+sandboxId, encoded, SANDBOX_AUTH_COOKIE_MAX_AGE_SECONDS, "/", cookieDomain, p.config.EnableTLS, true)
 
 	// Redirect back to the original URL
 	ctx.Redirect(http.StatusFound, returnTo)

--- a/apps/proxy/pkg/proxy/proxy.go
+++ b/apps/proxy/pkg/proxy/proxy.go
@@ -38,6 +38,13 @@ type RunnerInfo struct {
 const SANDBOX_AUTH_KEY_HEADER = "X-Daytona-Preview-Token"
 const SANDBOX_AUTH_KEY_QUERY_PARAM = "DAYTONA_SANDBOX_AUTH_KEY"
 const SANDBOX_AUTH_COOKIE_NAME = "daytona-sandbox-auth-"
+
+// SANDBOX_AUTH_COOKIE_MAX_AGE_SECONDS bounds both the auth cookie's browser
+// Max-Age and the shared securecookie signer's server-side acceptance window.
+// Without an explicit signer MaxAge, gorilla/securecookie accepts a copied
+// cookie value for its 30-day default, well past the 1h the browser is told.
+const SANDBOX_AUTH_COOKIE_MAX_AGE_SECONDS = 3600
+
 const SKIP_LAST_ACTIVITY_UPDATE_HEADER = "X-Daytona-Skip-Last-Activity-Update"
 const ACTIVITY_POLL_STOP_KEY = "daytona-activity-poll-stop"
 const TERMINAL_PORT = "22222"
@@ -74,6 +81,10 @@ func StartProxy(ctx context.Context, config *config.Config) error {
 	}
 
 	proxy.secureCookie = securecookie.New([]byte(config.ProxyApiKey), nil)
+	// Reject signed cookies older than their advertised lifetime instead of the
+	// gorilla/securecookie 30-day default, so a captured cookie cannot be replayed
+	// out-of-browser long after it should have expired.
+	proxy.secureCookie.MaxAge(SANDBOX_AUTH_COOKIE_MAX_AGE_SECONDS)
 	if config.CookieDomain != nil {
 		cookieDomain := GetCookieDomainFromHost(*config.CookieDomain)
 		proxy.cookieDomain = &cookieDomain


### PR DESCRIPTION
## What

The proxy signs the sandbox preview auth cookie (`daytona-sandbox-auth-<id>`) with a `gorilla/securecookie` instance that never had `MaxAge` set. The browser is told `Max-Age=3600` (1h), but the signer accepted a presented cookie value for the library default (**30 days**) — so a copied cookie could be replayed out-of-browser long after its advertised lifetime.

## Change

- Call `MaxAge` on the shared securecookie signer so it rejects cookies older than the cookie's 1h lifetime, instead of the 30-day default.
- Route both the cookie `Max-Age` (two `SetCookie` sites) and the signer window through one constant (`SANDBOX_AUTH_COOKIE_MAX_AGE_SECONDS`) so they cannot drift apart.

The shared signer is also used for the short-lived `pkce_verifier` cookie (300s, consumed within the OAuth callback), which is unaffected — its lifetime is already well under 1h.

No regression test is included: `gorilla/securecookie@v1.1.2` keeps its timestamp hook private, so `MaxAge` expiry can't be unit-tested without real-time sleeps. Verified against the library source (default `maxAge = 86400 * 30`; `Decode` enforces `MaxAge`) plus build/vet/existing tests.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the preview auth cookie to its 1-hour lifetime to prevent replay after expiry. Set the `gorilla/securecookie` signer `MaxAge` to 3600 and unified cookie `Max-Age` via a shared constant.

- Bug Fixes
  - Set signer `MaxAge` to `SANDBOX_AUTH_COOKIE_MAX_AGE_SECONDS` (3600).
  - Use the same constant for both `SetCookie` calls to keep browser and server in sync.
  - Prevents replay of copied `daytona-sandbox-auth-*` cookies beyond 1 hour.

<sup>Written for commit a944e044cdc87c48c17045cc69859dddb54f621b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

