### PR TITLE
fix(api,cli): snapshot create with sandbox class

### DIFF
--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -377,7 +377,7 @@ export class RunnerService {
    * creation fast with a 400 instead of letting it sit in PENDING indefinitely.
    */
   async hasSchedulableRunner(regionId: string, sandboxClass: SandboxClass): Promise<boolean> {
-    const count = await this.runnerRepository.count({
+    return this.runnerRepository.exists({
       where: {
         region: regionId,
         sandboxClass,
@@ -385,7 +385,6 @@ export class RunnerService {
         draining: Not(true),
       },
     })
-    return count > 0
   }
 
   /**

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -362,6 +362,33 @@ export class RunnerService {
   }
 
   /**
+   * Returns true if at least one runner is registered for the given (region, sandboxClass)
+   * and is currently schedulable.
+   *
+   * Callers must apply `getRunnerSandboxClass(snapshot.sandboxClass)` before calling, matching the
+   * convention used by `findAvailableRunners` / `getRandomAvailableRunner`. Otherwise classes
+   * that re-target to a different runner pool (currently `ANDROID → CONTAINER`) will be
+   * falsely reported as having no schedulable runners.
+   *
+   * Intentionally ignores transient signals like `state` (e.g. UNRESPONSIVE) and
+   * `availabilityScore`, so this returns true even if every matching runner is temporarily
+   * unhealthy. The purpose is to detect a *structural* misconfiguration where no runner could
+   * ever host a snapshot of that (region, sandboxClass) combination, and to fail snapshot
+   * creation fast with a 400 instead of letting it sit in PENDING indefinitely.
+   */
+  async hasSchedulableRunner(regionId: string, sandboxClass: SandboxClass): Promise<boolean> {
+    const count = await this.runnerRepository.count({
+      where: {
+        region: regionId,
+        sandboxClass,
+        unschedulable: Not(true),
+        draining: Not(true),
+      },
+    })
+    return count > 0
+  }
+
+  /**
    * @throws {NotFoundException} If the runner is not found.
    * @throws {HttpException} If the runner is not unschedulable.
    * @throws {HttpException} If the runner has sandboxes associated with it.

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -149,6 +149,16 @@ export class SnapshotService {
       .getExists()
   }
 
+  private async assertHasSchedulableRunner(region: Region, sandboxClass: SandboxClass): Promise<void> {
+    // Temporary: Android snapshots can go to container runners
+    const hasRunner = await this.runnerService.hasSchedulableRunner(region.id, getRunnerSandboxClass(sandboxClass))
+    if (!hasRunner) {
+      throw new BadRequestException(
+        `No runners are configured in region '${region.name}' for sandbox class '${sandboxClass}'. Try a different region or sandbox class.`,
+      )
+    }
+  }
+
   async createFromPull(organization: Organization, createSnapshotDto: CreateSnapshotDto, general = false) {
     if (!organization.defaultRegionId) {
       throw new DefaultRegionRequiredException()
@@ -184,6 +194,8 @@ export class SnapshotService {
           'Windows snapshots cannot be created via this endpoint; they are produced by snapshot-from-sandbox flows.',
         )
       }
+
+      await this.assertHasSchedulableRunner(region, sandboxClass)
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
@@ -280,6 +292,8 @@ export class SnapshotService {
           'Windows snapshots cannot be created via this endpoint; they are produced by snapshot-from-sandbox flows.',
         )
       }
+
+      await this.assertHasSchedulableRunner(region, sandboxClass)
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 

--- a/apps/cli/cmd/snapshot/create.go
+++ b/apps/cli/cmd/snapshot/create.go
@@ -54,6 +54,20 @@ var CreateCmd = &cobra.Command{
 		if regionIdFlag != "" {
 			createSnapshot.SetRegionId(regionIdFlag)
 		}
+		if sandboxClassFlag != "" {
+			var sc apiclient.SandboxClass
+			switch sandboxClassFlag {
+			case "container":
+				sc = apiclient.SANDBOXCLASS_CONTAINER
+			case "linux-vm":
+				sc = apiclient.SANDBOXCLASS_LINUX_VM
+			case "android":
+				sc = apiclient.SANDBOXCLASS_ANDROID
+			default:
+				return fmt.Errorf("invalid --sandbox-class %q: must be 'container', 'linux-vm' or 'android'", sandboxClassFlag)
+			}
+			createSnapshot.SetSandboxClass(sc)
+		}
 
 		if usingDockerfile {
 			createBuildInfoDto, err := common.GetCreateBuildInfoDto(ctx, dockerfilePathFlag, contextFlag)
@@ -142,6 +156,7 @@ var (
 	memoryFlag         int32
 	diskFlag           int32
 	regionIdFlag       string
+	sandboxClassFlag   string
 )
 
 func init() {
@@ -153,6 +168,7 @@ func init() {
 	CreateCmd.Flags().Int32Var(&memoryFlag, "memory", 0, "Memory that will be allocated to the underlying sandboxes in GB (default: 1)")
 	CreateCmd.Flags().Int32Var(&diskFlag, "disk", 0, "Disk space that will be allocated to the underlying sandboxes in GB (default: 3)")
 	CreateCmd.Flags().StringVar(&regionIdFlag, "region", "", "ID of the region where the snapshot will be available (defaults to organization default region)")
+	CreateCmd.Flags().StringVar(&sandboxClassFlag, "sandbox-class", "", "Target sandbox class for the snapshot. One of: 'container', 'linux-vm' or 'android' (defaults to organization/server default)")
 
 	CreateCmd.MarkFlagsMutuallyExclusive("image", "dockerfile")
 	CreateCmd.MarkFlagsMutuallyExclusive("image", "context")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add sandbox-class selection to snapshot creation and fail fast with a 400 when the chosen region can’t host that class. Also uses a lightweight exists check to validate runner availability. CLI supports `container`, `linux-vm`, and `android` (android targets container runners).

- **New Features**
  - CLI: Added `--sandbox-class` to `snapshot create` with `container`, `linux-vm`, or `android`.

- **Bug Fixes**
  - API: Before creating a snapshot, assert the region has at least one schedulable runner for the selected class (ignores transient runner state like UNRESPONSIVE); return 400 with a clear message if none.
  - API: Optimized runner availability check to use an exists query instead of count.

<sup>Written for commit 67bd1078b03bb5ac0ec3318d3e41f532ec2c44bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

