### PR TITLE
fix(sdk-go): add Sandbox.CreateLspServer accessor and fix LSP godoc

### DIFF
--- a/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
@@ -239,6 +239,7 @@ result, err := sandbox.Process.ExecuteCommand(ctx, "ls -la")
 - [type Sandbox](<#Sandbox>)
   - [func NewSandbox\(client \*Client, toolboxClient \*toolbox.APIClient, dto sandboxDTO, language types.CodeLanguage\) \*Sandbox](<#NewSandbox>)
   - [func \(s \*Sandbox\) Archive\(ctx context.Context\) error](<#Sandbox.Archive>)
+  - [func \(s \*Sandbox\) CreateLspServer\(languageID types.LspLanguageID, pathToProject string\) \*LspServerService](<#Sandbox.CreateLspServer>)
   - [func \(s \*Sandbox\) Delete\(ctx context.Context\) error](<#Sandbox.Delete>)
   - [func \(s \*Sandbox\) DeleteWithTimeout\(ctx context.Context, timeout time.Duration\) error](<#Sandbox.DeleteWithTimeout>)
   - [func \(s \*Sandbox\) ExperimentalCreateSnapshot\(ctx context.Context, name string\) error](<#Sandbox.ExperimentalCreateSnapshot>)
@@ -2467,13 +2468,13 @@ type ListSandboxesQuery struct {
 
 LspServerService provides Language Server Protocol \(LSP\) operations for a sandbox.
 
-LspServerService enables IDE\-like features such as code completion, symbol search, and document analysis through LSP. The service manages a language server instance for a specific language and project path. Access through \[Sandbox.Lsp\].
+LspServerService enables IDE\-like features such as code completion, symbol search, and document analysis through LSP. The service manages a language server instance for a specific language and project path. Access through [Sandbox.CreateLspServer](<#Sandbox.CreateLspServer>).
 
 Example:
 
 ```
-// Get LSP service for Python
-lsp := sandbox.Lsp(types.LspLanguageIDPython, "/home/user/project")
+// Create an LSP server for Python
+lsp := sandbox.CreateLspServer(types.LspLanguagePython, "/home/user/project")
 
 // Start the language server
 if err := lsp.Start(ctx); err != nil {
@@ -2506,12 +2507,12 @@ func NewLspServerService(toolboxClient *toolbox.APIClient, languageID types.LspL
 
 NewLspServerService creates a new LspServerService.
 
-This is typically called internally by the SDK through \[Sandbox.Lsp\]. Users should access LspServerService through \[Sandbox.Lsp\] rather than creating it directly.
+This is typically called internally by the SDK through [Sandbox.CreateLspServer](<#Sandbox.CreateLspServer>). Users should obtain an LspServerService through [Sandbox.CreateLspServer](<#Sandbox.CreateLspServer>) rather than creating it directly.
 
 Parameters:
 
 - toolboxClient: The toolbox API client
-- languageID: The language identifier \(e.g., \[types.LspLanguageIDPython\]\)
+- languageID: The language identifier \(e.g., \[types.LspLanguagePython\]\)
 - projectPath: The root path of the project for LSP analysis
 
 <a name="LspServerService.Completions"></a>
@@ -4027,6 +4028,8 @@ Access sandbox capabilities through the service fields:
 - CodeInterpreter: Python code execution
 - ComputerUse: Desktop automation \(mouse, keyboard, screenshots\)
 
+Language Server Protocol \(LSP\) servers are created on demand via [Sandbox.CreateLspServer](<#Sandbox.CreateLspServer>).
+
 Example:
 
 ```
@@ -4147,6 +4150,27 @@ if err != nil {
     return err
 }
 // Sandbox is now archived and can be restored later
+```
+
+<a name="Sandbox.CreateLspServer"></a>
+### func \(\*Sandbox\) CreateLspServer
+
+```go
+func (s *Sandbox) CreateLspServer(languageID types.LspLanguageID, pathToProject string) *LspServerService
+```
+
+CreateLspServer creates a Language Server Protocol \(LSP\) server scoped to a language and project path within the sandbox.
+
+The returned [LspServerService](<#LspServerService>) must be started with [LspServerService.Start](<#LspServerService.Start>) before use, and stopped with [LspServerService.Stop](<#LspServerService.Stop>) when finished.
+
+Example:
+
+```
+lsp := sandbox.CreateLspServer(types.LspLanguagePython, "/home/user/project")
+if err := lsp.Start(ctx); err != nil {
+    return err
+}
+defer lsp.Stop(ctx)
 ```
 
 <a name="Sandbox.Delete"></a>

--- a/apps/docs/src/content/docs/en/language-server-protocol.mdx
+++ b/apps/docs/src/content/docs/en/language-server-protocol.mdx
@@ -80,8 +80,8 @@ if err != nil {
 	log.Fatal(err)
 }
 
-// Get LSP service for Python
-lsp := sandbox.Lsp(types.LspLanguagePython, "workspace/project")
+// Create LSP server for Python
+lsp := sandbox.CreateLspServer(types.LspLanguagePython, "workspace/project")
 ```
 
 </TabItem>
@@ -154,7 +154,7 @@ lsp.start  # Initialize the server
 <TabItem label="Go" icon="seti:go">
 
 ```go
-lsp := sandbox.Lsp(types.LspLanguagePython, "workspace/project")
+lsp := sandbox.CreateLspServer(types.LspLanguagePython, "workspace/project")
 err := lsp.Start(ctx)  // Initialize the server
 if err != nil {
 	log.Fatal(err)

--- a/libs/sdk-go/pkg/daytona/e2e_test.go
+++ b/libs/sdk-go/pkg/daytona/e2e_test.go
@@ -725,7 +725,7 @@ PY`)
 		require.NoError(t, sandbox.FileSystem.CreateFolder(ctx, lspProjectDir))
 		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("class Greeter:\n    def greet(self) -> str:\n        return 'hello'\n\ngreeter = Greeter()\ngreeter.\n"), lspFilePath))
 
-		lspServer = NewLspServerService(sandbox.ToolboxClient, types.LspLanguagePython, lspProjectDir, sandbox.otel)
+		lspServer = sandbox.CreateLspServer(types.LspLanguagePython, lspProjectDir)
 		require.NoError(t, lspServer.Start(ctx))
 	})
 

--- a/libs/sdk-go/pkg/daytona/lsp_server.go
+++ b/libs/sdk-go/pkg/daytona/lsp_server.go
@@ -16,12 +16,12 @@ import (
 //
 // LspServerService enables IDE-like features such as code completion, symbol search,
 // and document analysis through LSP. The service manages a language server instance
-// for a specific language and project path. Access through [Sandbox.Lsp].
+// for a specific language and project path. Access through [Sandbox.CreateLspServer].
 //
 // Example:
 //
-//	// Get LSP service for Python
-//	lsp := sandbox.Lsp(types.LspLanguageIDPython, "/home/user/project")
+//	// Create an LSP server for Python
+//	lsp := sandbox.CreateLspServer(types.LspLanguagePython, "/home/user/project")
 //
 //	// Start the language server
 //	if err := lsp.Start(ctx); err != nil {
@@ -46,13 +46,13 @@ type LspServerService struct {
 
 // NewLspServerService creates a new LspServerService.
 //
-// This is typically called internally by the SDK through [Sandbox.Lsp].
-// Users should access LspServerService through [Sandbox.Lsp] rather than
-// creating it directly.
+// This is typically called internally by the SDK through [Sandbox.CreateLspServer].
+// Users should obtain an LspServerService through [Sandbox.CreateLspServer] rather
+// than creating it directly.
 //
 // Parameters:
 //   - toolboxClient: The toolbox API client
-//   - languageID: The language identifier (e.g., [types.LspLanguageIDPython])
+//   - languageID: The language identifier (e.g., [types.LspLanguagePython])
 //   - projectPath: The root path of the project for LSP analysis
 func NewLspServerService(toolboxClient *toolbox.APIClient, languageID types.LspLanguageID, projectPath string, otel *otelState) *LspServerService {
 	return &LspServerService{

--- a/libs/sdk-go/pkg/daytona/sandbox.go
+++ b/libs/sdk-go/pkg/daytona/sandbox.go
@@ -27,6 +27,9 @@ import (
 //   - CodeInterpreter: Python code execution
 //   - ComputerUse: Desktop automation (mouse, keyboard, screenshots)
 //
+// Language Server Protocol (LSP) servers are created on demand via
+// [Sandbox.CreateLspServer].
+//
 // Example:
 //
 //	// Create and use a sandbox
@@ -445,6 +448,23 @@ func (s *Sandbox) GetWorkingDir(ctx context.Context) (string, error) {
 
 		return resp.GetDir(), nil
 	})
+}
+
+// CreateLspServer creates a Language Server Protocol (LSP) server scoped to a
+// language and project path within the sandbox.
+//
+// The returned [LspServerService] must be started with [LspServerService.Start]
+// before use, and stopped with [LspServerService.Stop] when finished.
+//
+// Example:
+//
+//	lsp := sandbox.CreateLspServer(types.LspLanguagePython, "/home/user/project")
+//	if err := lsp.Start(ctx); err != nil {
+//	    return err
+//	}
+//	defer lsp.Stop(ctx)
+func (s *Sandbox) CreateLspServer(languageID types.LspLanguageID, pathToProject string) *LspServerService {
+	return NewLspServerService(s.ToolboxClient, languageID, pathToProject, s.otel)
 }
 
 // Start starts the sandbox with a default timeout of 60 seconds.

--- a/libs/sdk-go/pkg/daytona/sandbox_test.go
+++ b/libs/sdk-go/pkg/daytona/sandbox_test.go
@@ -371,6 +371,27 @@ func newSandboxForToolboxTest(toolboxClient *toolbox.APIClient, id string, state
 	return NewSandbox(nil, toolboxClient, dto, types.CodeLanguagePython)
 }
 
+func TestSandboxCreateLspServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	sandbox := newSandboxForToolboxTest(createTestToolboxClient(server), "sb", apiclient.SANDBOXSTATE_STARTED)
+	// Wire a non-nil otel state so we can assert it is propagated to the LSP
+	// service — instrumentation that external callers cannot supply themselves
+	// (otelState is unexported) is the reason this accessor exists.
+	sandbox.otel = &otelState{}
+
+	lsp := sandbox.CreateLspServer(types.LspLanguagePython, "/home/user/project")
+
+	require.NotNil(t, lsp)
+	require.Equal(t, types.LspLanguageID("python"), lsp.languageID)
+	require.Equal(t, "/home/user/project", lsp.projectPath)
+	require.Same(t, sandbox.ToolboxClient, lsp.toolboxClient)
+	require.Same(t, sandbox.otel, lsp.otel)
+}
+
 func TestSandboxRefreshDataSuccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		payload := testSandboxPayload("sb-1", "refreshed", apiclient.SANDBOXSTATE_STARTED)


### PR DESCRIPTION
## What

Adds a `Sandbox.CreateLspServer(languageID, pathToProject)` accessor to the Go SDK, fixes the stale LSP godoc, and aligns the docs site.

Closes #5068

## Why

The docs and godoc both presented a `sandbox.Lsp(...)` accessor that **never existed**, so the documented Go example did not compile. The godoc additionally referenced a non-existent constant `types.LspLanguageIDPython`. Go was also the only language SDK without a Sandbox-level LSP accessor:

| SDK | Accessor |
| --- | --- |
| Python | `sandbox.create_lsp_server("python", "/project")` |
| TypeScript | `sandbox.createLspServer("python", "/project")` |
| **Go (before)** | none — manual `NewLspServerService(...)` |
| **Go (this PR)** | `sandbox.CreateLspServer(types.LspLanguagePython, "/project")` |

The name `CreateLspServer` mirrors the Python/TS naming for parity. Crucially, the accessor wires the **unexported** `s.otel` into the service — external callers could never supply it (`otelState` is unexported), so the previous manual workaround forced a `nil` otel argument and silently lost OpenTelemetry instrumentation.

## Changes

Commit 1 — `fix(sdk-go)`:
- **`pkg/daytona/sandbox.go`** — new `func (s *Sandbox) CreateLspServer(languageID types.LspLanguageID, pathToProject string) *LspServerService`, delegating to `NewLspServerService(s.ToolboxClient, languageID, pathToProject, s.otel)`; struct godoc updated.
- **`pkg/daytona/lsp_server.go`** — corrected all stale godoc: `[Sandbox.Lsp]` → `[Sandbox.CreateLspServer]`, `types.LspLanguageIDPython` → `types.LspLanguagePython`.
- **`pkg/daytona/sandbox_test.go`** — `TestSandboxCreateLspServer` asserts the service is wired with the correct toolbox client, language ID, project path, and otel state.
- **`pkg/daytona/e2e_test.go`** — migrated the manual workaround to the new public accessor (dogfooding).

Commit 2 — `docs`:
- **`apps/docs/src/content/docs/en/language-server-protocol.mdx`** — the two Go tabs now call `sandbox.CreateLspServer(...)` instead of the non-existent `sandbox.Lsp(...)`.
- The `go-sdk/*` reference pages are gomarkdoc-generated (`DO NOT EDIT`) and pick up the godoc fix automatically. The `ja/*` translations are GT-managed and regenerate from the English source — neither is edited by hand.

## Usage

```go
lsp := sandbox.CreateLspServer(types.LspLanguagePython, "/home/user/project")
if err := lsp.Start(ctx); err != nil {
    return err
}
defer lsp.Stop(ctx)
```

## Testing

Run inside `nix develop .#go`:

- `go build ./...` / `go vet ./...` — pass
- `go vet -tags e2e ./pkg/daytona/...` — pass
- `go test ./pkg/daytona/...` — pass (incl. new `TestSandboxCreateLspServer`)
- `golangci-lint run ./pkg/daytona/...` — 0 issues
- `gofmt -l` — clean
- `grep -rn "Sandbox\.Lsp\b\|LspLanguageIDPython" libs/sdk-go` — 0 hits
