### PR TITLE
feat(api): add regionType to sandbox usage periods

### DIFF
--- a/apps/api/src/migrations/pre-deploy/1781597992117-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1781597992117-migration.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1781597992117 implements MigrationInterface {
+  name = 'Migration1781597992117'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "sandbox_usage_periods_archive" ADD "regionType" character varying NOT NULL DEFAULT 'shared'`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "sandbox_usage_periods" ADD "regionType" character varying NOT NULL DEFAULT 'shared'`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "organization" ADD "preview_warning_enabled" boolean NOT NULL DEFAULT false`)
+    await queryRunner.query(
+      `CREATE INDEX "idx_sandbox_last_activity_at" ON "sandbox_last_activity" ("lastActivityAt") `,
+    )
+  }
+}

--- a/apps/api/src/migrations/pre-deploy/1781597992117-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1781597992117-migration.ts
@@ -1,3 +1,7 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
 import { MigrationInterface, QueryRunner } from 'typeorm'
 
 export class Migration1781597992117 implements MigrationInterface {
@@ -13,9 +17,7 @@ export class Migration1781597992117 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "organization" ADD "preview_warning_enabled" boolean NOT NULL DEFAULT false`)
-    await queryRunner.query(
-      `CREATE INDEX "idx_sandbox_last_activity_at" ON "sandbox_last_activity" ("lastActivityAt") `,
-    )
+    await queryRunner.query(`ALTER TABLE "sandbox_usage_periods" DROP COLUMN "regionType"`)
+    await queryRunner.query(`ALTER TABLE "sandbox_usage_periods_archive" DROP COLUMN "regionType"`)
   }
 }

--- a/apps/api/src/usage/entities/sandbox-usage-period-archive.entity.ts
+++ b/apps/api/src/usage/entities/sandbox-usage-period-archive.entity.ts
@@ -7,6 +7,7 @@ import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
 import { SandboxUsagePeriod } from './sandbox-usage-period.entity'
 import { SandboxClass } from '../../sandbox/enums/sandbox-class.enum'
 import { GpuType } from '../../sandbox/enums/gpu-type.enum'
+import { RegionType } from '../../region/enums/region-type.enum'
 
 // Duplicate of SandboxUsagePeriod
 // Used to archive usage periods and keep the original table lightweight
@@ -57,6 +58,9 @@ export class SandboxUsagePeriodArchive {
   })
   sandboxClass: SandboxClass = SandboxClass.CONTAINER
 
+  @Column({ type: 'character varying', default: RegionType.SHARED })
+  regionType: string
+
   public static fromUsagePeriod(usagePeriod: SandboxUsagePeriod) {
     const usagePeriodEntity = new SandboxUsagePeriodArchive()
     usagePeriodEntity.sandboxId = usagePeriod.sandboxId
@@ -70,6 +74,7 @@ export class SandboxUsagePeriodArchive {
     usagePeriodEntity.disk = usagePeriod.disk
     usagePeriodEntity.region = usagePeriod.region
     usagePeriodEntity.sandboxClass = usagePeriod.sandboxClass
+    usagePeriodEntity.regionType = usagePeriod.regionType
     return usagePeriodEntity
   }
 }

--- a/apps/api/src/usage/entities/sandbox-usage-period.entity.ts
+++ b/apps/api/src/usage/entities/sandbox-usage-period.entity.ts
@@ -6,6 +6,7 @@
 import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm'
 import { SandboxClass } from '../../sandbox/enums/sandbox-class.enum'
 import { GpuType } from '../../sandbox/enums/gpu-type.enum'
+import { RegionType } from '../../region/enums/region-type.enum'
 
 @Entity('sandbox_usage_periods')
 @Index('idx_sandbox_usage_periods_sandbox_end', ['sandboxId', 'endAt'])
@@ -58,6 +59,9 @@ export class SandboxUsagePeriod {
   })
   sandboxClass: SandboxClass = SandboxClass.CONTAINER
 
+  @Column({ type: 'character varying', default: RegionType.SHARED })
+  regionType: string
+
   public static fromUsagePeriod(usagePeriod: SandboxUsagePeriod) {
     const usagePeriodEntity = new SandboxUsagePeriod()
     usagePeriodEntity.sandboxId = usagePeriod.sandboxId
@@ -71,6 +75,7 @@ export class SandboxUsagePeriod {
     usagePeriodEntity.disk = usagePeriod.disk
     usagePeriodEntity.region = usagePeriod.region
     usagePeriodEntity.sandboxClass = usagePeriod.sandboxClass
+    usagePeriodEntity.regionType = usagePeriod.regionType
     return usagePeriodEntity
   }
 }

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -23,6 +23,8 @@ import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { SandboxRepository } from '../../sandbox/repositories/sandbox.repository'
 import { SandboxDesiredStateUpdatedEvent } from '../../sandbox/events/sandbox-desired-state-updated.event'
 import { SandboxDesiredState } from '../../sandbox/enums/sandbox-desired-state.enum'
