### PR TITLE
fix: handle spaces in Python image COPY paths

### DIFF
--- a/libs/sdk-python/src/daytona/common/image.py
+++ b/libs/sdk-python/src/daytona/common/image.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import glob
+import json
 import os
 import re
 import shlex
@@ -240,7 +241,7 @@ class Image(BaseModel):
 
         archive_path = ObjectStorage.compute_archive_base_path(local_path)
         self._context_list.append(Context(source_path=local_path, archive_path=archive_path))
-        self._dockerfile += f"COPY {archive_path} {remote_path}\n"
+        self._dockerfile += f"COPY {self.__dockerfile_json_args([archive_path, remote_path])}\n"
 
         return self
 
@@ -268,7 +269,7 @@ class Image(BaseModel):
 
         archive_path = ObjectStorage.compute_archive_base_path(local_path)
         self._context_list.append(Context(source_path=local_path, archive_path=archive_path))
-        self._dockerfile += f"COPY {archive_path} {remote_path}\n"
+        self._dockerfile += f"COPY {self.__dockerfile_json_args([archive_path, remote_path])}\n"
 
         return self
 
@@ -564,13 +565,14 @@ class Image(BaseModel):
         # Handle JSON array format: COPY ["src1", "src2", "dest"]
         if parts.startswith("["):
             try:
-                # Parse the JSON-like array format
-                elements = shlex.split(parts.replace("[", "").replace("]", ""))
+                elements = json.loads(parts)
                 if len(elements) < 2:
+                    return None
+                if not all(isinstance(element, str) for element in elements):
                     return None
 
                 return {"sources": elements[:-1], "dest": elements[-1]}
-            except:
+            except (json.JSONDecodeError, TypeError):
                 return None
 
         # Handle regular format with possible flags
@@ -613,6 +615,10 @@ class Image(BaseModel):
                 ret.extend(x)
 
         return ret
+
+    @staticmethod
+    def __dockerfile_json_args(args: list[str]) -> str:
+        return json.dumps(args)
 
     @staticmethod
     def __format_pip_install_args(

--- a/libs/sdk-python/tests/test_image.py
+++ b/libs/sdk-python/tests/test_image.py
@@ -188,6 +188,17 @@ class TestImageFromDockerfile:
             finally:
                 os.unlink(f.name)
 
+    def test_from_dockerfile_parses_json_copy_with_spaces(self, tmp_path):
+        source = tmp_path / "config with spaces.txt"
+        source.write_text("test content")
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text('FROM python:3.12\nCOPY ["config with spaces.txt", "/app/config with spaces.txt"]\n')
+
+        img = Image.from_dockerfile(dockerfile)
+
+        assert img._context_list[0].source_path == str(source)
+        assert img._context_list[0].archive_path == "config with spaces.txt"
+
     def test_missing_dockerfile_raises(self):
         with pytest.raises(DaytonaError, match="does not exist"):
             Image.from_dockerfile("/nonexistent/Dockerfile")
@@ -267,3 +278,12 @@ class TestImageAddLocal:
                 assert f"/app/{os.path.basename(f.name)}" in img.dockerfile()
             finally:
                 os.unlink(f.name)
+
+    def test_add_local_file_handles_spaces_in_filename(self, tmp_path):
+        local_file = tmp_path / "config with spaces.txt"
+        local_file.write_text("test content")
+
+        img = Image.base("python:3.12").add_local_file(local_file, "/app/config with spaces.txt")
+
+        archive_path = str(local_file).lstrip("/")
+        assert f'COPY ["{archive_path}", "/app/config with spaces.txt"]' in img.dockerfile()


### PR DESCRIPTION
## Description

Handle Python SDK image `COPY` directives with local file or directory paths that contain spaces by emitting Dockerfile JSON-array syntax and parsing JSON-form `COPY` sources when reading a Dockerfile.

Fixes #2700

## Documentation

- [x] No documentation update is required for this Python SDK bug fix.
- [x] No documentation changes were needed.

## Related Issue(s)

This PR addresses issue #2700.

## Screenshots

n/a

## Notes

Validation:

```bash
PYTHONPATH="libs/sdk-python/src:libs/api-client-python:libs/api-client-python-async:libs/toolbox-api-client-python:libs/toolbox-api-client-python-async" libs/sdk-python/.venv/bin/pytest libs/sdk-python/tests/test_image.py::TestImageFromDockerfile libs/sdk-python/tests/test_image.py::TestImageAddLocal -q
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix handling of Dockerfile COPY paths with spaces in the Python SDK by emitting JSON-array syntax and parsing JSON-form COPY directives when reading Dockerfiles. Fixes #2700.

- **Bug Fixes**
  - Emit JSON-array args for COPY in add_local_file/add_local_dir to preserve spaces.
  - Parse JSON-form COPY with json.loads and validate string elements when loading a Dockerfile.
  - Add tests for JSON COPY parsing and paths with spaces.

<sup>Written for commit 7345a6ca0c35474c6f5872a87f3945f056ee4e14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

