### PR TITLE
fix(daemon): register no-slash DELETE /files route for toolbox deleteFile

### DIFF
--- a/apps/daemon/pkg/toolbox/server.go
+++ b/apps/daemon/pkg/toolbox/server.go
@@ -187,6 +187,7 @@ func (s *server) Start() error {
 
 		// delete operations
 		fsController.DELETE("/", fs.DeleteFile)
+		fsController.DELETE("", fs.DeleteFile)
 	}
 
 	processLogger := s.logger.With(slog.String("component", "process_controller"))

--- a/apps/daemon/pkg/toolbox/server_test.go
+++ b/apps/daemon/pkg/toolbox/server_test.go
@@ -7,7 +7,9 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -44,6 +46,60 @@ func TestFilesRoutesAcceptSlashAndNoSlash(t *testing.T) {
 
 	if statusSlash != http.StatusOK {
 		t.Fatalf("GET /files/ returned status %d, want %d", statusSlash, http.StatusOK)
+	}
+}
+
+func TestDeleteFilesRoutesAcceptSlashAndNoSlash(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+
+	fsController := r.Group("/files")
+	{
+		fsController.DELETE("/", fs.DeleteFile)
+		fsController.DELETE("", fs.DeleteFile)
+	}
+
+	tempDir := t.TempDir()
+
+	writeTempFile := func(name string) string {
+		p := filepath.Join(tempDir, name)
+		if err := os.WriteFile(p, []byte("content"), 0o644); err != nil {
+			t.Fatalf("failed to create temp file %q: %v", p, err)
+		}
+		return p
+	}
+
+	check := func(path string) int {
+		req := httptest.NewRequest(http.MethodDelete, path, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	fileNoSlash := writeTempFile("no-slash.txt")
+	fileSlash := writeTempFile("slash.txt")
+
+	statusNoSlash := check("/files?path=" + url.QueryEscape(fileNoSlash))
+	statusSlash := check("/files/?path=" + url.QueryEscape(fileSlash))
+
+	// Guard against the 307 trailing-slash redirect regression (#5029): the
+	// route must be served directly, never via a 3xx redirect. Check this first
+	// so a reintroduced redirect produces a clear failure message.
+	if statusNoSlash >= 300 && statusNoSlash < 400 {
+		t.Fatalf("DELETE /files was redirected with status %d, want a direct response", statusNoSlash)
+	}
+
+	if statusSlash >= 300 && statusSlash < 400 {
+		t.Fatalf("DELETE /files/ was redirected with status %d, want a direct response", statusSlash)
+	}
+
+	if statusNoSlash != http.StatusNoContent {
+		t.Fatalf("DELETE /files returned status %d, want %d", statusNoSlash, http.StatusNoContent)
+	}
+
+	if statusSlash != http.StatusNoContent {
+		t.Fatalf("DELETE /files/ returned status %d, want %d", statusSlash, http.StatusNoContent)
 	}
 }
 


### PR DESCRIPTION
## Summary

`Sandbox.fs.deleteFile(path, true)` fails with `404 page not found` against the Toolbox filesystem API, even though every other `fs.*` operation works on the same sandbox/path. This is the same class of route skew as the earlier `listFiles` fix (#4574) — it was just missed for `DELETE`.

## Root cause

The generated Toolbox client issues:

```
DELETE /files?path=...&recursive=true
```

with **no trailing slash** (`@Router /files [delete]`; `path`/`recursive` are query params). But the daemon only registered the trailing-slash form:

```go
fsController.DELETE("/", fs.DeleteFile) // only /files/
```

With `gin.New()` (default `RedirectTrailingSlash = true`), `DELETE /files` has no exact match, so gin issues a **307 redirect** to `/files/`. That redirect's root-relative `Location` loses the `/toolbox/<sandboxId>/` proxy prefix when the SDK follows it through the runner/proxy chain, and the request lands on an unmatched path — surfacing to the SDK as `404 page not found`.

This mirrors #4574, which fixed the identical gap for `listFiles` by registering both `GET("/")` and `GET("")`. The `DELETE` equivalent was never added.

## Fix

Register the no-slash form alongside the existing one, so `/files` is served directly with no redirect:

```go
fsController.DELETE("/", fs.DeleteFile)
fsController.DELETE("", fs.DeleteFile)
```

`DeleteFile` reads `path`/`recursive` purely from query params, so serving at `/files` vs `/files/` is behaviorally identical (204 on success).

## Tests

Added `TestDeleteFilesRoutesAcceptSlashAndNoSlash` (mirrors the existing `TestFilesRoutesAcceptSlashAndNoSlash`): deletes a real temp file via both `/files` and `/files/`, asserting each returns `204` directly and explicitly guarding against the 3xx redirect regression.

Verification (run on Linux — the package only builds on Linux due to a `go-netstat` Darwin limitation):
- `gofmt` clean
- `golangci-lint run ./pkg/toolbox/` → 0 issues
- full `pkg/toolbox` test suite passes (new test included)

Closes #5029


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `Sandbox.fs.deleteFile` 404s by serving DELETE `/files` without a trailing slash, avoiding `gin`’s redirect and proxy prefix loss (Linear #5029). Aligns DELETE routing with the earlier `listFiles` fix.

- **Bug Fixes**
  - Register `DELETE ""` alongside `DELETE "/"` so both `/files` and `/files/` hit `fs.DeleteFile` directly.
  - Add `TestDeleteFilesRoutesAcceptSlashAndNoSlash` to ensure both URLs return 204 and never 3xx.

<sup>Written for commit 721cc7e32682081d988d9802a7767e4ec1ecea3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

