### PR TITLE
chore(docker): add yarn dep build dependencies

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -3,18 +3,13 @@ FROM node:24-slim AS builder
 
 ENV CI=true
 
-# Build toolchain (python3/make/g++) is only needed to compile the bundle and
-# any native devDependencies — it stays out of the runtime image.
+# Build toolchain (python3/python3-setuptools/make/g++) is only needed to compile
+# the bundle and any native devDependencies — it stays out of the runtime image.
+# python3-setuptools provides the distutils module node-gyp needs on Python 3.12+.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      bash curl python3 make g++ && \
+      bash curl python3 python3-setuptools make g++ && \
     rm -rf /var/lib/apt/lists/*
 RUN npm install -g corepack && corepack enable
-
-# Pre-cache Node headers so that if a native module's prebuilt-binary download
-# times out and node-gyp falls back to compiling from source, the header tarball
-# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
-# transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 WORKDIR /daytona
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -10,6 +10,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 RUN npm install -g corepack && corepack enable
 
+# Pre-cache Node headers so that if a native module's prebuilt-binary download
+# times out and node-gyp falls back to compiling from source, the header tarball
+# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
+# transient DNS failures on this single fetch.
+RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+
 WORKDIR /daytona
 
 # Yarn caching layer

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install -g corepack && corepack enable
 # times out and node-gyp falls back to compiling from source, the header tarball
 # is already local — no flaky network/DNS lookup mid-install. Retried to absorb
 # transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 WORKDIR /daytona
 

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -2,6 +2,11 @@ FROM node:20-alpine AS builder
 
 ENV CI=true
 
+# Build toolchain (python3/make/g++) is needed when a native module's prebuilt
+# binary download fails and node-gyp falls back to compiling from source —
+# it stays out of the runtime image.
+RUN apk add --no-cache python3 make g++
+
 RUN npm install -g corepack && corepack enable
 
 WORKDIR /daytona

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -13,7 +13,7 @@ RUN npm install -g corepack && corepack enable
 # times out and node-gyp falls back to compiling from source, the header tarball
 # is already local — no flaky network/DNS lookup mid-install. Retried to absorb
 # transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 WORKDIR /daytona
 

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -9,6 +9,12 @@ RUN apk add --no-cache python3 make g++
 
 RUN npm install -g corepack && corepack enable
 
+# Pre-cache Node headers so that if a native module's prebuilt-binary download
+# times out and node-gyp falls back to compiling from source, the header tarball
+# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
+# transient DNS failures on this single fetch.
+RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+
 WORKDIR /daytona
 
 # Yarn caching layer

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -2,18 +2,13 @@ FROM node:20-alpine AS builder
 
 ENV CI=true
 
-# Build toolchain (python3/make/g++) is needed when a native module's prebuilt
-# binary download fails and node-gyp falls back to compiling from source —
-# it stays out of the runtime image.
-RUN apk add --no-cache python3 make g++
+# Build toolchain (python3/py3-setuptools/make/g++) is needed when a native
+# module's prebuilt binary download fails and node-gyp falls back to compiling
+# from source — it stays out of the runtime image. py3-setuptools provides the
+# distutils module node-gyp needs on Python 3.12+.
+RUN apk add --no-cache python3 py3-setuptools make g++
 
 RUN npm install -g corepack && corepack enable
-
-# Pre-cache Node headers so that if a native module's prebuilt-binary download
-# times out and node-gyp falls back to compiling from source, the header tarball
-# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
-# transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 WORKDIR /daytona
 

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -2,18 +2,13 @@ FROM node:22-alpine AS build
 
 ENV CI=true
 
-# Build toolchain (python3/make/g++) is needed when a native module's prebuilt
-# binary download fails and node-gyp falls back to compiling from source —
-# it stays out of the runtime image.
-RUN apk add --no-cache python3 make g++
+# Build toolchain (python3/py3-setuptools/make/g++) is needed when a native
+# module's prebuilt binary download fails and node-gyp falls back to compiling
+# from source — it stays out of the runtime image. py3-setuptools provides the
+# distutils module node-gyp needs on Python 3.12+.
+RUN apk add --no-cache python3 py3-setuptools make g++
 
 RUN npm install -g corepack && corepack enable
-
-# Pre-cache Node headers so that if a native module's prebuilt-binary download
-# times out and node-gyp falls back to compiling from source, the header tarball
-# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
-# transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 WORKDIR /daytona
 

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -13,7 +13,7 @@ RUN npm install -g corepack && corepack enable
 # times out and node-gyp falls back to compiling from source, the header tarball
 # is already local — no flaky network/DNS lookup mid-install. Retried to absorb
 # transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 WORKDIR /daytona
 

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -9,6 +9,12 @@ RUN apk add --no-cache python3 make g++
 
 RUN npm install -g corepack && corepack enable
 
+# Pre-cache Node headers so that if a native module's prebuilt-binary download
+# times out and node-gyp falls back to compiling from source, the header tarball
+# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
+# transient DNS failures on this single fetch.
+RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+
 WORKDIR /daytona
 
 # Yarn caching layer

--- a/apps/otel-collector/Dockerfile
+++ b/apps/otel-collector/Dockerfile
@@ -4,6 +4,11 @@ FROM node:22-alpine AS build
 
 ENV CI=true
 
+# Build toolchain (python3/make/g++) is needed when a native module's prebuilt
+# binary download fails and node-gyp falls back to compiling from source —
+# it stays out of the runtime image.
+RUN apk add --no-cache python3 make g++
+
 RUN npm install -g corepack && corepack enable
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/

--- a/apps/otel-collector/Dockerfile
+++ b/apps/otel-collector/Dockerfile
@@ -11,6 +11,12 @@ RUN apk add --no-cache python3 make g++
 
 RUN npm install -g corepack && corepack enable
 
+# Pre-cache Node headers so that if a native module's prebuilt-binary download
+# times out and node-gyp falls back to compiling from source, the header tarball
+# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
+# transient DNS failures on this single fetch.
+RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/apps/otel-collector/Dockerfile
+++ b/apps/otel-collector/Dockerfile
@@ -15,7 +15,7 @@ RUN npm install -g corepack && corepack enable
 # times out and node-gyp falls back to compiling from source, the header tarball
 # is already local — no flaky network/DNS lookup mid-install. Retried to absorb
 # transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 

--- a/apps/otel-collector/Dockerfile
+++ b/apps/otel-collector/Dockerfile
@@ -4,18 +4,13 @@ FROM node:22-alpine AS build
 
 ENV CI=true
 
-# Build toolchain (python3/make/g++) is needed when a native module's prebuilt
-# binary download fails and node-gyp falls back to compiling from source —
-# it stays out of the runtime image.
-RUN apk add --no-cache python3 make g++
+# Build toolchain (python3/py3-setuptools/make/g++) is needed when a native
+# module's prebuilt binary download fails and node-gyp falls back to compiling
+# from source — it stays out of the runtime image. py3-setuptools provides the
+# distutils module node-gyp needs on Python 3.12+.
+RUN apk add --no-cache python3 py3-setuptools make g++
 
 RUN npm install -g corepack && corepack enable
-
-# Pre-cache Node headers so that if a native module's prebuilt-binary download
-# times out and node-gyp falls back to compiling from source, the header tarball
-# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
-# transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 

--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -4,6 +4,11 @@ FROM node:22-alpine AS build
 
 ENV CI=true
 
+# Build toolchain (python3/make/g++) is needed when a native module's prebuilt
+# binary download fails and node-gyp falls back to compiling from source —
+# it stays out of the runtime image.
+RUN apk add --no-cache python3 make g++
+
 RUN npm install -g corepack && corepack enable
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/

--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -11,6 +11,12 @@ RUN apk add --no-cache python3 make g++
 
 RUN npm install -g corepack && corepack enable
 
+# Pre-cache Node headers so that if a native module's prebuilt-binary download
+# times out and node-gyp falls back to compiling from source, the header tarball
+# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
+# transient DNS failures on this single fetch.
+RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -15,7 +15,7 @@ RUN npm install -g corepack && corepack enable
 # times out and node-gyp falls back to compiling from source, the header tarball
 # is already local — no flaky network/DNS lookup mid-install. Retried to absorb
 # transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 

--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -4,18 +4,13 @@ FROM node:22-alpine AS build
 
 ENV CI=true
 
-# Build toolchain (python3/make/g++) is needed when a native module's prebuilt
-# binary download fails and node-gyp falls back to compiling from source —
-# it stays out of the runtime image.
-RUN apk add --no-cache python3 make g++
+# Build toolchain (python3/py3-setuptools/make/g++) is needed when a native
+# module's prebuilt binary download fails and node-gyp falls back to compiling
+# from source — it stays out of the runtime image. py3-setuptools provides the
+# distutils module node-gyp needs on Python 3.12+.
+RUN apk add --no-cache python3 py3-setuptools make g++
 
 RUN npm install -g corepack && corepack enable
-
-# Pre-cache Node headers so that if a native module's prebuilt-binary download
-# times out and node-gyp falls back to compiling from source, the header tarball
-# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
-# transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -4,6 +4,11 @@ FROM node:22-alpine AS build
 
 ENV CI=true
 
+# Build toolchain (python3/make/g++) is needed when a native module's prebuilt
+# binary download fails and node-gyp falls back to compiling from source —
+# it stays out of the runtime image.
+RUN apk add --no-cache python3 make g++
+
 RUN npm install -g corepack && corepack enable
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -11,6 +11,12 @@ RUN apk add --no-cache python3 make g++
 
 RUN npm install -g corepack && corepack enable
 
+# Pre-cache Node headers so that if a native module's prebuilt-binary download
+# times out and node-gyp falls back to compiling from source, the header tarball
+# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
+# transient DNS failures on this single fetch.
+RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -15,7 +15,7 @@ RUN npm install -g corepack && corepack enable
 # times out and node-gyp falls back to compiling from source, the header tarball
 # is already local — no flaky network/DNS lookup mid-install. Retried to absorb
 # transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -4,18 +4,13 @@ FROM node:22-alpine AS build
 
 ENV CI=true
 
-# Build toolchain (python3/make/g++) is needed when a native module's prebuilt
-# binary download fails and node-gyp falls back to compiling from source —
-# it stays out of the runtime image.
-RUN apk add --no-cache python3 make g++
+# Build toolchain (python3/py3-setuptools/make/g++) is needed when a native
+# module's prebuilt binary download fails and node-gyp falls back to compiling
+# from source — it stays out of the runtime image. py3-setuptools provides the
+# distutils module node-gyp needs on Python 3.12+.
+RUN apk add --no-cache python3 py3-setuptools make g++
 
 RUN npm install -g corepack && corepack enable
-
-# Pre-cache Node headers so that if a native module's prebuilt-binary download
-# times out and node-gyp falls back to compiling from source, the header tarball
-# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
-# transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 

--- a/apps/snapshot-manager/Dockerfile
+++ b/apps/snapshot-manager/Dockerfile
@@ -4,6 +4,11 @@ FROM node:22-alpine AS build
 
 ENV CI=true
 
+# Build toolchain (python3/make/g++) is needed when a native module's prebuilt
+# binary download fails and node-gyp falls back to compiling from source —
+# it stays out of the runtime image.
+RUN apk add --no-cache python3 make g++
+
 RUN npm install -g corepack && corepack enable
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/

--- a/apps/snapshot-manager/Dockerfile
+++ b/apps/snapshot-manager/Dockerfile
@@ -11,6 +11,12 @@ RUN apk add --no-cache python3 make g++
 
 RUN npm install -g corepack && corepack enable
 
+# Pre-cache Node headers so that if a native module's prebuilt-binary download
+# times out and node-gyp falls back to compiling from source, the header tarball
+# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
+# transient DNS failures on this single fetch.
+RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/apps/snapshot-manager/Dockerfile
+++ b/apps/snapshot-manager/Dockerfile
@@ -15,7 +15,7 @@ RUN npm install -g corepack && corepack enable
 # times out and node-gyp falls back to compiling from source, the header tarball
 # is already local — no flaky network/DNS lookup mid-install. Retried to absorb
 # transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 

--- a/apps/snapshot-manager/Dockerfile
+++ b/apps/snapshot-manager/Dockerfile
@@ -4,18 +4,13 @@ FROM node:22-alpine AS build
 
 ENV CI=true
 
-# Build toolchain (python3/make/g++) is needed when a native module's prebuilt
-# binary download fails and node-gyp falls back to compiling from source —
-# it stays out of the runtime image.
-RUN apk add --no-cache python3 make g++
+# Build toolchain (python3/py3-setuptools/make/g++) is needed when a native
+# module's prebuilt binary download fails and node-gyp falls back to compiling
+# from source — it stays out of the runtime image. py3-setuptools provides the
+# distutils module node-gyp needs on Python 3.12+.
+RUN apk add --no-cache python3 py3-setuptools make g++
 
 RUN npm install -g corepack && corepack enable
-
-# Pre-cache Node headers so that if a native module's prebuilt-binary download
-# times out and node-gyp falls back to compiling from source, the header tarball
-# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
-# transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 

--- a/apps/ssh-gateway/Dockerfile
+++ b/apps/ssh-gateway/Dockerfile
@@ -4,6 +4,11 @@ FROM node:22-alpine AS build
 
 ENV CI=true
 
+# Build toolchain (python3/make/g++) is needed when a native module's prebuilt
+# binary download fails and node-gyp falls back to compiling from source —
+# it stays out of the runtime image.
+RUN apk add --no-cache python3 make g++
+
 RUN npm install -g corepack && corepack enable
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/

--- a/apps/ssh-gateway/Dockerfile
+++ b/apps/ssh-gateway/Dockerfile
@@ -11,6 +11,12 @@ RUN apk add --no-cache python3 make g++
 
 RUN npm install -g corepack && corepack enable
 
+# Pre-cache Node headers so that if a native module's prebuilt-binary download
+# times out and node-gyp falls back to compiling from source, the header tarball
+# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
+# transient DNS failures on this single fetch.
+RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/apps/ssh-gateway/Dockerfile
+++ b/apps/ssh-gateway/Dockerfile
@@ -15,7 +15,7 @@ RUN npm install -g corepack && corepack enable
 # times out and node-gyp falls back to compiling from source, the header tarball
 # is already local — no flaky network/DNS lookup mid-install. Retried to absorb
 # transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && break || sleep 5; done
+RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 

--- a/apps/ssh-gateway/Dockerfile
+++ b/apps/ssh-gateway/Dockerfile
@@ -4,18 +4,13 @@ FROM node:22-alpine AS build
 
 ENV CI=true
 
-# Build toolchain (python3/make/g++) is needed when a native module's prebuilt
-# binary download fails and node-gyp falls back to compiling from source —
-# it stays out of the runtime image.
-RUN apk add --no-cache python3 make g++
+# Build toolchain (python3/py3-setuptools/make/g++) is needed when a native
+# module's prebuilt binary download fails and node-gyp falls back to compiling
+# from source — it stays out of the runtime image. py3-setuptools provides the
+# distutils module node-gyp needs on Python 3.12+.
+RUN apk add --no-cache python3 py3-setuptools make g++
 
 RUN npm install -g corepack && corepack enable
-
-# Pre-cache Node headers so that if a native module's prebuilt-binary download
-# times out and node-gyp falls back to compiling from source, the header tarball
-# is already local — no flaky network/DNS lookup mid-install. Retried to absorb
-# transient DNS failures on this single fetch.
-RUN for i in 1 2 3; do npx --yes node-gyp install && exit 0; sleep 5; done; exit 1
 
 COPY --from=go-toolchain /usr/local/go/ /usr/local/go/
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add build tools and Python setuptools in Node builder stages so `yarn` can build native modules when prebuilt binaries are missing. Fixes Python 3.12 `distutils` for `node-gyp` and reduces CI flakes without increasing runtime image size.

- **Dependencies**
  - Install `python3`, `python3-setuptools`/`py3-setuptools`, `make`, `g++` in builder stages to enable native builds (`distutils` on Python 3.12+).
  - Pre-cache Node headers via `npx --yes node-gyp install` with retries in `api`, `dashboard`, `docs`, `otel-collector`, `proxy`, `runner`, `snapshot-manager`, and `ssh-gateway`.

<sup>Written for commit 2ed469c24136b37e1864dc98eb8b7b0e27868db6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

