### PR TITLE
feat(docs): add async python sdk variable

### DIFF
--- a/apps/docs/src/content/docs/en/configuration.mdx
+++ b/apps/docs/src/content/docs/en/configuration.mdx
@@ -169,6 +169,26 @@ DAYTONA_API_URL=https://your_api_url
 DAYTONA_TARGET=us
 ```
 
+### Async Python SDK
+
+Daytona provides an additional `DAYTONA_HAPPY_EYEBALLS_DELAY` environment variable for HTTP transport tuning in the async Python SDK. Use it to reduce intermittent async connection failures, such as `aiohttp.ClientConnectorError`, that can occur on dual-stack (IPv4/IPv6) networks.
+
+| Variable                           | Description                                                                 | Required |
+| ---------------------------------- | --------------------------------------------------------------------------- | -------- |
+| **`DAYTONA_HAPPY_EYEBALLS_DELAY`** | Controls **`aiohttp`** Happy Eyeballs (IPv4/IPv6 connection race) delay in seconds. | No       |
+
+- unset or empty: use `aiohttp` default behavior
+- `none` (case-insensitive): disable the IPv4/IPv6 race
+- non-negative float (for example `0.25`): set an explicit delay in seconds
+
+```bash
+# Disable Happy Eyeballs
+export DAYTONA_HAPPY_EYEBALLS_DELAY=none
+
+# Or set an explicit delay in seconds
+export DAYTONA_HAPPY_EYEBALLS_DELAY=0.25
+```
+
 ## Default values
 
 If no configuration is provided, Daytona will use its built-in default values:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Documented `DAYTONA_HAPPY_EYEBALLS_DELAY` for the async Python SDK to tune `aiohttp` Happy Eyeballs delay and reduce dual-stack connection errors. Added usage notes and examples: unset = default, `none` = disable, float seconds (e.g., `0.25`) = explicit delay.

<sup>Written for commit 6c22401a7db776aa58d08521c9eceb2543848150. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

