### PR TITLE
build(images): pin Go toolchain to 1.25.11 and align Alpine hardening

### DIFF
--- a/apps/otel-collector/Dockerfile
+++ b/apps/otel-collector/Dockerfile
@@ -1,10 +1,12 @@
+FROM golang:1.25.11-alpine AS go-toolchain
+
 FROM node:22-alpine AS build
 
 ENV CI=true
 
 RUN npm install -g corepack && corepack enable
 
-COPY --from=golang:1.25.4-alpine /usr/local/go/ /usr/local/go/
+COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
@@ -43,7 +45,8 @@ RUN yarn nx build otel-collector --configuration=production --nxBail=true
 
 FROM alpine:3.23 AS otel-collector
 
-RUN apk add --no-cache curl
+RUN apk update && apk upgrade --no-cache openssl pcre2 \
+  && apk add --no-cache curl
 
 WORKDIR /usr/local/bin
 

--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -1,10 +1,12 @@
+FROM golang:1.25.11-alpine AS go-toolchain
+
 FROM node:22-alpine AS build
 
 ENV CI=true
 
 RUN npm install -g corepack && corepack enable
 
-COPY --from=golang:1.25.7-alpine /usr/local/go/ /usr/local/go/
+COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -1,10 +1,12 @@
+FROM golang:1.25.11-alpine AS go-toolchain
+
 FROM node:22-alpine AS build
 
 ENV CI=true
 
 RUN npm install -g corepack && corepack enable
 
-COPY --from=golang:1.25.7-alpine /usr/local/go/ /usr/local/go/
+COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 

--- a/apps/snapshot-manager/Dockerfile
+++ b/apps/snapshot-manager/Dockerfile
@@ -1,10 +1,12 @@
+FROM golang:1.25.11-alpine AS go-toolchain
+
 FROM node:22-alpine AS build
 
 ENV CI=true
 
 RUN npm install -g corepack && corepack enable
 
-COPY --from=golang:1.25.4-alpine /usr/local/go/ /usr/local/go/
+COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
@@ -38,7 +40,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM alpine:3.23 AS snapshot-manager
 
-RUN apk add --no-cache curl
+RUN apk update && apk upgrade --no-cache openssl pcre2 \
+  && apk add --no-cache curl
 
 WORKDIR /usr/local/bin
 

--- a/apps/ssh-gateway/Dockerfile
+++ b/apps/ssh-gateway/Dockerfile
@@ -1,10 +1,12 @@
+FROM golang:1.25.11-alpine AS go-toolchain
+
 FROM node:22-alpine AS build
 
 ENV CI=true
 
 RUN npm install -g corepack && corepack enable
 
-COPY --from=golang:1.25.4-alpine /usr/local/go/ /usr/local/go/
+COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
@@ -37,6 +39,8 @@ COPY libs/api-client-go/ libs/api-client-go/
 RUN yarn nx build ssh-gateway --configuration=production --nxBail=true
 
 FROM alpine:3.23 AS ssh-gateway
+
+RUN apk update && apk upgrade --no-cache openssl pcre2
 
 WORKDIR /usr/local/bin
 


### PR DESCRIPTION
## What

- Pin the Go build toolchain to `1.25.11` across all Go service images (`proxy`, `runner`, `snapshot-manager`, `ssh-gateway`, `otel-collector`), declared as a tracked `go-toolchain` build stage.
- Add the existing `apk upgrade --no-cache openssl pcre2` hardening (already used by `proxy`/`runner`) to the `snapshot-manager`, `ssh-gateway`, and `otel-collector` final stages.

## Why

- The toolchain previously lived in `COPY --from=golang:...`, which Dependabot does not track, so the version had drifted to `1.25.4` / `1.25.7` across services. Declaring it as a `FROM ... AS go-toolchain` stage places it in the `docker-base-images` Dependabot group so it stays current. A current toolchain pulls in Go stdlib fixes that are compiled into the service binaries.
- Brings OS-package hardening to parity across all service images.

## Validation

- `docker build --check` passes for all five Dockerfiles.

Supersedes the Dockerfile portion of #4779.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the Go toolchain to 1.25.11 across all Go service images and aligns Alpine hardening. Builds now use a tracked `go-toolchain` stage and apply consistent `openssl`/`pcre2` upgrades.

- **Dependencies**
  - Add `FROM golang:1.25.11-alpine AS go-toolchain` and use `COPY --from=go-toolchain` in `proxy`, `runner`, `snapshot-manager`, `ssh-gateway`, `otel-collector` to ensure Dependabot tracks the toolchain.
  - Replace drifting `COPY --from=golang:...` references (previously 1.25.4/1.25.7).
  - Apply Alpine hardening to `snapshot-manager`, `ssh-gateway`, `otel-collector`: `apk update && apk upgrade --no-cache openssl pcre2` (parity with `proxy`/`runner`).

<sup>Written for commit 0909946060a8cb729ebb83c064a1410376e88da8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

