### PR TITLE
Support self-hosted Svix URL in dashboard webhooks

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -162,6 +162,7 @@ const configuration = {
   webhook: {
     authToken: process.env.SVIX_AUTH_TOKEN,
     serverUrl: process.env.SVIX_SERVER_URL,
+    publicServerUrl: process.env.SVIX_PUBLIC_SERVER_URL || process.env.SVIX_SERVER_URL,
   },
   healthCheck: {
     apiKey: process.env.HEALTH_CHECK_API_KEY,

--- a/apps/api/src/webhook/README.md
+++ b/apps/api/src/webhook/README.md
@@ -7,12 +7,19 @@ This service provides webhook functionality using [Svix](https://svix.com) as th
 Set the following environment variables:
 
 ```bash
-# Required: Your Svix authentication token
+# Required: Your Svix authentication token.
 SVIX_AUTH_TOKEN=your_svix_auth_token_here
 
-# Optional: Custom Svix server URL (for self-hosted instances)
+# Optional: Custom server-side Svix API URL for the Daytona API.
 SVIX_SERVER_URL=https://your-svix-instance.com
+
+# Optional: Browser-facing Svix API URL for the dashboard. Defaults to SVIX_SERVER_URL.
+SVIX_PUBLIC_SERVER_URL=https://svix.example.com
 ```
+
+For self-hosted Svix, use `SVIX_SERVER_URL` for the URL reachable by the Daytona API service. Set
+`SVIX_PUBLIC_SERVER_URL` when browsers need a different public or proxied URL for `svix-react`; for example, API pods
+may use `http://svix.svc.cluster.local:8071` while browsers use `https://svix.example.com`.
 
 ## API Endpoints
 

--- a/apps/api/src/webhook/dto/webhook-app-portal-access.dto.ts
+++ b/apps/api/src/webhook/dto/webhook-app-portal-access.dto.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { ApiProperty, ApiSchema } from '@nestjs/swagger'
+import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
 
 @ApiSchema({ name: 'WebhookAppPortalAccess' })
 export class WebhookAppPortalAccessDto {
@@ -18,4 +18,10 @@ export class WebhookAppPortalAccessDto {
     example: 'https://app.svix.com/app_1234567890',
   })
   url: string
+
+  @ApiPropertyOptional({
+    description: 'The browser-facing Svix API URL for self-hosted Svix deployments',
+    example: 'https://svix.example.com',
+  })
+  serverUrl?: string
 }

--- a/apps/api/src/webhook/services/webhook.service.spec.ts
+++ b/apps/api/src/webhook/services/webhook.service.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ServiceUnavailableException } from '@nestjs/common'
+import { TypedConfigService } from '../../config/typed-config.service'
+import { WebhookInitialization } from '../entities/webhook-initialization.entity'
+import { WebhookService } from './webhook.service'
+import { Repository } from 'typeorm'
+
+describe('WebhookService', () => {
+  const organizationId = 'org_123'
+  const appPortalAccess = {
+    token: 'appsk_test',
+    url: 'https://app.svix.com/consumer/app_123',
+  }
+
+  const createService = (publicServerUrl?: string) => {
+    const configService = {
+      get: jest.fn((key: string) => (key === 'webhook.publicServerUrl' ? publicServerUrl : undefined)),
+    } as unknown as TypedConfigService
+
+    const service = new WebhookService(configService, {} as Repository<WebhookInitialization>)
+    const appPortalAccessMock = jest.fn().mockResolvedValue(appPortalAccess)
+    ;(service as unknown as { svix: unknown }).svix = {
+      authentication: {
+        appPortalAccess: appPortalAccessMock,
+      },
+    }
+
+    return { service, appPortalAccessMock }
+  }
+
+  describe('getAppPortalAccess', () => {
+    it('returns token and url from Svix', async () => {
+      const { service, appPortalAccessMock } = createService()
+
+      const result = await service.getAppPortalAccess(organizationId)
+
+      expect(appPortalAccessMock).toHaveBeenCalledWith(organizationId, {})
+      expect(result.token).toBe(appPortalAccess.token)
+      expect(result.url).toBe(appPortalAccess.url)
+    })
+
+    it('includes serverUrl when browser-facing Svix URL is configured', async () => {
+      const { service } = createService('https://svix.example.com')
+
+      await expect(service.getAppPortalAccess(organizationId)).resolves.toEqual({
+        ...appPortalAccess,
+        serverUrl: 'https://svix.example.com',
+      })
+    })
+
+    it('omits serverUrl when no Svix URL is configured', async () => {
+      const { service } = createService()
+
+      await expect(service.getAppPortalAccess(organizationId)).resolves.toEqual(appPortalAccess)
+    })
+
+    it('throws when Svix is not configured', async () => {
+      const service = new WebhookService(
+        { get: jest.fn() } as unknown as TypedConfigService,
+        {} as Repository<WebhookInitialization>,
+      )
+
+      await expect(service.getAppPortalAccess(organizationId)).rejects.toBeInstanceOf(ServiceUnavailableException)
+    })
+  })
+})

--- a/apps/api/src/webhook/services/webhook.service.ts
+++ b/apps/api/src/webhook/services/webhook.service.ts
@@ -10,6 +10,7 @@ import { Organization } from '../../organization/entities/organization.entity'
 import { InjectRepository } from '@nestjs/typeorm'
 import { WebhookInitialization } from '../entities/webhook-initialization.entity'
 import { Repository } from 'typeorm'
+import { WebhookAppPortalAccessDto } from '../dto/webhook-app-portal-access.dto'
 
 @Injectable()
 export class WebhookService implements OnModuleInit {
@@ -220,16 +221,18 @@ export class WebhookService implements OnModuleInit {
   /**
    * Get Svix Consumer App Portal access for an organization
    */
-  async getAppPortalAccess(organizationId: string): Promise<{ token: string; url: string }> {
+  async getAppPortalAccess(organizationId: string): Promise<WebhookAppPortalAccessDto> {
     if (!this.svix) {
       throw new ServiceUnavailableException('Webhook service is not configured')
     }
     try {
       const appPortalAccess = await this.svix.authentication.appPortalAccess(organizationId, {})
+      const publicServerUrl = this.configService.get('webhook.publicServerUrl')
       this.logger.debug(`Generated app portal access for organization ${organizationId}`)
       return {
         token: appPortalAccess.token,
         url: appPortalAccess.url,
+        ...(publicServerUrl ? { serverUrl: publicServerUrl } : {}),
       }
     } catch (error) {
       this.logger.debug(`Failed to generate app portal access for organization ${organizationId}:`, error)

--- a/apps/dashboard/src/hooks/queries/useWebhookAppPortalAccessQuery.ts
+++ b/apps/dashboard/src/hooks/queries/useWebhookAppPortalAccessQuery.ts
@@ -10,6 +10,7 @@ import { queryKeys } from './queryKeys'
 interface WebhookAppPortalAccess {
   token: string
   url: string
+  serverUrl?: string
 }
 
 export const useWebhookAppPortalAccessQuery = (organizationId?: string) => {

--- a/apps/dashboard/src/providers/SvixProvider.tsx
+++ b/apps/dashboard/src/providers/SvixProvider.tsx
@@ -87,7 +87,11 @@ export function SvixProvider({ children }: SvixProviderProps) {
   }
 
   return (
-    <SvixReactProvider token={appPortalAccess.token} appId={initStatus.svixApplicationId}>
+    <SvixReactProvider
+      token={appPortalAccess.token}
+      appId={initStatus.svixApplicationId}
+      options={appPortalAccess.serverUrl ? { serverUrl: appPortalAccess.serverUrl } : undefined}
+    >
       {children}
     </SvixReactProvider>
   )

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -15015,6 +15015,7 @@ components:
       type: object
     WebhookAppPortalAccess:
       example:
+        serverUrl: https://svix.example.com
         url: https://app.svix.com/app_1234567890
         token: appsk_...
       properties:
@@ -15025,6 +15026,10 @@ components:
         url:
           description: The URL to the webhook app portal
           example: https://app.svix.com/app_1234567890
+          type: string
+        serverUrl:
+          description: The browser-facing Svix API URL for self-hosted Svix deployments
+          example: https://svix.example.com
           type: string
       required:
       - token

--- a/libs/api-client-go/model_webhook_app_portal_access.go
+++ b/libs/api-client-go/model_webhook_app_portal_access.go
@@ -25,6 +25,8 @@ type WebhookAppPortalAccess struct {
 	Token string `json:"token"`
 	// The URL to the webhook app portal
 	Url string `json:"url"`
+	// The browser-facing Svix API URL for self-hosted Svix deployments
+	ServerUrl *string `json:"serverUrl,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -97,6 +99,38 @@ func (o *WebhookAppPortalAccess) SetUrl(v string) {
 	o.Url = v
 }
 
+// GetServerUrl returns the ServerUrl field value if set, zero value otherwise.
+func (o *WebhookAppPortalAccess) GetServerUrl() string {
+	if o == nil || IsNil(o.ServerUrl) {
+		var ret string
+		return ret
+	}
+	return *o.ServerUrl
+}
+
+// GetServerUrlOk returns a tuple with the ServerUrl field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *WebhookAppPortalAccess) GetServerUrlOk() (*string, bool) {
+	if o == nil || IsNil(o.ServerUrl) {
+		return nil, false
+	}
+	return o.ServerUrl, true
+}
+
+// HasServerUrl returns a boolean if a field has been set.
+func (o *WebhookAppPortalAccess) HasServerUrl() bool {
+	if o != nil && !IsNil(o.ServerUrl) {
+		return true
+	}
+
+	return false
+}
+
+// SetServerUrl gets a reference to the given string and assigns it to the ServerUrl field.
+func (o *WebhookAppPortalAccess) SetServerUrl(v string) {
+	o.ServerUrl = &v
+}
+
 func (o WebhookAppPortalAccess) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -109,6 +143,9 @@ func (o WebhookAppPortalAccess) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["token"] = o.Token
 	toSerialize["url"] = o.Url
+	if !IsNil(o.ServerUrl) {
+		toSerialize["serverUrl"] = o.ServerUrl
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -155,6 +192,7 @@ func (o *WebhookAppPortalAccess) UnmarshalJSON(data []byte) (err error) {
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "token")
 		delete(additionalProperties, "url")
+		delete(additionalProperties, "serverUrl")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/WebhookAppPortalAccess.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/WebhookAppPortalAccess.java
@@ -60,6 +60,11 @@ public class WebhookAppPortalAccess {
   @javax.annotation.Nonnull
   private String url;
 
+  public static final String SERIALIZED_NAME_SERVER_URL = "serverUrl";
+  @SerializedName(SERIALIZED_NAME_SERVER_URL)
+  @javax.annotation.Nullable
+  private String serverUrl;
+
   public WebhookAppPortalAccess() {
   }
 
@@ -98,6 +103,25 @@ public class WebhookAppPortalAccess {
 
   public void setUrl(@javax.annotation.Nonnull String url) {
     this.url = url;
+  }
+
+
+  public WebhookAppPortalAccess serverUrl(@javax.annotation.Nullable String serverUrl) {
+    this.serverUrl = serverUrl;
+    return this;
+  }
+
+  /**
+   * The browser-facing Svix API URL for self-hosted Svix deployments
+   * @return serverUrl
+   */
+  @javax.annotation.Nullable
+  public String getServerUrl() {
+    return serverUrl;
+  }
+
+  public void setServerUrl(@javax.annotation.Nullable String serverUrl) {
+    this.serverUrl = serverUrl;
   }
 
   /**
@@ -156,13 +180,14 @@ public class WebhookAppPortalAccess {
     }
     WebhookAppPortalAccess webhookAppPortalAccess = (WebhookAppPortalAccess) o;
     return Objects.equals(this.token, webhookAppPortalAccess.token) &&
-        Objects.equals(this.url, webhookAppPortalAccess.url)&&
+        Objects.equals(this.url, webhookAppPortalAccess.url) &&
+        Objects.equals(this.serverUrl, webhookAppPortalAccess.serverUrl)&&
         Objects.equals(this.additionalProperties, webhookAppPortalAccess.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(token, url, additionalProperties);
+    return Objects.hash(token, url, serverUrl, additionalProperties);
   }
 
   @Override
@@ -171,6 +196,7 @@ public class WebhookAppPortalAccess {
     sb.append("class WebhookAppPortalAccess {\n");
     sb.append("    token: ").append(toIndentedString(token)).append("\n");
     sb.append("    url: ").append(toIndentedString(url)).append("\n");
+    sb.append("    serverUrl: ").append(toIndentedString(serverUrl)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -190,7 +216,7 @@ public class WebhookAppPortalAccess {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("token", "url"));
+    openapiFields = new HashSet<String>(Arrays.asList("token", "url", "serverUrl"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("token", "url"));
@@ -221,6 +247,9 @@ public class WebhookAppPortalAccess {
       }
       if (!jsonObj.get("url").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `url` to be a primitive type in the JSON string but got `%s`", jsonObj.get("url").toString()));
+      }
+      if ((jsonObj.get("serverUrl") != null && !jsonObj.get("serverUrl").isJsonNull()) && !jsonObj.get("serverUrl").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `serverUrl` to be a primitive type in the JSON string but got `%s`", jsonObj.get("serverUrl").toString()));
       }
   }
 

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/WebhookAppPortalAccessTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/WebhookAppPortalAccessTest.java
@@ -53,4 +53,12 @@ public class WebhookAppPortalAccessTest {
         // TODO: test url
     }
 
+    /**
+     * Test the property 'serverUrl'
+     */
+    @Test
+    public void serverUrlTest() {
+        // TODO: test serverUrl
+    }
+
 }

--- a/libs/api-client-python-async/daytona_api_client_async/models/webhook_app_portal_access.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/webhook_app_portal_access.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -32,8 +32,9 @@ class WebhookAppPortalAccess(BaseModel):
     """ # noqa: E501
     token: StrictStr = Field(description="The authentication token for the Svix consumer app portal")
     url: StrictStr = Field(description="The URL to the webhook app portal")
+    server_url: Optional[StrictStr] = Field(default=None, description="The browser-facing Svix API URL for self-hosted Svix deployments", serialization_alias="serverUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["token", "url"]
+    __properties: ClassVar[List[str]] = ["token", "url", "serverUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -93,7 +94,8 @@ class WebhookAppPortalAccess(BaseModel):
 
         _obj = cls.model_validate({
             "token": obj.get("token"),
-            "url": obj.get("url")
+            "url": obj.get("url"),
+            "server_url": obj.get("serverUrl")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/webhook_app_portal_access.py
+++ b/libs/api-client-python/daytona_api_client/models/webhook_app_portal_access.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -32,8 +32,9 @@ class WebhookAppPortalAccess(BaseModel):
     """ # noqa: E501
     token: StrictStr = Field(description="The authentication token for the Svix consumer app portal")
     url: StrictStr = Field(description="The URL to the webhook app portal")
+    server_url: Optional[StrictStr] = Field(default=None, description="The browser-facing Svix API URL for self-hosted Svix deployments", serialization_alias="serverUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["token", "url"]
+    __properties: ClassVar[List[str]] = ["token", "url", "serverUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -93,7 +94,8 @@ class WebhookAppPortalAccess(BaseModel):
 
         _obj = cls.model_validate({
             "token": obj.get("token"),
-            "url": obj.get("url")
+            "url": obj.get("url"),
+            "server_url": obj.get("serverUrl")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-ruby/lib/daytona_api_client/models/webhook_app_portal_access.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/webhook_app_portal_access.rb
@@ -21,11 +21,15 @@ module DaytonaApiClient
     # The URL to the webhook app portal
     attr_accessor :url
 
+    # The browser-facing Svix API URL for self-hosted Svix deployments
+    attr_accessor :server_url
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         :'token' => :'token',
-        :'url' => :'url'
+        :'url' => :'url',
+        :'server_url' => :'serverUrl'
       }
     end
 
@@ -43,7 +47,8 @@ module DaytonaApiClient
     def self.openapi_types
       {
         :'token' => :'String',
-        :'url' => :'String'
+        :'url' => :'String',
+        :'server_url' => :'String'
       }
     end
 
@@ -79,6 +84,10 @@ module DaytonaApiClient
         self.url = attributes[:'url']
       else
         self.url = nil
+      end
+
+      if attributes.key?(:'server_url')
+        self.server_url = attributes[:'server_url']
       end
     end
 
@@ -133,7 +142,8 @@ module DaytonaApiClient
       return true if self.equal?(o)
       self.class == o.class &&
           token == o.token &&
-          url == o.url
+          url == o.url &&
+          server_url == o.server_url
     end
 
     # @see the `==` method
@@ -145,7 +155,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [token, url].hash
+      [token, url, server_url].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client/src/models/webhook-app-portal-access.ts
+++ b/libs/api-client/src/models/webhook-app-portal-access.ts
@@ -23,5 +23,9 @@ export interface WebhookAppPortalAccess {
      * The URL to the webhook app portal
      */
     'url': string;
+    /**
+     * The browser-facing Svix API URL for self-hosted Svix deployments
+     */
+    'serverUrl'?: string;
 }
 


### PR DESCRIPTION

Fixes #5078

## Description

This fixes Daytona dashboard webhook management for self-hosted Svix deployments.

The API already supports `SVIX_SERVER_URL` for server-side Svix calls, but the dashboard did not pass a self-hosted Svix API URL to `svix-react`. In split-route deployments, browser-side webhook management could fall back to Svix Cloud instead of the configured self-hosted Svix instance.

This change adds optional `SVIX_PUBLIC_SERVER_URL`, defaulting to `SVIX_SERVER_URL`, exposes it as optional `serverUrl` in `WebhookAppPortalAccess`, and passes it to `SvixReactProvider` through `options.serverUrl`.

Generated API clients were regenerated for the public OpenAPI response schema change.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #5078.

## Screenshots

Not applicable.

## Notes

Validation completed locally:

- `yarn install && yarn generate:api-client` using the Nexus npm registry
- `npx nx test api`
- `npx nx build api`
- `npx nx build dashboard`
- `yarn lint:ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for a browser-facing Svix API URL in the dashboard so self-hosted deployments use the intended endpoint instead of falling back to Svix Cloud. Addresses #5078.

- **New Features**
  - Introduced `SVIX_PUBLIC_SERVER_URL` (defaults to `SVIX_SERVER_URL`) for browser access.
  - API now returns optional `serverUrl` in WebhookAppPortalAccess.
  - Dashboard passes `serverUrl` to `svix-react` via `SvixReactProvider` (`options.serverUrl`).

- **Migration**
  - For self-hosted Svix, set `SVIX_PUBLIC_SERVER_URL` to the public/proxied URL used by browsers; no change needed if it matches `SVIX_SERVER_URL`.

<sup>Written for commit a8e5450fad3e8e88fa8b35b5afd8067d1c90afdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

