### PR TITLE
chore(docs): correct Java SDK Maven coordinates and stale TypeScript package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Gradle (`build.gradle.kts`):
 
 ```kotlin
 dependencies {
-    implementation("io.daytona:sdk:0.1.0")
+    implementation("io.daytona:sdk:x.y.z")
 }
 ```
 
@@ -135,7 +135,7 @@ Maven (`pom.xml`):
 <dependency>
   <groupId>io.daytona</groupId>
   <artifactId>sdk</artifactId>
-  <version>0.1.0</version>
+  <version>x.y.z</version>
 </dependency>
 ```
 

--- a/apps/docs/src/content/docs/en/index.mdx
+++ b/apps/docs/src/content/docs/en/index.mdx
@@ -87,7 +87,7 @@ Add the Daytona SDK dependency to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("io.daytona:sdk-java:0.1.0")
+    implementation("io.daytona:sdk:x.y.z")
 }
 ```
 
@@ -98,8 +98,8 @@ Add the Daytona SDK dependency to your `pom.xml`:
 ```xml
 <dependency>
   <groupId>io.daytona</groupId>
-  <artifactId>sdk-java</artifactId>
-  <version>0.1.0</version>
+  <artifactId>sdk</artifactId>
+  <version>x.y.z</version>
 </dependency>
 ```
 

--- a/apps/docs/src/content/docs/en/java-sdk/index.mdx
+++ b/apps/docs/src/content/docs/en/java-sdk/index.mdx
@@ -14,7 +14,7 @@ Add the Daytona SDK dependency to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("io.daytona:sdk-java:0.1.0")
+    implementation("io.daytona:sdk:x.y.z")
 }
 ```
 
@@ -25,8 +25,8 @@ Add the Daytona SDK dependency to your `pom.xml`:
 ```xml
 <dependency>
   <groupId>io.daytona</groupId>
-  <artifactId>sdk-java</artifactId>
-  <version>0.1.0</version>
+  <artifactId>sdk</artifactId>
+  <version>x.y.z</version>
 </dependency>
 ```
 

--- a/apps/docs/src/content/docs/en/vpn-connections.mdx
+++ b/apps/docs/src/content/docs/en/vpn-connections.mdx
@@ -948,7 +948,7 @@ if __name__ == "__main__":
 <TabItem label="TypeScript" icon="seti:typescript">
 
 ```typescript
-import { Daytona } from '@daytonaio/sdk';
+import { Daytona } from '@daytona/sdk';
 
 // Configuration
 const DAYTONA_API_KEY = "YOUR_API_KEY";
@@ -1136,7 +1136,7 @@ if __name__ == "__main__":
 <TabItem label="TypeScript" icon="seti:typescript">
 
 ```typescript
-import { Daytona } from '@daytonaio/sdk';
+import { Daytona } from '@daytona/sdk';
 
 // Configuration
 const DAYTONA_API_KEY = "YOUR_API_KEY";

--- a/libs/sdk-java/README.md
+++ b/libs/sdk-java/README.md
@@ -10,7 +10,7 @@ Add the dependency using **Gradle**:
 
 ```kotlin
 dependencies {
-    implementation("io.daytona:sdk:0.1.0")
+    implementation("io.daytona:sdk:x.y.z")
 }
 ```
 
@@ -20,7 +20,7 @@ or using **Maven**:
 <dependency>
   <groupId>io.daytona</groupId>
   <artifactId>sdk</artifactId>
-  <version>0.1.0</version>
+  <version>x.y.z</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Description

Fixes incorrect SDK references that cause agent and developer confusion:

### Java SDK Maven coordinates
The documented artifact ID `sdk-java` does not exist on Maven Central — the actual published artifact is `sdk` under group `io.daytona`. The hardcoded version `0.1.0` was also stale. Replaced with `x.y.z` placeholder to match the convention used by other SDK install snippets (npm/pip/gem don't pin versions either).

### TypeScript package name
Two code examples in `vpn-connections.mdx` still imported from the old `@daytonaio/sdk` package instead of `@daytona/sdk`.

### Changed files
- `README.md` — Java install snippet version
- `apps/docs/src/content/docs/en/index.mdx` — Java install snippet artifact ID + version
- `apps/docs/src/content/docs/en/java-sdk/index.mdx` — Java install snippet artifact ID + version
- `libs/sdk-java/README.md` — Java install snippet version
- `apps/docs/src/content/docs/en/vpn-connections.mdx` — `@daytonaio/sdk` → `@daytona/sdk` (2 occurrences)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Java SDK install snippets and TypeScript imports in docs to match published artifacts and avoid install errors.

- **Bug Fixes**
  - Java: use `io.daytona:sdk` (not `sdk-java`) and set version to `x.y.z` in Gradle/Maven snippets.
  - TypeScript: switch imports from `@daytonaio/sdk` to `@daytona/sdk` in `vpn-connections.mdx`.

<sup>Written for commit 0c449853284d6ed41b2d9d067b4ebcbb851f4930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

