### PR TITLE
chore(deps): track Go workspace modules with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,8 +69,8 @@ updates:
   # npm: scope to production manifests only.
   # NOTE: This config controls Dependabot PR creation, NOT GitHub Advisory
   # Database alert recurrence. Alerts in guides/ and runtime-tests/ paths
-  # are dismissed in GitHub directly (see scripts/dependabot-dismiss.sh
-  # for the auditable dismissal manifest and rationale).
+  # are dismissed in GitHub directly, with the rationale recorded on each
+  # dismissal in the Dependabot alerts UI.
   - package-ecosystem: npm
     directories:
       - "/"
@@ -99,5 +99,38 @@ updates:
       pip-prod:
         patterns:
           - "*"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # gomod: Go workspace modules (go.work). Without this they get
+  # security-only updates and never version updates, so they drift.
+  - package-ecosystem: gomod
+    directories:
+      - "/apps/cli"
+      - "/apps/daemon"
+      - "/apps/daytona-e2e"
+      - "/apps/otel-collector/exporter"
+      - "/apps/proxy"
+      - "/apps/runner"
+      - "/apps/snapshot-manager"
+      - "/apps/ssh-gateway"
+      - "/libs/api-client-go"
+      - "/libs/common-go"
+      - "/libs/computer-use"
+      - "/libs/sdk-go"
+      - "/libs/toolbox-api-client-go"
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      gomod-prod:
+        patterns:
+          - "*"
+    ignore:
+      # Go module majors are import-path changes (/v2, /v3) and always
+      # breaking; land them manually after review.
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
## What

Add a `gomod` Dependabot lane covering the 13 Go workspace modules (`go.work`), and fix a stale comment reference.

## Why

Go modules had no `gomod` ecosystem entry, so they received security-only updates and never version updates — they drifted. This is the module-side complement to the toolchain fix in #5048. Grouped weekly (`gomod-prod`) with semver-major ignored (Go major bumps are breaking import-path changes that should land manually), matching the existing `npm`/`pip` lanes.

Also corrects the `npm`-lane comment, which referenced `scripts/dependabot-dismiss.sh` — a file that does not exist in the repo.

## Rollout

Expect an initial batch of grouped `gomod` PRs on the first weekly run as the backlog clears; the grouping bounds the noise.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Dependabot `gomod` updates for all 13 `go.work` modules to keep modules current with regular version bumps. Also fix the `npm` lane comment that referenced a non-existent script.

- **Dependencies**
  - Enable `gomod` for 13 workspace modules; weekly on Monday; grouped as `gomod-prod`.
  - Ignore semver-major bumps (Go import-path majors); handle manually.
  - Matches schedule/grouping used by `npm`/`pip`.

- **Bug Fixes**
  - Replace stale `scripts/dependabot-dismiss.sh` reference; note dismissals occur in Dependabot alerts UI.

<sup>Written for commit 2b2a4319442ee5790ca4870f8383776ec3b4ff9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