+import { Region } from '../../region/entities/region.entity'
+import { RegionType } from '../../region/enums/region-type.enum'
 
 @Injectable()
 export class UsageService implements TrackableJobExecutions, OnApplicationShutdown {
@@ -34,6 +36,8 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     private sandboxUsagePeriodRepository: Repository<SandboxUsagePeriod>,
     private readonly redisLockProvider: RedisLockProvider,
     private readonly sandboxRepository: SandboxRepository,
+    @InjectRepository(Region)
+    private readonly regionRepository: Repository<Region>,
   ) {}
 
   async onApplicationShutdown() {
@@ -130,6 +134,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     usagePeriod.organizationId = event.sandbox.organizationId
     usagePeriod.region = event.sandbox.region
     usagePeriod.sandboxClass = event.sandbox.sandboxClass
+    usagePeriod.regionType = await this.getRegionType(event.sandbox.region)
 
     await this.sandboxUsagePeriodRepository.save(usagePeriod)
   }
@@ -267,5 +272,20 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
 
   private async releaseLock(sandboxId: string) {
     await this.redisLockProvider.unlock(`usage-period-${sandboxId}`)
+  }
+
+  private async getRegionType(regionId: string): Promise<string> {
+    const region = await this.regionRepository.findOne({
+      select: ['regionType'],
+      where: {
+        id: regionId,
+      },
+      cache: {
+        id: `region-type-${regionId}`,
+        milliseconds: 1000 * 60 * 60, // 1 hour
+      },
+    })
+
+    return region?.regionType ?? RegionType.SHARED
   }
 }

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -275,17 +275,22 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
   }
 
   private async getRegionType(regionId: string): Promise<string> {
-    const region = await this.regionRepository.findOne({
-      select: ['regionType'],
-      where: {
-        id: regionId,
-      },
-      cache: {
-        id: `region-type-${regionId}`,
-        milliseconds: 1000 * 60 * 60, // 1 hour
-      },
-    })
+    try {
+      const region = await this.regionRepository.findOne({
+        select: ['regionType'],
+        where: {
+          id: regionId,
+        },
+        cache: {
+          id: `region-type-${regionId}`,
+          milliseconds: 1000 * 60 * 60, // 1 hour
+        },
+      })
 
-    return region?.regionType ?? RegionType.SHARED
+      return region?.regionType ?? RegionType.SHARED
+    } catch (error) {
+      this.logger.error(`Error fetching region type for region ${regionId}`, error)
+      return RegionType.SHARED
+    }
   }
 }

--- a/apps/api/src/usage/usage.module.ts
+++ b/apps/api/src/usage/usage.module.ts
@@ -14,9 +14,10 @@ import { SandboxUsagePeriodArchive } from './entities/sandbox-usage-period-archi
 import { SandboxRepository } from '../sandbox/repositories/sandbox.repository'
 import { SandboxLookupCacheInvalidationService } from '../sandbox/services/sandbox-lookup-cache-invalidation.service'
 import { Sandbox } from '../sandbox/entities/sandbox.entity'
+import { Region } from '../region/entities/region.entity'
 
 @Module({
-  imports: [TypeOrmModule.forFeature([SandboxUsagePeriod, Sandbox, SandboxUsagePeriodArchive])],
+  imports: [TypeOrmModule.forFeature([SandboxUsagePeriod, Sandbox, SandboxUsagePeriodArchive, Region])],
   providers: [
     UsageService,
     RedisLockProvider,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `regionType` to sandbox usage periods (and archive) to record if a session ran in a shared or dedicated region. This enables region-type aware usage reporting.

- **New Features**
  - Added `regionType` column to `sandbox_usage_periods` and `sandbox_usage_periods_archive` with default `shared` (migration included).
  - Set `regionType` when creating usage periods by looking up the sandbox’s region via `Region` repo (1h TypeORM cache; falls back to `shared` on miss/error).
  - Updated entities and archive mapping to persist `regionType`; added `Region` to `UsageModule` and injected into `UsageService`.

<sup>Written for commit f3c9dfdca1baf93076cb0a8176a692886f27feb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

