### PR TITLE
chore(sdk-typescript): auto-deprecate @daytonaio/sdk on each publish

### DIFF
--- a/libs/sdk-typescript/project.json
+++ b/libs/sdk-typescript/project.json
@@ -123,7 +123,8 @@
           "npm publish --tag $NPM_TAG --access public --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$NPM_TOKEN",
           "node -e \"const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); pkg.name = '@daytonaio/sdk'; fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));\"",
           "cp ../../../libs/sdk-typescript/README.legacy.md README.md",
-          "npm publish --tag $NPM_TAG --access public --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$NPM_TOKEN"
+          "npm publish --tag $NPM_TAG --access public --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$NPM_TOKEN",
+          "npm deprecate \"@daytonaio/sdk@$NPM_PKG_VERSION\" \"Moved to @daytona/sdk, same API, no breaking changes. Please update: npm uninstall @daytonaio/sdk && npm i @daytona/sdk\" --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$NPM_TOKEN || true"
         ],
         "parallel": false
       },


### PR DESCRIPTION
## Description

Adds an `npm deprecate` step to the TypeScript SDK publish pipeline so that every new version of `@daytonaio/sdk` is automatically marked as deprecated on the npm registry immediately after publishing.

Previously, `npm deprecate` had to be run manually and only applied to versions that existed at the time. New versions published after that were clean, causing users to miss the deprecation warning.

Now the publish flow is:

1. Publish `@daytona/sdk` (primary package)
2. Rename package to `@daytonaio/sdk`
3. Swap in legacy README
4. Publish `@daytonaio/sdk` (backward-compat)
5. **`npm deprecate` that version** (new step)

Users installing `@daytonaio/sdk` will see:

```
npm warn deprecated @daytonaio/sdk@x.y.z: Moved to @daytona/sdk, same API, no breaking changes. Please update: npm uninstall @daytonaio/sdk && npm i @daytona/sdk
```

The deprecate command uses `|| true` to ensure it never blocks the publish pipeline if the registry call fails.

### Changed files
- `libs/sdk-typescript/project.json` — added `npm deprecate` command after legacy publish

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically deprecates each published `@daytonaio/sdk` version by running `npm deprecate` right after the legacy publish, so users always see the move-to-`@daytona/sdk` warning. The step is non-blocking (`|| true`) to avoid failing the release if the registry call errors.

<sup>Written for commit c9a2fa00a7734c8a6c6229988f4dbfd72a60e8a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

