### PR TITLE
chore(deps): gate python minor bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,10 +59,14 @@ updates:
       - dependency-name: "node"
         update-types:
           - "version-update:semver-major"
-      # python: sandbox-slim runs user code; minor jumps need lifecycle validation
+      # python: sandbox-slim runs user code. Auto-bump patch only; gate major AND
+      # minor manually after lifecycle validation. Ignoring minor also stops
+      # Dependabot proposing PEP 440 pre-release tags (e.g. 3.15.0bN), which it
+      # does not recognize as pre-releases.
       - dependency-name: "python"
         update-types:
           - "version-update:semver-major"
+          - "version-update:semver-minor"
     commit-message:
       prefix: "chore(deps)"
 


### PR DESCRIPTION
## What

Add `version-update:semver-minor` to the `python` ignore rule in `dependabot.yml`, so the `sandbox-slim` base image (which runs user code) auto-bumps **patch-only**; major/minor land manually after lifecycle validation.

## Why

The rule's comment already said "minor jumps need lifecycle validation," but the rule only ignored `semver-major`. As a result Dependabot proposed bumping `python:3.14.5-slim → 3.15.0b2-slim` — a 3.14→3.15 **minor** bump to a **pre-release** (PEP 440 `b2`, which Dependabot does not recognize as a pre-release; no stable 3.15 exists yet). Ignoring minor matches the comment's intent and structurally blocks pre-release tags as well.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate Dependabot `python` updates to patch-only by ignoring `version-update:semver-minor`, so the `sandbox-slim` base image auto-bumps safe patches. This blocks pre-release proposals (e.g., 3.15.0bN) and keeps minor/major behind manual lifecycle validation.

<sup>Written for commit 6eabe23c2d791131bc5273253e21a9df13ecec80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

