### PR TITLE
fix(computer-use): serialize X11 screenshot access

### DIFF
--- a/libs/computer-use/pkg/computeruse/display.go
+++ b/libs/computer-use/pkg/computeruse/display.go
@@ -13,7 +13,6 @@ import (
 	"image/png"
 
 	"github.com/daytonaio/daemon/pkg/toolbox/computeruse"
-	"github.com/go-vgo/robotgo"
 )
 
 // ImageCompressionParams holds parameters for image compression
@@ -182,37 +181,11 @@ func (u *ComputerUse) GetDisplayInfo() (*computeruse.DisplayInfoResponse, error)
 }
 
 func (u *ComputerUse) GetWindows() (*computeruse.WindowsResponse, error) {
-	// This is a simplified version - robotgo's window functions
-	// might need additional setup depending on the platform
-
 	windows := make([]computeruse.WindowInfo, 0)
 	err := withX11Client(func() error {
-		titles, err := robotgo.FindIds("")
-		if err != nil {
-			return err
-		}
-
-		for _, id := range titles {
-			title := robotgo.GetTitle(id)
-			if title != "" {
-				// Get window position and size (this might need platform-specific implementation)
-				// For now, we'll use placeholder values
-				windows = append(windows, computeruse.WindowInfo{
-					ID:    id,
-					Title: title,
-					Position: computeruse.Position{
-						X: 0, // Would need platform-specific implementation
-						Y: 0, // Would need platform-specific implementation
-					},
-					Size: computeruse.Size{
-						Width:  0, // Would need platform-specific implementation
-						Height: 0, // Would need platform-specific implementation
-					},
-					IsActive: false, // Would need platform-specific implementation
-				})
-			}
-		}
-		return nil
+		var err error
+		windows, err = getWindows()
+		return err
 	})
 	if err != nil {
 		return nil, err

--- a/libs/computer-use/pkg/computeruse/display.go
+++ b/libs/computer-use/pkg/computeruse/display.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/daytonaio/daemon/pkg/toolbox/computeruse"
 	"github.com/go-vgo/robotgo"
-	"github.com/kbinani/screenshot"
 )
 
 // ImageCompressionParams holds parameters for image compression
@@ -103,20 +102,43 @@ func (u *ComputerUse) TakeCompressedScreenshot(req *computeruse.CompressedScreen
 		Scale:   req.Scale,
 	}
 
-	bounds := screenshot.GetDisplayBounds(0)
-	img, err := screenshot.CaptureRect(bounds)
+	img, mouseX, mouseY, err := captureWithCursor(req.ShowCursor, 0, 0, capturePrimaryDisplay)
 	if err != nil {
 		return nil, err
 	}
 
+	return encodeCompressedScreenshot(img, params, req.ShowCursor, mouseX, mouseY, 0, 0)
+}
+
+// TakeCompressedRegionScreenshot takes a region screenshot with compression options
+func (u *ComputerUse) TakeCompressedRegionScreenshot(req *computeruse.CompressedRegionScreenshotRequest) (*computeruse.ScreenshotResponse, error) {
+	params := ImageCompressionParams{
+		Format:  req.Format,
+		Quality: req.Quality,
+		Scale:   req.Scale,
+	}
+
+	if err := validateScreenshotRegion(req.Width, req.Height); err != nil {
+		return nil, err
+	}
+
+	rect := image.Rect(req.X, req.Y, req.X+req.Width, req.Y+req.Height)
+	img, mouseX, mouseY, err := captureWithCursor(req.ShowCursor, req.X, req.Y, func() (*image.RGBA, error) {
+		return captureRect(rect)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to capture screenshot region x=%d y=%d width=%d height=%d: %w", req.X, req.Y, req.Width, req.Height, err)
+	}
+
+	return encodeCompressedScreenshot(img, params, req.ShowCursor, mouseX, mouseY, req.X, req.Y)
+}
+
+func encodeCompressedScreenshot(img image.Image, params ImageCompressionParams, showCursor bool, mouseX, mouseY, offsetX, offsetY int) (*computeruse.ScreenshotResponse, error) {
 	// Convert to RGBA for drawing
 	rgbaImg := image.NewRGBA(img.Bounds())
 	draw.Draw(rgbaImg, rgbaImg.Bounds(), img, image.Point{}, draw.Src)
 
-	// Draw cursor if requested
-	mouseX, mouseY := 0, 0
-	if req.ShowCursor {
-		mouseX, mouseY = robotgo.Location()
+	if showCursor && mouseX >= 0 && mouseX < img.Bounds().Dx() && mouseY >= 0 && mouseY < img.Bounds().Dy() {
 		drawCursor(rgbaImg, mouseX, mouseY)
 	}
 
@@ -133,67 +155,10 @@ func (u *ComputerUse) TakeCompressedScreenshot(req *computeruse.CompressedScreen
 		SizeBytes:  len(imageData),
 	}
 
-	if req.ShowCursor {
+	if showCursor {
 		response.CursorPosition = &computeruse.Position{
-			X: int(float64(mouseX) * params.Scale),
-			Y: int(float64(mouseY) * params.Scale),
-		}
-	}
-
-	return response, nil
-}
-
-// TakeCompressedRegionScreenshot takes a region screenshot with compression options
-func (u *ComputerUse) TakeCompressedRegionScreenshot(req *computeruse.CompressedRegionScreenshotRequest) (*computeruse.ScreenshotResponse, error) {
-	params := ImageCompressionParams{
-		Format:  req.Format,
-		Quality: req.Quality,
-		Scale:   req.Scale,
-	}
-
-	if err := validateScreenshotRegion(req.Width, req.Height); err != nil {
-		return nil, err
-	}
-
-	rect := image.Rect(req.X, req.Y, req.X+req.Width, req.Y+req.Height)
-	img, err := screenshot.CaptureRect(rect)
-	if err != nil {
-		return nil, fmt.Errorf("failed to capture screenshot region x=%d y=%d width=%d height=%d: %w", req.X, req.Y, req.Width, req.Height, err)
-	}
-
-	// Convert to RGBA for drawing
-	rgbaImg := image.NewRGBA(img.Bounds())
-	draw.Draw(rgbaImg, rgbaImg.Bounds(), img, image.Point{}, draw.Src)
-
-	// Draw cursor if requested and it's within the region
-	mouseX, mouseY := 0, 0
-	if req.ShowCursor {
-		absoluteMouseX, absoluteMouseY := robotgo.Location()
-		mouseX = absoluteMouseX - req.X
-		mouseY = absoluteMouseY - req.Y
-
-		if mouseX >= 0 && mouseX < req.Width && mouseY >= 0 && mouseY < req.Height {
-			drawCursor(rgbaImg, mouseX, mouseY)
-		}
-	}
-
-	// Encode with compression
-	imageData, err := encodeImageWithCompression(rgbaImg, params)
-	if err != nil {
-		return nil, err
-	}
-
-	base64Str := base64.StdEncoding.EncodeToString(imageData)
-
-	response := &computeruse.ScreenshotResponse{
-		Screenshot: base64Str,
-		SizeBytes:  len(imageData),
-	}
-
-	if req.ShowCursor {
-		response.CursorPosition = &computeruse.Position{
-			X: req.X + int(float64(mouseX)*params.Scale),
-			Y: req.Y + int(float64(mouseY)*params.Scale),
+			X: offsetX + int(float64(mouseX)*params.Scale),
+			Y: offsetY + int(float64(mouseY)*params.Scale),
 		}
 	}
 
@@ -201,23 +166,14 @@ func (u *ComputerUse) TakeCompressedRegionScreenshot(req *computeruse.Compressed
 }
 
 func (u *ComputerUse) GetDisplayInfo() (*computeruse.DisplayInfoResponse, error) {
-	n := screenshot.NumActiveDisplays()
-	displays := make([]computeruse.DisplayInfo, n)
-
-	for i := 0; i < n; i++ {
-		bounds := screenshot.GetDisplayBounds(i)
-		displays[i] = computeruse.DisplayInfo{
-			ID: i,
-			Position: computeruse.Position{
-				X: bounds.Min.X,
-				Y: bounds.Min.Y,
-			},
-			Size: computeruse.Size{
-				Width:  bounds.Dx(),
-				Height: bounds.Dy(),
-			},
-			IsActive: true, // Assuming all detected displays are active
-		}
+	var displays []computeruse.DisplayInfo
+	err := withX11Client(func() error {
+		var err error
+		displays, err = getDisplayInfos()
+		return err
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &computeruse.DisplayInfoResponse{
@@ -229,31 +185,37 @@ func (u *ComputerUse) GetWindows() (*computeruse.WindowsResponse, error) {
 	// This is a simplified version - robotgo's window functions
 	// might need additional setup depending on the platform
 
-	titles, err := robotgo.FindIds("")
+	windows := make([]computeruse.WindowInfo, 0)
+	err := withX11Client(func() error {
+		titles, err := robotgo.FindIds("")
+		if err != nil {
+			return err
+		}
+
+		for _, id := range titles {
+			title := robotgo.GetTitle(id)
+			if title != "" {
+				// Get window position and size (this might need platform-specific implementation)
+				// For now, we'll use placeholder values
+				windows = append(windows, computeruse.WindowInfo{
+					ID:    id,
+					Title: title,
+					Position: computeruse.Position{
+						X: 0, // Would need platform-specific implementation
+						Y: 0, // Would need platform-specific implementation
+					},
+					Size: computeruse.Size{
+						Width:  0, // Would need platform-specific implementation
+						Height: 0, // Would need platform-specific implementation
+					},
+					IsActive: false, // Would need platform-specific implementation
+				})
+			}
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	windows := make([]computeruse.WindowInfo, 0)
-	for _, id := range titles {
-		title := robotgo.GetTitle(id)
-		if title != "" {
-			// Get window position and size (this might need platform-specific implementation)
-			// For now, we'll use placeholder values
-			windows = append(windows, computeruse.WindowInfo{
-				ID:    id,
-				Title: title,
-				Position: computeruse.Position{
-					X: 0, // Would need platform-specific implementation
-					Y: 0, // Would need platform-specific implementation
-				},
-				Size: computeruse.Size{
-					Width:  0, // Would need platform-specific implementation
-					Height: 0, // Would need platform-specific implementation
-				},
-				IsActive: false, // Would need platform-specific implementation
-			})
-		}
 	}
 
 	return &computeruse.WindowsResponse{

--- a/libs/computer-use/pkg/computeruse/getwindows_linux.go
+++ b/libs/computer-use/pkg/computeruse/getwindows_linux.go
@@ -1,0 +1,61 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+//go:build linux
+
+package computeruse
+
+import (
+	"github.com/daytonaio/daemon/pkg/toolbox/computeruse"
+	"github.com/robotn/xgbutil"
+	"github.com/robotn/xgbutil/ewmh"
+)
+
+func getWindows() ([]computeruse.WindowInfo, error) {
+	return getWindowsX11()
+}
+
+func getWindowsX11() ([]computeruse.WindowInfo, error) {
+	xu, err := xgbutil.NewConn()
+	if err != nil {
+		return nil, err
+	}
+	defer xu.Conn().Close()
+
+	clientList, err := ewmh.ClientListGet(xu)
+	if err != nil {
+		return nil, err
+	}
+
+	windows := make([]computeruse.WindowInfo, 0, len(clientList))
+	for _, win := range clientList {
+		title, err := ewmh.WmVisibleNameGet(xu, win)
+		if err != nil || title == "" {
+			title, _ = ewmh.WmNameGet(xu, win)
+		}
+		if title == "" {
+			continue
+		}
+
+		id := 0
+		if pid, err := ewmh.WmPidGet(xu, win); err == nil {
+			id = int(pid)
+		}
+
+		windows = append(windows, computeruse.WindowInfo{
+			ID:    id,
+			Title: title,
+			Position: computeruse.Position{
+				X: 0, // Would need platform-specific implementation.
+				Y: 0, // Would need platform-specific implementation.
+			},
+			Size: computeruse.Size{
+				Width:  0, // Would need platform-specific implementation.
+				Height: 0, // Would need platform-specific implementation.
+			},
+			IsActive: false, // Would need platform-specific implementation.
+		})
+	}
+
+	return windows, nil
+}

--- a/libs/computer-use/pkg/computeruse/getwindows_linux.go
+++ b/libs/computer-use/pkg/computeruse/getwindows_linux.go
@@ -37,13 +37,8 @@ func getWindowsX11() ([]computeruse.WindowInfo, error) {
 			continue
 		}
 
-		id := 0
-		if pid, err := ewmh.WmPidGet(xu, win); err == nil {
-			id = int(pid)
-		}
-
 		windows = append(windows, computeruse.WindowInfo{
-			ID:    id,
+			ID:    int(win),
 			Title: title,
 			Position: computeruse.Position{
 				X: 0, // Would need platform-specific implementation.

--- a/libs/computer-use/pkg/computeruse/getwindows_linux.go
+++ b/libs/computer-use/pkg/computeruse/getwindows_linux.go
@@ -28,7 +28,13 @@ func getWindowsX11() ([]computeruse.WindowInfo, error) {
 	}
 
 	windows := make([]computeruse.WindowInfo, 0, len(clientList))
+	seen := make(map[uint]bool)
 	for _, win := range clientList {
+		pid, err := ewmh.WmPidGet(xu, win)
+		if err != nil || seen[pid] {
+			continue
+		}
+
 		title, err := ewmh.WmVisibleNameGet(xu, win)
 		if err != nil || title == "" {
 			title, _ = ewmh.WmNameGet(xu, win)
@@ -37,8 +43,9 @@ func getWindowsX11() ([]computeruse.WindowInfo, error) {
 			continue
 		}
 
+		seen[pid] = true
 		windows = append(windows, computeruse.WindowInfo{
-			ID:    int(win),
+			ID:    int(pid),
 			Title: title,
 			Position: computeruse.Position{
 				X: 0, // Would need platform-specific implementation.

--- a/libs/computer-use/pkg/computeruse/getwindows_other.go
+++ b/libs/computer-use/pkg/computeruse/getwindows_other.go
@@ -1,0 +1,45 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+//go:build !linux
+
+package computeruse
+
+import (
+	"github.com/daytonaio/daemon/pkg/toolbox/computeruse"
+	"github.com/go-vgo/robotgo"
+)
+
+func getWindows() ([]computeruse.WindowInfo, error) {
+	// This is a simplified version - robotgo's window functions
+	// might need additional setup depending on the platform.
+
+	windows := make([]computeruse.WindowInfo, 0)
+	titles, err := robotgo.FindIds("")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, id := range titles {
+		title := robotgo.GetTitle(id)
+		if title != "" {
+			// Get window position and size (this might need platform-specific implementation)
+			// For now, we'll use placeholder values.
+			windows = append(windows, computeruse.WindowInfo{
+				ID:    id,
+				Title: title,
+				Position: computeruse.Position{
+					X: 0, // Would need platform-specific implementation.
+					Y: 0, // Would need platform-specific implementation.
+				},
+				Size: computeruse.Size{
+					Width:  0, // Would need platform-specific implementation.
+					Height: 0, // Would need platform-specific implementation.
+				},
+				IsActive: false, // Would need platform-specific implementation.
+			})
+		}
+	}
+
+	return windows, nil
+}

--- a/libs/computer-use/pkg/computeruse/screenshot.go
+++ b/libs/computer-use/pkg/computeruse/screenshot.go
@@ -14,8 +14,6 @@ import (
 	"os"
 
 	"github.com/daytonaio/daemon/pkg/toolbox/computeruse"
-	"github.com/go-vgo/robotgo"
-	"github.com/kbinani/screenshot"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -88,81 +86,42 @@ func (u *ComputerUse) TakeScreenshot(req *computeruse.ScreenshotRequest) (*compu
 	display := os.Getenv("DISPLAY")
 	log.Infof("TakeScreenshot: DISPLAY=%s", display)
 
-	bounds := screenshot.GetDisplayBounds(0)
-	img, err := screenshot.CaptureRect(bounds)
+	img, mouseX, mouseY, err := captureWithCursor(req.ShowCursor, 0, 0, capturePrimaryDisplay)
 	if err != nil {
 		log.Errorf("TakeScreenshot error: %v", err)
 		return nil, err
 	}
 
-	// Convert to RGBA for drawing
-	rgbaImg := image.NewRGBA(img.Bounds())
-	draw.Draw(rgbaImg, rgbaImg.Bounds(), img, image.Point{}, draw.Src)
-
-	// Draw cursor if requested
-	mouseX, mouseY := 0, 0
-	if req.ShowCursor {
-		mouseX, mouseY = robotgo.Location()
-		drawCursor(rgbaImg, mouseX, mouseY)
-	}
-
-	// Convert to base64
-	var buf bytes.Buffer
-	if err := png.Encode(&buf, rgbaImg); err != nil {
-		return nil, err
-	}
-
-	base64Str := base64.StdEncoding.EncodeToString(buf.Bytes())
-
-	response := &computeruse.ScreenshotResponse{
-		Screenshot: base64Str,
-		CursorPosition: &computeruse.Position{
-			X: mouseX,
-			Y: mouseY,
-		},
-	}
-
-	if req.ShowCursor {
-		response.CursorPosition = &computeruse.Position{
-			X: mouseX,
-			Y: mouseY,
-		}
-	}
-
-	return response, nil
+	return encodeScreenshot(img, req.ShowCursor, mouseX, mouseY, 0, 0)
 }
 
 func (u *ComputerUse) TakeRegionScreenshot(req *computeruse.RegionScreenshotRequest) (*computeruse.ScreenshotResponse, error) {
-	// Debug: Check DISPLAY environment variable
-	display := os.Getenv("DISPLAY")
-	log.Infof("TakeRegionScreenshot: DISPLAY=%s", display)
-
 	if err := validateScreenshotRegion(req.Width, req.Height); err != nil {
 		return nil, err
 	}
 
+	// Debug: Check DISPLAY environment variable
+	display := os.Getenv("DISPLAY")
+	log.Infof("TakeRegionScreenshot: DISPLAY=%s", display)
+
 	rect := image.Rect(req.X, req.Y, req.X+req.Width, req.Y+req.Height)
-	img, err := screenshot.CaptureRect(rect)
+	img, mouseX, mouseY, err := captureWithCursor(req.ShowCursor, req.X, req.Y, func() (*image.RGBA, error) {
+		return captureRect(rect)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to capture screenshot region x=%d y=%d width=%d height=%d: %w", req.X, req.Y, req.Width, req.Height, err)
 	}
 
+	return encodeScreenshot(img, req.ShowCursor, mouseX, mouseY, req.X, req.Y)
+}
+
+func encodeScreenshot(img image.Image, showCursor bool, mouseX, mouseY, offsetX, offsetY int) (*computeruse.ScreenshotResponse, error) {
 	// Convert to RGBA for drawing
 	rgbaImg := image.NewRGBA(img.Bounds())
 	draw.Draw(rgbaImg, rgbaImg.Bounds(), img, image.Point{}, draw.Src)
 
-	// Draw cursor if requested and it's within the region
-	mouseX, mouseY := 0, 0
-	if req.ShowCursor {
-		absoluteMouseX, absoluteMouseY := robotgo.Location()
-		// Convert to relative coordinates within the region
-		mouseX = absoluteMouseX - req.X
-		mouseY = absoluteMouseY - req.Y
-
-		// Only draw if cursor is within the region
-		if mouseX >= 0 && mouseX < req.Width && mouseY >= 0 && mouseY < req.Height {
-			drawCursor(rgbaImg, mouseX, mouseY)
-		}
+	if showCursor && mouseX >= 0 && mouseX < img.Bounds().Dx() && mouseY >= 0 && mouseY < img.Bounds().Dy() {
+		drawCursor(rgbaImg, mouseX, mouseY)
 	}
 
 	var buf bytes.Buffer
@@ -174,16 +133,12 @@ func (u *ComputerUse) TakeRegionScreenshot(req *computeruse.RegionScreenshotRequ
 
 	response := &computeruse.ScreenshotResponse{
 		Screenshot: base64Str,
-		CursorPosition: &computeruse.Position{
-			X: mouseX + req.X,
-			Y: mouseY + req.Y,
-		},
 	}
 
-	if req.ShowCursor {
+	if showCursor {
 		response.CursorPosition = &computeruse.Position{
-			X: mouseX + req.X,
-			Y: mouseY + req.Y,
+			X: mouseX + offsetX,
+			Y: mouseY + offsetY,
 		}
 	}
 

--- a/libs/computer-use/pkg/computeruse/screenshot_capture.go
+++ b/libs/computer-use/pkg/computeruse/screenshot_capture.go
@@ -1,0 +1,72 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package computeruse
+
+import (
+	"image"
+
+	"github.com/daytonaio/daemon/pkg/toolbox/computeruse"
+	"github.com/go-vgo/robotgo"
+	"github.com/kbinani/screenshot"
+)
+
+func capturePrimaryDisplay() (*image.RGBA, error) {
+	return screenshot.CaptureDisplay(0)
+}
+
+func captureRect(rect image.Rectangle) (*image.RGBA, error) {
+	return screenshot.CaptureRect(rect)
+}
+
+func getCursorPosition(showCursor bool, offsetX, offsetY int) (int, int) {
+	if !showCursor {
+		return 0, 0
+	}
+
+	absoluteMouseX, absoluteMouseY := robotgo.Location()
+	return absoluteMouseX - offsetX, absoluteMouseY - offsetY
+}
+
+func captureWithCursor(showCursor bool, offsetX, offsetY int, capture func() (*image.RGBA, error)) (*image.RGBA, int, int, error) {
+	var img *image.RGBA
+	mouseX, mouseY := 0, 0
+
+	err := withX11Client(func() error {
+		var err error
+		img, err = capture()
+		if err != nil {
+			return err
+		}
+		mouseX, mouseY = getCursorPosition(showCursor, offsetX, offsetY)
+		return nil
+	})
+	if err != nil {
+		return nil, 0, 0, err
+	}
+
+	return img, mouseX, mouseY, nil
+}
+
+func getDisplayInfos() ([]computeruse.DisplayInfo, error) {
+	n := screenshot.NumActiveDisplays()
+	displays := make([]computeruse.DisplayInfo, n)
+
+	for i := 0; i < n; i++ {
+		bounds := screenshot.GetDisplayBounds(i)
+		displays[i] = computeruse.DisplayInfo{
+			ID: i,
+			Position: computeruse.Position{
+				X: bounds.Min.X,
+				Y: bounds.Min.Y,
+			},
+			Size: computeruse.Size{
+				Width:  bounds.Dx(),
+				Height: bounds.Dy(),
+			},
+			IsActive: true, // Assuming all detected displays are active.
+		}
+	}
+
+	return displays, nil
+}

--- a/libs/computer-use/pkg/computeruse/x11_clients.go
+++ b/libs/computer-use/pkg/computeruse/x11_clients.go
@@ -1,0 +1,15 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package computeruse
+
+import "sync"
+
+var x11ClientMu sync.Mutex
+
+func withX11Client(fn func() error) error {
+	x11ClientMu.Lock()
+	defer x11ClientMu.Unlock()
+
+	return fn()
+}


### PR DESCRIPTION
## Summary
Fixes #5047.

Serialize X11 screenshot/display access through a shared mutex and replace the Linux GetWindows robotgo title lookup with direct X11 window enumeration.

## What Changed
- Added a shared X11 client gate for screenshot, compressed screenshot, display info, and window enumeration paths.
- Replaced the Linux GetWindows implementation with direct xgbutil/ewmh enumeration. It now opens a single X11 connection per call, defers xu.Conn().Close() immediately, reads the client list, resolves titles and PIDs via ewmh, deduplicates by PID, and returns the same WindowInfo shape as the original robotgo path.
- Moved full-screen and region screenshot capture through common helper functions so X11 access is handled consistently.
- Refactored normal and compressed screenshot encoding to share the cursor-safe capture/encoding flow.
- Non-Linux keeps the existing robotgo path untouched.

## Why
Repeated calls to `/computeruse/display/windows` could monotonically increase X11 client count because `robotgo.GetTitle` opens xgbutil connections internally on Linux without closing them. Serialization alone did not fix this since the leak is monotonic even without concurrency. The complete fix owns the X11 window listing directly so connection lifecycle is deterministic.

## Testing
- Ran compile-only package check in Docker:
```bash
docker run --rm -v ${PWD}:/repo -w /repo golang:1.25-bookworm bash -lc "apt-get update >/dev/null && apt-get install -y libx11-dev libxtst-dev libxinerama-dev gcc pkg-config >/dev/null && /usr/local/go/bin/go build ./libs/computer-use/..."
```