### PR TITLE
config wip

### DIFF
--- a/apps/dashboard/src/components/ApiKeyTable.tsx
+++ b/apps/dashboard/src/components/ApiKeyTable.tsx
@@ -6,7 +6,7 @@
 import { CREATE_API_KEY_PERMISSIONS_GROUPS } from '@/constants/CreateApiKeyPermissionsGroups'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { ApiKeyList, ApiKeyListPermissionsEnum, CreateApiKeyPermissionsEnum } from '@daytona/api-client'
 
 import {
@@ -69,6 +69,7 @@ export function ApiKeyTable({ data, loading, isLoadingKey, onRevokeRequest }: Da
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState('')
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
     meta: {
@@ -127,6 +128,7 @@ export function ApiKeyTable({ data, loading, isLoadingKey, onRevokeRequest }: Da
         />
       </div>
       <TableContainer
+        table={table}
         className={cn({
           'min-h-[26rem]': isEmpty,
         })}
@@ -172,13 +174,14 @@ export function ApiKeyTable({ data, loading, isLoadingKey, onRevokeRequest }: Da
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
+                    header={header}
                     sticky={header.column.getIsPinned()}
                     style={getColumnSizeStyles(header.column)}
                   >
@@ -265,7 +268,7 @@ const columns: ColumnDef<ApiKeyList>[] = [
     header: 'Key',
     size: 220,
     cell: ({ row }) => {
-      return <div className="truncate">{row.original.value}</div>
+      return <div className="truncate text-muted-foreground">{row.original.value}</div>
     },
   },
   {

--- a/apps/dashboard/src/components/ApiKeyTable.tsx
+++ b/apps/dashboard/src/components/ApiKeyTable.tsx
@@ -6,7 +6,7 @@
 import { CREATE_API_KEY_PERMISSIONS_GROUPS } from '@/constants/CreateApiKeyPermissionsGroups'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { ApiKeyList, ApiKeyListPermissionsEnum, CreateApiKeyPermissionsEnum } from '@daytona/api-client'
 
 import {
@@ -75,9 +75,7 @@ export function ApiKeyTable({ data, loading, isLoadingKey, onRevokeRequest }: Da
     meta: {
       apiKey: { isLoadingKey, onRevokeRequest },
     },
-    defaultColumn: {
-      minSize: 0,
-    },
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/apps/dashboard/src/components/AuditLogTable.tsx
+++ b/apps/dashboard/src/components/AuditLogTable.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/components/ui/table'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn, getMaskedTokenFromParts, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { AuditLog } from '@daytona/api-client'
 import { Column, ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { TextSearch } from 'lucide-react'
@@ -58,6 +58,7 @@ export function AuditLogTable({
     columnResizeMode: 'onEnd',
     data,
     columns: auditLogColumns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     getCoreRowModel: getCoreRowModel(),
     manualPagination: true,
     pageCount: pageCount || 1,

--- a/apps/dashboard/src/components/AuditLogTable.tsx
+++ b/apps/dashboard/src/components/AuditLogTable.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/components/ui/table'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn, getMaskedTokenFromParts, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { AuditLog } from '@daytona/api-client'
 import { Column, ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { TextSearch } from 'lucide-react'
@@ -55,6 +55,7 @@ export function AuditLogTable({
   toolbarActions,
 }: Props) {
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: auditLogColumns,
     getCoreRowModel: getCoreRowModel(),
@@ -81,6 +82,7 @@ export function AuditLogTable({
     <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
       <div className="flex items-center justify-between gap-2 empty:hidden">{toolbarActions}</div>
       <TableContainer
+        table={table}
         className={cn({
           'min-h-[26rem]': isEmpty,
         })}
@@ -107,13 +109,17 @@ export function AuditLogTable({
           ) : null
         }
       >
-        <Table>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => {
                   return (
-                    <TableHead key={header.id} style={isEmpty ? undefined : getColumnSizeStyles(header.column)}>
+                    <TableHead
+                      key={header.id}
+                      header={header}
+                      style={isEmpty ? undefined : getColumnSizeStyles(header.column)}
+                    >
                       {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
                     </TableHead>
                   )

--- a/apps/dashboard/src/components/Charges/index.tsx
+++ b/apps/dashboard/src/components/Charges/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { flexRender } from '@tanstack/react-table'
 import { Receipt } from 'lucide-react'
 import { Pagination } from '../Pagination'
@@ -33,6 +33,7 @@ export function ChargesTable({ data, loading, onRowClick }: ChargesTableProps) {
       <ChargesTableHeader table={table} />
 
       <TableContainer
+        table={table}
         className={cn('max-h-[550px]', {
           'min-h-[20rem]': isEmpty,
         })}
@@ -54,13 +55,14 @@ export function ChargesTable({ data, loading, onRowClick }: ChargesTableProps) {
           ) : null
         }
       >
-        <Table className="table-fixed border-separate border-spacing-0" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed border-separate border-spacing-0" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
+                    header={header}
                     sticky={header.column.getIsPinned()}
                     style={getColumnSizeStyles(header.column)}
                   >

--- a/apps/dashboard/src/components/Charges/useChargesTable.ts
+++ b/apps/dashboard/src/components/Charges/useChargesTable.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { DEFAULT_TABLE_COLUMN } from '@/lib/utils/table'
 import { Charge } from '@daytona/billing-api-client'
 import {
   ColumnFiltersState,
@@ -55,6 +56,7 @@ export function useChargesTable({ data }: UseChargesTableProps) {
       pagination,
     },
     defaultColumn: {
+      ...DEFAULT_TABLE_COLUMN,
       size: 100,
     },
     getRowId: (row, index) => row.id ?? String(index),

--- a/apps/dashboard/src/components/Charges/useChargesTable.ts
+++ b/apps/dashboard/src/components/Charges/useChargesTable.ts
@@ -33,8 +33,8 @@ export function useChargesTable({ data }: UseChargesTableProps) {
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 })
 
   const columns = useMemo(() => getColumns(), [])
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
     onColumnFiltersChange: setColumnFilters,

--- a/apps/dashboard/src/components/DataTableConfigMenu.tsx
+++ b/apps/dashboard/src/components/DataTableConfigMenu.tsx
@@ -1,0 +1,651 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { Column, ColumnPinningState, Table, VisibilityState } from '@tanstack/react-table'
+import isEqual from 'fast-deep-equal'
+import { Eye, EyeOff, GripVertical, Pin, PinOff, RotateCcw, Settings2Icon } from 'lucide-react'
+import { motion, Reorder, useDragControls } from 'motion/react'
+import { type ComponentProps, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { useDeepCompareMemo } from '@/hooks/useDeepCompareMemo'
+import { useStorageState } from '@/hooks/useStorageState'
+import { cn } from '@/lib/utils'
+import { Button } from './ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from './ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
+
+const DATA_TABLE_CONFIG_STORAGE_PREFIX = 'daytona:data-table-config'
+const DATA_TABLE_CONFIG_VERSION = 1
+const DEFAULT_DATA_TABLE_CONFIG_EXCLUDED_COLUMN_IDS = ['actions', 'select'] as const
+const DATA_TABLE_CONFIG_PIN_SEPARATOR_ID = '__data-table-config-pin-separator__'
+
+type DataTableConfig = {
+  columnOrder: string[]
+  columnPinning: ColumnPinningState
+  columnVisibility: VisibilityState
+}
+
+type DataTableConfigMenuProps<TData> = {
+  align?: ComponentProps<typeof DropdownMenuContent>['align']
+  className?: string
+  excludedColumnIds?: readonly string[]
+  getColumnLabel?: (columnId: string) => string
+  persistenceKey: string
+  table: Table<TData>
+}
+
+function DataTableConfigMenu<TData>({
+  align = 'end',
+  className,
+  excludedColumnIds = DEFAULT_DATA_TABLE_CONFIG_EXCLUDED_COLUMN_IDS,
+  getColumnLabel,
+  persistenceKey,
+  table,
+}: DataTableConfigMenuProps<TData>) {
+  const storageKey = useMemo(() => getTableConfigStorageKey(persistenceKey), [persistenceKey])
+  const initialConfigRef = useRef<DataTableConfig | null>(null)
+  const initialConfigStorageKeyRef = useRef<string | null>(null)
+  const appliedStoredConfigKeyRef = useRef<string | null>(null)
+
+  const [storedConfig, setStoredConfig, removeStoredConfig, { hasStoredValue: hasStoredConfig }] =
+    useStorageState<DataTableConfig | null>(storageKey, null, {
+      deserialize: deserializeTableConfig,
+    })
+
+  if (initialConfigStorageKeyRef.current !== storageKey) {
+    initialConfigRef.current = getCurrentTableConfig(table)
+    initialConfigStorageKeyRef.current = storageKey
+  }
+
+  const excludedColumnIdSet = useMemo(() => new Set(excludedColumnIds), [excludedColumnIds])
+  const columns = table.getAllLeafColumns()
+  const configurableColumns = columns.filter((column) => getColumnCanBeConfigured(column, excludedColumnIdSet))
+  const configurableColumnIds = configurableColumns.map((column) => column.id)
+  const configurableColumnsById = new Map(configurableColumns.map((column) => [column.id, column]))
+  const currentGroupedColumnOrder = useDeepCompareMemo(
+    getGroupedColumnOrder(columns, table.getState().columnOrder, table.getState().columnPinning, configurableColumnIds),
+  )
+  const [localGroupedColumnOrder, setLocalGroupedColumnOrder] = useState(currentGroupedColumnOrder)
+  const localGroupedColumnOrderRef = useRef(localGroupedColumnOrder)
+  const localGroupedColumnState = splitGroupedColumnOrder(localGroupedColumnOrder, configurableColumnIds)
+  const hasPinnedConfigurableColumns = localGroupedColumnState.pinnedColumnIds.length > 0
+  const currentConfig = getCurrentTableConfig(table)
+  const initialConfig = initialConfigRef.current
+  const hasConfigChanges = Boolean(initialConfig && !isEqual(currentConfig, initialConfig))
+
+  useEffect(() => {
+    setLocalGroupedColumnOrder(currentGroupedColumnOrder)
+    localGroupedColumnOrderRef.current = currentGroupedColumnOrder
+  }, [currentGroupedColumnOrder])
+
+  const persistConfig = useCallback(
+    (updates: Partial<DataTableConfig>) => {
+      const nextConfig = normalizeTableConfig(
+        {
+          ...getCurrentTableConfig(table),
+          ...updates,
+        },
+        table.getAllLeafColumns(),
+      )
+
+      if (initialConfigRef.current && isEqual(nextConfig, initialConfigRef.current)) {
+        removeStoredConfig()
+        return
+      }
+
+      setStoredConfig(nextConfig)
+    },
+    [removeStoredConfig, setStoredConfig, table],
+  )
+
+  const applyConfig = useCallback(
+    (config: DataTableConfig) => {
+      const normalizedConfig = normalizeTableConfig(config, table.getAllLeafColumns())
+
+      table.setColumnOrder(normalizedConfig.columnOrder)
+      table.setColumnVisibility(normalizedConfig.columnVisibility)
+      table.setColumnPinning(normalizedConfig.columnPinning)
+    },
+    [table],
+  )
+
+  useEffect(() => {
+    if (appliedStoredConfigKeyRef.current === storageKey) {
+      return
+    }
+
+    appliedStoredConfigKeyRef.current = storageKey
+
+    if (storedConfig) {
+      applyConfig(storedConfig)
+    }
+  }, [applyConfig, storageKey, storedConfig])
+
+  const handleVisibilityToggle = useCallback(
+    (column: Column<TData, unknown>) => {
+      const nextVisibility = {
+        ...table.getState().columnVisibility,
+        [column.id]: !column.getIsVisible(),
+      }
+
+      table.setColumnVisibility(nextVisibility)
+      persistConfig({ columnVisibility: nextVisibility })
+    },
+    [persistConfig, table],
+  )
+
+  const handlePinToggle = useCallback(
+    (column: Column<TData, unknown>) => {
+      const currentPinning = normalizeColumnPinning(table.getState().columnPinning, table.getAllLeafColumns())
+      const nextPinning = getNextColumnPinning(currentPinning, column.id, column.getIsPinned() ? false : 'left')
+
+      table.setColumnPinning(nextPinning)
+      persistConfig({ columnPinning: nextPinning })
+    },
+    [persistConfig, table],
+  )
+
+  const commitGroupedColumnOrder = useCallback(
+    (nextGroupedColumnOrder: string[]) => {
+      const nextConfig = getTableConfigUpdatesFromGroupedOrder(table, nextGroupedColumnOrder, configurableColumnIds)
+
+      table.setColumnOrder(nextConfig.columnOrder)
+      table.setColumnPinning(nextConfig.columnPinning)
+      persistConfig(nextConfig)
+    },
+    [configurableColumnIds, persistConfig, table],
+  )
+
+  const handleLocalReorder = useCallback((nextGroupedColumnOrder: string[]) => {
+    localGroupedColumnOrderRef.current = nextGroupedColumnOrder
+    setLocalGroupedColumnOrder(nextGroupedColumnOrder)
+  }, [])
+
+  const handleDragEnd = useCallback(() => {
+    commitGroupedColumnOrder(localGroupedColumnOrderRef.current)
+  }, [commitGroupedColumnOrder])
+
+  const handleUnpinAll = useCallback(() => {
+    const groupedOrder = splitGroupedColumnOrder(localGroupedColumnOrderRef.current, configurableColumnIds)
+    const nextGroupedColumnOrder = [DATA_TABLE_CONFIG_PIN_SEPARATOR_ID, ...groupedOrder.orderedColumnIds]
+
+    localGroupedColumnOrderRef.current = nextGroupedColumnOrder
+    setLocalGroupedColumnOrder(nextGroupedColumnOrder)
+    commitGroupedColumnOrder(nextGroupedColumnOrder)
+  }, [commitGroupedColumnOrder, configurableColumnIds])
+
+  const handleReset = useCallback(() => {
+    removeStoredConfig()
+
+    const defaultConfig = initialConfigRef.current ?? getCurrentTableConfig(table)
+    applyConfig(defaultConfig)
+  }, [applyConfig, removeStoredConfig, table])
+
+  if (configurableColumns.length === 0) {
+    return null
+  }
+
+  return (
+    <DropdownMenu modal={false}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon-sm"
+              className={cn('relative shrink-0', className)}
+              aria-label="Table settings"
+            >
+              <Settings2Icon className="size-4" />
+              {hasStoredConfig && (
+                <span
+                  aria-hidden="true"
+                  className="absolute right-1 top-1 size-1.5 rounded-full bg-info ring-2 ring-background"
+                />
+              )}
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Table settings</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align={align} className="w-80 p-1.5">
+        <div className="flex items-center justify-between gap-2 px-1 py-1">
+          <DropdownMenuLabel className="px-1 py-0">Columns</DropdownMenuLabel>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2"
+            disabled={!hasConfigChanges}
+            onClick={handleReset}
+          >
+            <RotateCcw className="size-3.5" />
+            Reset
+          </Button>
+        </div>
+        <DropdownMenuSeparator />
+        {hasPinnedConfigurableColumns && (
+          <div className="flex items-center justify-between gap-2 px-2 pb-1 pt-1.5">
+            <div className="text-xs font-medium text-muted-foreground">Pinned</div>
+            <Button type="button" variant="ghost" size="sm" className="h-7 px-2" onClick={handleUnpinAll}>
+              <PinOff className="size-3.5" />
+              Unpin all
+            </Button>
+          </div>
+        )}
+        <motion.div layoutScroll className="scrollbar-sm scroll-fade max-h-80 overflow-y-auto pb-1">
+          <Reorder.Group as="div" axis="y" values={localGroupedColumnOrder} onReorder={handleLocalReorder}>
+            {localGroupedColumnOrder.map((columnId) => {
+              if (columnId === DATA_TABLE_CONFIG_PIN_SEPARATOR_ID) {
+                return <DataTableConfigMenuGroupSeparator key={DATA_TABLE_CONFIG_PIN_SEPARATOR_ID} />
+              }
+
+              const column = configurableColumnsById.get(columnId)
+              if (!column) {
+                return null
+              }
+
+              return (
+                <DataTableConfigMenuItem
+                  key={column.id}
+                  column={column}
+                  label={getColumnLabel?.(column.id) ?? getDefaultColumnLabel(column)}
+                  onDragEnd={handleDragEnd}
+                  onPinToggle={handlePinToggle}
+                  onVisibilityToggle={handleVisibilityToggle}
+                />
+              )
+            })}
+          </Reorder.Group>
+        </motion.div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+type DataTableConfigMenuItemProps<TData> = {
+  column: Column<TData, unknown>
+  label: string
+  onDragEnd: () => void
+  onPinToggle: (column: Column<TData, unknown>) => void
+  onVisibilityToggle: (column: Column<TData, unknown>) => void
+}
+
+function DataTableConfigMenuItem<TData>({
+  column,
+  label,
+  onDragEnd,
+  onPinToggle,
+  onVisibilityToggle,
+}: DataTableConfigMenuItemProps<TData>) {
+  const dragControls = useDragControls()
+  const isPinned = Boolean(column.getIsPinned())
+
+  return (
+    <Reorder.Item
+      as="div"
+      value={column.id}
+      dragControls={dragControls}
+      dragListener={false}
+      onDragEnd={onDragEnd}
+      transition={{ type: 'spring', bounce: 0, duration: 0.12 }}
+      className="relative grid grid-cols-[1.75rem_minmax(0,1fr)_auto] items-center gap-2 rounded-md bg-popover px-1.5 py-1 text-sm hover:bg-accent/60"
+    >
+      <button
+        type="button"
+        aria-label={`Reorder ${label}`}
+        className="flex size-7 cursor-grab touch-none items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground active:cursor-grabbing"
+        onPointerDown={(event) => {
+          if (event.button !== 0) {
+            return
+          }
+
+          dragControls.start(event)
+        }}
+      >
+        <GripVertical className="size-4" />
+      </button>
+
+      <span
+        className={cn('min-w-0 truncate', {
+          'text-muted-foreground': !column.getIsVisible(),
+        })}
+      >
+        {label}
+      </span>
+
+      <div className="flex items-center gap-0.5">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="size-7 text-muted-foreground hover:text-foreground"
+          disabled={!column.getCanHide()}
+          aria-label={`${column.getIsVisible() ? 'Hide' : 'Show'} ${label}`}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onVisibilityToggle(column)
+          }}
+        >
+          {column.getIsVisible() ? <Eye className="size-4" /> : <EyeOff className="size-4" />}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className={cn('size-7 text-muted-foreground hover:text-foreground', {
+            'text-foreground': isPinned,
+          })}
+          disabled={!column.getCanPin()}
+          aria-label={`${isPinned ? 'Unpin' : 'Pin'} ${label}`}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onPinToggle(column)
+          }}
+        >
+          {isPinned ? <PinOff className="size-4" /> : <Pin className="size-4" />}
+        </Button>
+      </div>
+    </Reorder.Item>
+  )
+}
+
+function DataTableConfigMenuGroupSeparator() {
+  return (
+    <Reorder.Item
+      as="div"
+      value={DATA_TABLE_CONFIG_PIN_SEPARATOR_ID}
+      dragListener={false}
+      transition={{ type: 'spring', bounce: 0, duration: 0.12 }}
+      className="cursor-default px-2 pb-1 pt-2 text-xs font-medium text-muted-foreground"
+    >
+      Unpinned
+    </Reorder.Item>
+  )
+}
+
+function getTableConfigStorageKey(persistenceKey: string) {
+  return `${DATA_TABLE_CONFIG_STORAGE_PREFIX}:${persistenceKey}:v${DATA_TABLE_CONFIG_VERSION}`
+}
+
+function getDefaultColumnLabel<TData>(column: Column<TData, unknown>) {
+  return typeof column.columnDef.header === 'string' ? column.columnDef.header : column.id
+}
+
+function getColumnCanBeConfigured<TData>(column: Column<TData, unknown>, excludedColumnIds: Set<string>) {
+  if (excludedColumnIds.has(column.id)) {
+    return false
+  }
+
+  return Boolean(column.columnDef.header || column.columnDef.cell || column.getCanHide() || column.getIsPinned())
+}
+
+function getGroupedColumnOrder<TData>(
+  columns: Column<TData, unknown>[],
+  columnOrder: unknown,
+  columnPinning: unknown,
+  configurableColumnIds: string[],
+) {
+  const configurableColumnIdSet = new Set(configurableColumnIds)
+  const normalizedColumnOrder = normalizeColumnOrder(
+    columnOrder,
+    columns.map((column) => column.id),
+  ).filter((columnId) => configurableColumnIdSet.has(columnId))
+  const normalizedColumnPinning = normalizeColumnPinning(columnPinning, columns)
+  const pinnedColumnIds = new Set([...(normalizedColumnPinning.left ?? []), ...(normalizedColumnPinning.right ?? [])])
+
+  return [
+    ...normalizedColumnOrder.filter((columnId) => pinnedColumnIds.has(columnId)),
+    DATA_TABLE_CONFIG_PIN_SEPARATOR_ID,
+    ...normalizedColumnOrder.filter((columnId) => !pinnedColumnIds.has(columnId)),
+  ]
+}
+
+function getCurrentTableConfig<TData>(table: Table<TData>): DataTableConfig {
+  const columns = table.getAllLeafColumns()
+  const columnIds = columns.map((column) => column.id)
+
+  return normalizeTableConfig(
+    {
+      columnOrder: normalizeColumnOrder(table.getState().columnOrder, columnIds),
+      columnPinning: table.getState().columnPinning,
+      columnVisibility: table.getState().columnVisibility,
+    },
+    columns,
+  )
+}
+
+function normalizeTableConfig<TData>(config: DataTableConfig, columns: Column<TData, unknown>[]): DataTableConfig {
+  const columnIds = columns.map((column) => column.id)
+  const columnOrder = normalizeColumnOrder(config.columnOrder, columnIds)
+
+  return {
+    columnOrder,
+    columnPinning: orderColumnPinning(normalizeColumnPinning(config.columnPinning, columns), columnOrder),
+    columnVisibility: normalizeColumnVisibility(config.columnVisibility, columns),
+  }
+}
+
+function normalizeColumnOrder(columnOrder: unknown, columnIds: string[]) {
+  const columnIdSet = new Set(columnIds)
+  const orderedIds = Array.isArray(columnOrder)
+    ? columnOrder.filter((columnId): columnId is string => typeof columnId === 'string' && columnIdSet.has(columnId))
+    : []
+  const orderedIdSet = new Set(orderedIds)
+  const remainingIds = columnIds.filter((columnId) => !orderedIdSet.has(columnId))
+
+  return [...orderedIds, ...remainingIds]
+}
+
+function normalizeColumnVisibility<TData>(columnVisibility: unknown, columns: Column<TData, unknown>[]) {
+  const columnsById = new Map(columns.map((column) => [column.id, column]))
+  const normalizedVisibility: VisibilityState = {}
+
+  if (!columnVisibility || typeof columnVisibility !== 'object' || Array.isArray(columnVisibility)) {
+    return normalizedVisibility
+  }
+
+  for (const [columnId, isVisible] of Object.entries(columnVisibility)) {
+    const column = columnsById.get(columnId)
+    if (!column?.getCanHide() || typeof isVisible !== 'boolean') {
+      continue
+    }
+
+    normalizedVisibility[columnId] = isVisible
+  }
+
+  return normalizedVisibility
+}
+
+function normalizeColumnPinning<TData>(columnPinning: unknown, columns: Column<TData, unknown>[]) {
+  const columnsById = new Map(columns.map((column) => [column.id, column]))
+  const usedColumnIds = new Set<string>()
+
+  if (!columnPinning || typeof columnPinning !== 'object' || Array.isArray(columnPinning)) {
+    return {}
+  }
+
+  const pinning = columnPinning as ColumnPinningState
+  const readPinnedIds = (side: 'left' | 'right') => {
+    if (!Array.isArray(pinning[side])) {
+      return []
+    }
+
+    return pinning[side].filter((columnId): columnId is string => {
+      const column = columnsById.get(columnId)
+      if (!column?.getCanPin() || usedColumnIds.has(columnId)) {
+        return false
+      }
+
+      usedColumnIds.add(columnId)
+      return true
+    })
+  }
+
+  return {
+    left: readPinnedIds('left'),
+    right: readPinnedIds('right'),
+  }
+}
+
+function getNextColumnPinning(
+  columnPinning: ColumnPinningState,
+  columnId: string,
+  pinSide: 'left' | 'right' | false,
+): ColumnPinningState {
+  const nextPinning: ColumnPinningState = {
+    left: (columnPinning.left ?? []).filter((pinnedColumnId) => pinnedColumnId !== columnId),
+    right: (columnPinning.right ?? []).filter((pinnedColumnId) => pinnedColumnId !== columnId),
+  }
+
+  if (pinSide) {
+    nextPinning[pinSide] = [...(nextPinning[pinSide] ?? []), columnId]
+  }
+
+  return nextPinning
+}
+
+function getTableConfigUpdatesFromGroupedOrder<TData>(
+  table: Table<TData>,
+  groupedColumnOrder: string[],
+  configurableColumnIds: string[],
+): Pick<DataTableConfig, 'columnOrder' | 'columnPinning'> {
+  const columns = table.getAllLeafColumns()
+  const columnIds = columns.map((column) => column.id)
+  const groupedOrder = splitGroupedColumnOrder(groupedColumnOrder, configurableColumnIds)
+  const currentOrder = normalizeColumnOrder(table.getState().columnOrder, columnIds)
+  const nextOrder = mergeConfigurableColumnOrder(currentOrder, groupedOrder.orderedColumnIds, configurableColumnIds)
+  const nextPinning = getColumnPinningFromGroupedOrder(
+    normalizeColumnPinning(table.getState().columnPinning, columns),
+    configurableColumnIds,
+    groupedOrder.pinnedColumnIds,
+    nextOrder,
+  )
+
+  return {
+    columnOrder: nextOrder,
+    columnPinning: nextPinning,
+  }
+}
+
+function splitGroupedColumnOrder(groupedColumnOrder: string[], configurableColumnIds: string[]) {
+  const normalizedGroupedColumnOrder = normalizeGroupedColumnOrder(groupedColumnOrder, configurableColumnIds)
+  const separatorIndex = normalizedGroupedColumnOrder.indexOf(DATA_TABLE_CONFIG_PIN_SEPARATOR_ID)
+  const pinnedColumnIds = normalizedGroupedColumnOrder.slice(0, separatorIndex)
+  const unpinnedColumnIds = normalizedGroupedColumnOrder.slice(separatorIndex + 1)
+
+  return {
+    orderedColumnIds: [...pinnedColumnIds, ...unpinnedColumnIds],
+    pinnedColumnIds,
+    unpinnedColumnIds,
+  }
+}
+
+function normalizeGroupedColumnOrder(groupedColumnOrder: unknown, configurableColumnIds: string[]) {
+  const configurableColumnIdSet = new Set(configurableColumnIds)
+  const seenColumnIds = new Set<string>()
+  const normalizedGroupedColumnOrder: string[] = []
+  let hasSeparator = false
+
+  if (Array.isArray(groupedColumnOrder)) {
+    for (const columnId of groupedColumnOrder) {
+      if (columnId === DATA_TABLE_CONFIG_PIN_SEPARATOR_ID && !hasSeparator) {
+        normalizedGroupedColumnOrder.push(columnId)
+        hasSeparator = true
+        continue
+      }
+
+      if (typeof columnId !== 'string' || !configurableColumnIdSet.has(columnId) || seenColumnIds.has(columnId)) {
+        continue
+      }
+
+      normalizedGroupedColumnOrder.push(columnId)
+      seenColumnIds.add(columnId)
+    }
+  }
+
+  if (!hasSeparator) {
+    normalizedGroupedColumnOrder.push(DATA_TABLE_CONFIG_PIN_SEPARATOR_ID)
+  }
+
+  for (const columnId of configurableColumnIds) {
+    if (!seenColumnIds.has(columnId)) {
+      normalizedGroupedColumnOrder.push(columnId)
+    }
+  }
+
+  return normalizedGroupedColumnOrder
+}
+
+function mergeConfigurableColumnOrder(
+  columnOrder: string[],
+  nextConfigurableOrder: string[],
+  configurableColumnIds: string[],
+) {
+  const configurableColumnIdSet = new Set(configurableColumnIds)
+  const nextConfigurableIds = normalizeColumnOrder(nextConfigurableOrder, configurableColumnIds)
+  const nextConfigurableIdQueue = [...nextConfigurableIds]
+
+  return columnOrder.map((columnId) => {
+    if (!configurableColumnIdSet.has(columnId)) {
+      return columnId
+    }
+
+    return nextConfigurableIdQueue.shift() ?? columnId
+  })
+}
+
+function getColumnPinningFromGroupedOrder(
+  columnPinning: ColumnPinningState,
+  configurableColumnIds: string[],
+  pinnedColumnIds: string[],
+  columnOrder: string[],
+) {
+  const configurableColumnIdSet = new Set(configurableColumnIds)
+
+  return orderColumnPinning(
+    {
+      left: [
+        ...(columnPinning.left ?? []).filter((columnId) => !configurableColumnIdSet.has(columnId)),
+        ...pinnedColumnIds,
+      ],
+      right: (columnPinning.right ?? []).filter((columnId) => !configurableColumnIdSet.has(columnId)),
+    },
+    columnOrder,
+  )
+}
+
+function orderColumnPinning(columnPinning: ColumnPinningState, columnOrder: string[]) {
+  const columnOrderIndex = new Map(columnOrder.map((columnId, index) => [columnId, index]))
+  const orderPinnedIds = (columnIds: string[] = []) =>
+    columnIds
+      .filter((columnId) => columnOrderIndex.has(columnId))
+      .sort((a, b) => (columnOrderIndex.get(a) ?? 0) - (columnOrderIndex.get(b) ?? 0))
+
+  return {
+    left: orderPinnedIds(columnPinning.left),
+    right: orderPinnedIds(columnPinning.right),
+  }
+}
+
+function deserializeTableConfig(storedConfig: string): DataTableConfig {
+  const parsedConfig = JSON.parse(storedConfig)
+
+  if (!parsedConfig || typeof parsedConfig !== 'object') {
+    throw new Error('Stored table configuration is invalid')
+  }
+
+  return parsedConfig as DataTableConfig
+}
+
+export { DataTableConfigMenu }

--- a/apps/dashboard/src/components/Invoices/index.tsx
+++ b/apps/dashboard/src/components/Invoices/index.tsx
@@ -5,7 +5,7 @@
 
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { flexRender } from '@tanstack/react-table'
 import { FileText } from 'lucide-react'
 import { Pagination } from '../Pagination'
@@ -53,6 +53,7 @@ export function InvoicesTable({
       <InvoicesTableHeader table={table} />
 
       <TableContainer
+        table={table}
         className={cn('max-h-[550px]', {
           'min-h-[20rem]': isEmpty,
         })}
@@ -68,13 +69,14 @@ export function InvoicesTable({
           ) : null
         }
       >
-        <Table className="table-fixed border-separate border-spacing-0" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed border-separate border-spacing-0" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
+                    header={header}
                     sticky={header.column.getIsPinned()}
                     style={getColumnSizeStyles(header.column)}
                   >

--- a/apps/dashboard/src/components/Invoices/useInvoicesTable.ts
+++ b/apps/dashboard/src/components/Invoices/useInvoicesTable.ts
@@ -47,8 +47,8 @@ export function useInvoicesTable({
     },
   ])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: invoiceColumns,
     meta: {

--- a/apps/dashboard/src/components/Invoices/useInvoicesTable.ts
+++ b/apps/dashboard/src/components/Invoices/useInvoicesTable.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { DEFAULT_TABLE_COLUMN } from '@/lib/utils/table'
 import { Invoice } from '@daytona/billing-api-client'
 import {
   ColumnFiltersState,
@@ -84,6 +85,7 @@ export function useInvoicesTable({
       },
     },
     defaultColumn: {
+      ...DEFAULT_TABLE_COLUMN,
       size: 100,
     },
     getRowId: (row, index) => row.id ?? String(index),

--- a/apps/dashboard/src/components/OrganizationMembers/OrganizationInvitationTable.tsx
+++ b/apps/dashboard/src/components/OrganizationMembers/OrganizationInvitationTable.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/components/ui/table'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationInvitation, UpdateOrganizationInvitationRoleEnum } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -131,6 +131,7 @@ export function OrganizationInvitationTable({
     columnResizeMode: 'onEnd',
     data,
     columns: organizationInvitationColumns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     meta: {
       organizationInvitation: {
         onCancel: handleCancel,

--- a/apps/dashboard/src/components/OrganizationMembers/OrganizationInvitationTable.tsx
+++ b/apps/dashboard/src/components/OrganizationMembers/OrganizationInvitationTable.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/components/ui/table'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationInvitation, UpdateOrganizationInvitationRoleEnum } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -127,8 +127,8 @@ export function OrganizationInvitationTable({
         : undefined,
     [invitationToUpdate],
   )
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: organizationInvitationColumns,
     meta: {
@@ -187,6 +187,7 @@ export function OrganizationInvitationTable({
           containerClassName="max-w-sm"
         />
         <TableContainer
+          table={table}
           className={cn('max-h-[550px]', {
             'min-h-[20rem]': isEmpty,
           })}
@@ -209,7 +210,7 @@ export function OrganizationInvitationTable({
             ) : null
           }
         >
-          <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+          <Table className="table-fixed" style={getTableSizeStyles(table)}>
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id}>
@@ -217,6 +218,7 @@ export function OrganizationInvitationTable({
                     return (
                       <TableHead
                         key={header.id}
+                        header={header}
                         sticky={header.column.getIsPinned()}
                         style={getColumnSizeStyles(header.column)}
                       >

--- a/apps/dashboard/src/components/OrganizationMembers/OrganizationMemberTable.tsx
+++ b/apps/dashboard/src/components/OrganizationMembers/OrganizationMemberTable.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/components/ui/table'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { capitalize, cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationUser, OrganizationUserRoleEnum } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -82,8 +82,8 @@ export function OrganizationMemberTable({
   const [isUpdateMemberAccessDialogOpen, setIsUpdateMemberAccessDialogOpen] = useState(false)
   const [memberToRemove, setMemberToRemove] = useState<string | null>(null)
   const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false)
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
     meta: {
@@ -195,6 +195,7 @@ export function OrganizationMemberTable({
           />
         </div>
         <TableContainer
+          table={table}
           className={cn('max-h-[550px]', {
             'min-h-[20rem]': isEmpty,
           })}
@@ -217,13 +218,14 @@ export function OrganizationMemberTable({
             ) : null
           }
         >
-          <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+          <Table className="table-fixed" style={getTableSizeStyles(table)}>
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id}>
                   {headerGroup.headers.map((header) => (
                     <TableHead
                       key={header.id}
+                      header={header}
                       sticky={header.column.getIsPinned()}
                       style={getColumnSizeStyles(header.column)}
                     >

--- a/apps/dashboard/src/components/OrganizationMembers/OrganizationMemberTable.tsx
+++ b/apps/dashboard/src/components/OrganizationMembers/OrganizationMemberTable.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/components/ui/table'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { capitalize, cn } from '@/lib/utils'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationUser, OrganizationUserRoleEnum } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -86,6 +86,7 @@ export function OrganizationMemberTable({
     columnResizeMode: 'onEnd',
     data,
     columns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     meta: {
       member: {
         onUpdateMemberRole: (member) => {

--- a/apps/dashboard/src/components/OrganizationRoles/OrganizationRoleTable.tsx
+++ b/apps/dashboard/src/components/OrganizationRoles/OrganizationRoleTable.tsx
@@ -24,7 +24,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationRole, OrganizationRolePermissionsEnum } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -82,8 +82,8 @@ export function OrganizationRoleTable({
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const [roleToUpdate, setRoleToUpdate] = useState<OrganizationRole | null>(null)
   const [isUpdateDialogOpen, setIsUpdateDialogOpen] = useState(false)
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: organizationRoleColumns,
     meta: {
@@ -177,6 +177,7 @@ export function OrganizationRoleTable({
           />
         </div>
         <TableContainer
+          table={table}
           className={cn('max-h-[550px]', {
             'min-h-[26rem]': isEmpty,
           })}
@@ -199,7 +200,7 @@ export function OrganizationRoleTable({
             ) : null
           }
         >
-          <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+          <Table className="table-fixed" style={getTableSizeStyles(table)}>
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id}>
@@ -207,6 +208,7 @@ export function OrganizationRoleTable({
                     return (
                       <TableHead
                         key={header.id}
+                        header={header}
                         sticky={header.column.getIsPinned()}
                         style={getColumnSizeStyles(header.column)}
                       >

--- a/apps/dashboard/src/components/OrganizationRoles/OrganizationRoleTable.tsx
+++ b/apps/dashboard/src/components/OrganizationRoles/OrganizationRoleTable.tsx
@@ -24,7 +24,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationRole, OrganizationRolePermissionsEnum } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -86,6 +86,7 @@ export function OrganizationRoleTable({
     columnResizeMode: 'onEnd',
     data,
     columns: organizationRoleColumns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     meta: {
       organizationRole: {
         onUpdate: (role) => {

--- a/apps/dashboard/src/components/RegionTable.tsx
+++ b/apps/dashboard/src/components/RegionTable.tsx
@@ -5,7 +5,7 @@
 
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { Region, RegionType } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -84,6 +84,7 @@ export function RegionTable({
     columnResizeMode: 'onEnd',
     data,
     columns: regionColumns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     meta: {
       region: {
         deletePermitted,

--- a/apps/dashboard/src/components/RegionTable.tsx
+++ b/apps/dashboard/src/components/RegionTable.tsx
@@ -5,7 +5,7 @@
 
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { Region, RegionType } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -28,6 +28,7 @@ import { SearchInput } from './SearchInput'
 import { TimestampTooltip } from './TimestampTooltip'
 import { Button } from './ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './ui/dropdown-menu'
+import { MiddleTruncate } from './ui/middle-truncate'
 import { Skeleton } from './ui/skeleton'
 import {
   Table,
@@ -79,8 +80,8 @@ export function RegionTable({
 }: DataTableProps) {
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState('')
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: regionColumns,
     meta: {
@@ -137,6 +138,7 @@ export function RegionTable({
         />
       </div>
       <TableContainer
+        table={table}
         className={cn({
           'min-h-[26rem]': isEmpty,
         })}
@@ -159,7 +161,7 @@ export function RegionTable({
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
@@ -168,6 +170,7 @@ export function RegionTable({
                     <TableHead
                       className="px-2"
                       key={header.id}
+                      header={header}
                       style={getColumnSizeStyles(header.column)}
                       sticky={header.column.getIsPinned()}
                     >
@@ -260,8 +263,8 @@ const regionColumns: ColumnDef<Region>[] = [
     size: 300,
     cell: ({ row }) => {
       return (
-        <div className="w-full truncate flex items-center gap-1 group/copy-button">
-          <span className="truncate block">{row.original.id}</span>
+        <div className="w-full min-w-0 flex items-center gap-1 group/copy-button">
+          <MiddleTruncate value={row.original.id} start={8} end={4} className="font-mono" />
           <CopyButton value={row.original.id} size="icon-xs" autoHide tooltipText="Copy ID" />
         </div>
       )

--- a/apps/dashboard/src/components/RegistryTable.tsx
+++ b/apps/dashboard/src/components/RegistryTable.tsx
@@ -6,7 +6,7 @@
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { DockerRegistry, OrganizationRolePermissionsEnum } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -92,9 +92,7 @@ export function RegistryTable({ data, loading, onDelete, onEdit }: DataTableProp
     meta: {
       registry: { onDelete, onEdit, loading, writePermitted, deletePermitted },
     },
-    defaultColumn: {
-      minSize: 0,
-    },
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/apps/dashboard/src/components/RegistryTable.tsx
+++ b/apps/dashboard/src/components/RegistryTable.tsx
@@ -6,7 +6,7 @@
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { DockerRegistry, OrganizationRolePermissionsEnum } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -86,6 +86,7 @@ export function RegistryTable({ data, loading, onDelete, onEdit }: DataTableProp
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState('')
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
     meta: {
@@ -145,6 +146,7 @@ export function RegistryTable({ data, loading, onDelete, onEdit }: DataTableProp
         />
       </div>
       <TableContainer
+        table={table}
         className={cn({
           'min-h-[26rem]': isEmpty,
         })}
@@ -174,13 +176,14 @@ export function RegistryTable({ data, loading, onDelete, onEdit }: DataTableProp
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
+                    header={header}
                     sticky={header.column.getIsPinned()}
                     style={getColumnSizeStyles(header.column)}
                   >

--- a/apps/dashboard/src/components/RunnerTable.tsx
+++ b/apps/dashboard/src/components/RunnerTable.tsx
@@ -5,7 +5,12 @@
 
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import {
+  DEFAULT_TABLE_COLUMN,
+  DEFAULT_TABLE_COLUMN_MIN_SIZE,
+  getColumnSizeStyles,
+  getTableSizeStyles,
+} from '@/lib/utils/table'
 import { Region, Runner, RunnerState } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -103,6 +108,7 @@ export function RunnerTable({
     columnResizeMode: 'onEnd',
     data,
     columns: runnerColumns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     meta: {
       runner: {
         deletePermitted,
@@ -368,7 +374,7 @@ const runnerColumns: ColumnDef<Runner>[] = [
   {
     accessorKey: 'unschedulable',
     header: 'Schedulable',
-    size: 60,
+    size: DEFAULT_TABLE_COLUMN_MIN_SIZE,
     cell: ({ row, table }) => {
       const { isLoadingRunner, onToggleEnabled, writePermitted } = getMeta(table)
       const isLoading = isLoadingRunner(row.original)

--- a/apps/dashboard/src/components/RunnerTable.tsx
+++ b/apps/dashboard/src/components/RunnerTable.tsx
@@ -5,7 +5,7 @@
 
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { Region, Runner, RunnerState } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -29,6 +29,7 @@ import { SearchInput } from './SearchInput'
 import { Badge, BadgeProps } from './ui/badge'
 import { Button } from './ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './ui/dropdown-menu'
+import { MiddleTruncate } from './ui/middle-truncate'
 import { Skeleton } from './ui/skeleton'
 import { Switch } from './ui/switch'
 import {
@@ -98,8 +99,8 @@ export function RunnerTable({
 }: RunnerTableProps) {
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState('')
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: runnerColumns,
     meta: {
@@ -180,6 +181,7 @@ export function RunnerTable({
       </div>
 
       <TableContainer
+        table={table}
         className={cn({
           'min-h-[26rem]': isEmpty,
         })}
@@ -211,7 +213,7 @@ export function RunnerTable({
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
@@ -220,6 +222,7 @@ export function RunnerTable({
                     <TableHead
                       className="px-2"
                       key={header.id}
+                      header={header}
                       style={getColumnSizeStyles(header.column)}
                       sticky={header.column.getIsPinned()}
                     >
@@ -331,8 +334,8 @@ const runnerColumns: ColumnDef<Runner>[] = [
     size: 240,
     cell: ({ row }) => {
       return (
-        <div className="w-full truncate flex items-center gap-1 group/copy-button">
-          <span className="truncate block text-sm">{row.original.id}</span>
+        <div className="w-full min-w-0 flex items-center gap-1 group/copy-button">
+          <MiddleTruncate value={row.original.id} start={8} end={4} className="font-mono text-sm" />
           <CopyButton value={row.original.id} size="icon-xs" autoHide tooltipText="Copy ID" />
         </div>
       )

--- a/apps/dashboard/src/components/SandboxTable/SandboxTable.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTable.tsx
@@ -19,7 +19,7 @@ import {
   getBulkActionCounts,
   isTransitioning,
 } from '@/lib/utils/sandbox'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationRolePermissionsEnum, SandboxListItem, SandboxState } from '@daytona/api-client'
 import {
   flexRender,
@@ -145,8 +145,8 @@ export function SandboxTable({
   const selectableCount = useMemo(() => {
     return data.filter((sandbox) => !sandboxIsLoading[sandbox.id] && sandbox.state !== SandboxState.DESTROYED).length
   }, [sandboxIsLoading, data])
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: visibleColumns,
     manualFiltering: true,
@@ -289,6 +289,7 @@ export function SandboxTable({
       />
 
       <TableContainer
+        table={table}
         className={cn({
           'min-h-[26rem]': isEmpty,
         })}
@@ -333,13 +334,14 @@ export function SandboxTable({
           ) : null
         }
       >
-        <Table style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
+                    header={header}
                     sticky={header.column.getIsPinned()}
                     style={getColumnSizeStyles(header.column)}
                   >

--- a/apps/dashboard/src/components/SandboxTable/SandboxTable.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTable.tsx
@@ -4,12 +4,10 @@
  */
 
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
-import { LocalStorageKey } from '@/enums/LocalStorageKey'
 import { RoutePath } from '@/enums/RoutePath'
 import { useAvailableSandboxClassesForOrganization } from '@/hooks/useAvailableSandboxClasses'
 import { useCommandPaletteAnalytics } from '@/hooks/useCommandPaletteAnalytics'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
-import { getLocalStorageItem, setLocalStorageItem } from '@/lib/local-storage'
 import { cn, getRegionFullDisplayName } from '@/lib/utils'
 import {
   filterArchivable,
@@ -19,19 +17,21 @@ import {
   getBulkActionCounts,
   isTransitioning,
 } from '@/lib/utils/sandbox'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationRolePermissionsEnum, SandboxListItem, SandboxState } from '@daytona/api-client'
 import {
+  type ColumnPinningState,
   flexRender,
   getCoreRowModel,
   getFacetedRowModel,
   getFacetedUniqueValues,
+  type OnChangeFn,
   useReactTable,
-  VisibilityState,
+  type VisibilityState,
 } from '@tanstack/react-table'
 import { Container } from 'lucide-react'
 import { AnimatePresence } from 'motion/react'
-import { useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react'
+import { useCallback, useImperativeHandle, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useCommandPaletteActions } from '../CommandPalette'
 import { SelectionToast } from '../SelectionToast'
@@ -58,6 +58,26 @@ import {
   convertTableSortingToApiSorting,
 } from './types'
 import { useSandboxCommands } from './useSandboxCommands'
+
+const DEFAULT_SANDBOX_TABLE_COLUMN_VISIBILITY: VisibilityState = {
+  id: false,
+  isPublic: false,
+  isRecoverable: false,
+  labels: false,
+}
+
+const DEFAULT_SANDBOX_TABLE_COLUMN_PINNING: ColumnPinningState = {
+  left: ['select', 'name'],
+  right: ['actions'],
+}
+
+function getSandboxTableColumnVisibility(columnVisibility: VisibilityState): VisibilityState {
+  return {
+    ...columnVisibility,
+    isPublic: false,
+    isRecoverable: false,
+  }
+}
 
 export function SandboxTable({
   ref,
@@ -103,21 +123,16 @@ export function SandboxTable({
   const writePermitted = authenticatedUserHasPermission(OrganizationRolePermissionsEnum.WRITE_SANDBOXES)
   const deletePermitted = authenticatedUserHasPermission(OrganizationRolePermissionsEnum.DELETE_SANDBOXES)
 
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(() => {
-    const saved = getLocalStorageItem(LocalStorageKey.SandboxTableColumnVisibility)
-    if (saved) {
-      try {
-        return JSON.parse(saved)
-      } catch {
-        return { id: false, labels: false }
-      }
-    }
-    return { id: false, labels: false }
-  })
+  const [columnOrder, setColumnOrder] = useState<string[]>([])
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(DEFAULT_SANDBOX_TABLE_COLUMN_VISIBILITY)
+  const [columnPinning, setColumnPinning] = useState<ColumnPinningState>(DEFAULT_SANDBOX_TABLE_COLUMN_PINNING)
+  const handleColumnVisibilityChange = useCallback<OnChangeFn<VisibilityState>>((updater) => {
+    setColumnVisibility((currentColumnVisibility) => {
+      const nextColumnVisibility = typeof updater === 'function' ? updater(currentColumnVisibility) : updater
 
-  useEffect(() => {
-    setLocalStorageItem(LocalStorageKey.SandboxTableColumnVisibility, JSON.stringify(columnVisibility))
-  }, [columnVisibility])
+      return getSandboxTableColumnVisibility(nextColumnVisibility)
+    })
+  }, [])
 
   const availableSandboxClasses = useAvailableSandboxClassesForOrganization()
   const visibleColumns = useMemo(() => {
@@ -162,19 +177,17 @@ export function SandboxTable({
     },
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
+    onColumnOrderChange: setColumnOrder,
+    onColumnPinningChange: setColumnPinning,
     state: {
       sorting: tableSorting,
       columnFilters: tableFilters,
+      columnOrder,
       columnVisibility,
-      columnPinning: {
-        left: ['select', 'name'],
-        right: ['actions'],
-      },
+      columnPinning,
     },
-    onColumnVisibilityChange: setColumnVisibility,
-    defaultColumn: {
-      minSize: 0,
-    },
+    onColumnVisibilityChange: handleColumnVisibilityChange,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     enableRowSelection: (row) =>
       (writePermitted || deletePermitted) &&
       !sandboxIsLoading[row.original.id] &&

--- a/apps/dashboard/src/components/SandboxTable/SandboxTableHeader.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTableHeader.tsx
@@ -8,7 +8,6 @@ import {
   Calendar,
   CalendarPlus,
   Camera,
-  Columns,
   Cpu,
   Eye,
   Globe,
@@ -20,23 +19,20 @@ import {
   Tag,
   Wrench,
 } from 'lucide-react'
+import { DataTableConfigMenu } from '@/components/DataTableConfigMenu'
 import { cn } from '@/lib/utils'
 import { SearchInput } from '../SearchInput'
 import TooltipButton from '../TooltipButton'
 import { Button } from '../ui/button'
 import {
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuLabel,
   DropdownMenuPortal,
-  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu'
-import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { BooleanFilter, BooleanFilterIndicator } from './filters/BooleanFilter'
 import { CreatedAtFilter, CreatedAtFilterIndicator } from './filters/CreatedAtFilter'
 import { LabelFilter, LabelFilterIndicator } from './filters/LabelFilter'
@@ -55,10 +51,12 @@ const RESOURCE_FILTERS = [
 ]
 
 const SANDBOX_TABLE_COLUMN_LABELS: Record<string, string> = {
+  actions: 'Actions',
+  select: 'Selection',
   name: 'Name',
   id: 'UUID',
   state: 'State',
-  class: 'Class',
+  sandboxClass: 'Class',
   snapshot: 'Snapshot',
   region: 'Region',
   resources: 'Resources',
@@ -66,6 +64,8 @@ const SANDBOX_TABLE_COLUMN_LABELS: Record<string, string> = {
   lastEvent: 'Last Event',
   createdAt: 'Created At',
 }
+
+const SANDBOX_TABLE_CONFIG_EXCLUDED_COLUMN_IDS = ['actions', 'select', 'isPublic', 'isRecoverable'] as const
 
 export function SandboxTableHeader({
   table,
@@ -293,7 +293,12 @@ export function SandboxTableHeader({
           >
             <RefreshCw className={cn('w-4 h-4', { 'animate-spin': isRefreshing })} />
           </TooltipButton>
-          <SandboxTableSettings table={table} />
+          <DataTableConfigMenu
+            table={table}
+            persistenceKey="sandboxes"
+            excludedColumnIds={SANDBOX_TABLE_CONFIG_EXCLUDED_COLUMN_IDS}
+            getColumnLabel={(columnId) => SANDBOX_TABLE_COLUMN_LABELS[columnId] ?? columnId}
+          />
         </div>
       </div>
 
@@ -375,42 +380,5 @@ export function SandboxTableHeader({
         </div>
       ) : null}
     </div>
-  )
-}
-
-function SandboxTableSettings({ table }: Pick<SandboxTableHeaderProps, 'table'>) {
-  const hideableColumns = table.getAllLeafColumns().filter((column) => column.getCanHide())
-
-  if (hideableColumns.length === 0) {
-    return null
-  }
-
-  return (
-    <DropdownMenu modal={false}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="icon-sm" aria-label="Table settings">
-              <Columns className="size-4" />
-            </Button>
-          </DropdownMenuTrigger>
-        </TooltipTrigger>
-        <TooltipContent>Table settings</TooltipContent>
-      </Tooltip>
-      <DropdownMenuContent align="end" className="w-48">
-        <DropdownMenuLabel>Columns</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        {hideableColumns.map((column) => (
-          <DropdownMenuCheckboxItem
-            key={column.id}
-            checked={column.getIsVisible()}
-            onCheckedChange={(checked) => column.toggleVisibility(checked === true)}
-            onSelect={(event) => event.preventDefault()}
-          >
-            {SANDBOX_TABLE_COLUMN_LABELS[column.id] ?? column.id}
-          </DropdownMenuCheckboxItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
   )
 }

--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -11,8 +11,9 @@ import { TimestampTooltip } from '@/components/TimestampTooltip'
 import { SandboxState as SandboxStateComponent } from '@/components/sandboxes/SandboxState'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
+import { MiddleTruncate } from '@/components/ui/middle-truncate'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { getRelativeTimeString, truncateUUID } from '@/lib/utils'
+import { getRelativeTimeString } from '@/lib/utils'
 import { SandboxDesiredState, SandboxListItem } from '@daytona/api-client'
 import { Column, ColumnDef, RowData, Table } from '@tanstack/react-table'
 import { Loader2 } from 'lucide-react'
@@ -169,8 +170,9 @@ const columns: ColumnDef<SandboxListItem>[] = [
   },
   {
     id: 'id',
-    size: 150,
-    maxSize: 150,
+    size: 240,
+    minSize: 150,
+    maxSize: 360,
     enableSorting: false,
     enableHiding: true,
     header: () => <span>UUID</span>,
@@ -178,8 +180,8 @@ const columns: ColumnDef<SandboxListItem>[] = [
     cell: ({ row }) => {
       const id = row.original.id
       return (
-        <div className="w-full truncate flex items-center gap-1 group/copy-button">
-          <span className="truncate block text-muted-foreground">{truncateUUID(id)}</span>
+        <div className="w-full min-w-0 flex items-center gap-1 group/copy-button">
+          <MiddleTruncate value={id} start={8} end={4} className="font-mono text-muted-foreground" />
           <CopyButton value={id} size="icon-xs" autoHide tooltipText="Copy UUID" />
         </div>
       )

--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -192,7 +192,7 @@ const columns: ColumnDef<SandboxListItem>[] = [
     size: 110,
     minSize: 110,
     enableSorting: false,
-    enableHiding: false,
+    enableHiding: true,
     header: () => <span>State</span>,
     cell: ({ row }) => (
       <SandboxStateCell
@@ -206,9 +206,10 @@ const columns: ColumnDef<SandboxListItem>[] = [
   {
     id: 'sandboxClass',
     size: 64,
+    minSize: 64,
     maxSize: 64,
     enableSorting: false,
-    enableHiding: false,
+    enableHiding: true,
     header: () => <span>Class</span>,
     cell: ({ row }) => {
       const sandboxClass = row.original.sandboxClass
@@ -231,7 +232,7 @@ const columns: ColumnDef<SandboxListItem>[] = [
     id: 'snapshot',
     size: 150,
     enableSorting: false,
-    enableHiding: false,
+    enableHiding: true,
     header: () => <span>Snapshot</span>,
     cell: ({ row }) => (
       <div className="w-full truncate">
@@ -248,7 +249,7 @@ const columns: ColumnDef<SandboxListItem>[] = [
     id: 'region',
     size: 120,
     enableSorting: false,
-    enableHiding: false,
+    enableHiding: true,
     header: () => <span>Region</span>,
     cell: ({ row, table }) => {
       const { getRegionName } = getMeta(table)
@@ -264,7 +265,7 @@ const columns: ColumnDef<SandboxListItem>[] = [
     id: 'resources',
     size: 190,
     enableSorting: false,
-    enableHiding: false,
+    enableHiding: true,
     header: () => <span>Resources</span>,
     cell: ({ row }) => (
       <div className="flex w-full items-center gap-2 truncate">
@@ -326,7 +327,7 @@ const columns: ColumnDef<SandboxListItem>[] = [
     size: 140,
     maxSize: 140,
     enableSorting: true,
-    enableHiding: false,
+    enableHiding: true,
     header: ({ column }) => <SortableHeader column={column} label="Last Event" />,
     accessorFn: (row) => getLastEvent(row).date,
     cell: ({ row }) => {
@@ -345,7 +346,7 @@ const columns: ColumnDef<SandboxListItem>[] = [
     size: 180,
     maxSize: 180,
     enableSorting: true,
-    enableHiding: false,
+    enableHiding: true,
     header: ({ column }) => <SortableHeader column={column} label="Created" />,
     accessorFn: (row) => (row.createdAt ? new Date(row.createdAt) : new Date()),
     cell: ({ row }) => {

--- a/apps/dashboard/src/components/UserOrganizationInvitations/UserOrganizationInvitationTable.tsx
+++ b/apps/dashboard/src/components/UserOrganizationInvitations/UserOrganizationInvitationTable.tsx
@@ -22,7 +22,7 @@ import {
 import { DeclineOrganizationInvitationDialog } from '@/components/UserOrganizationInvitations/DeclineOrganizationInvitationDialog'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationInvitation } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -90,8 +90,8 @@ export function UserOrganizationInvitationTable({
     }
     return false
   }
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: userOrganizationInvitationColumns,
     meta: {
@@ -150,6 +150,7 @@ export function UserOrganizationInvitationTable({
         />
       </div>
       <TableContainer
+        table={table}
         className={cn({
           'min-h-64': isEmpty,
         })}
@@ -172,7 +173,7 @@ export function UserOrganizationInvitationTable({
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
@@ -180,6 +181,7 @@ export function UserOrganizationInvitationTable({
                   return (
                     <TableHead
                       key={header.id}
+                      header={header}
                       sticky={header.column.getIsPinned()}
                       style={getColumnSizeStyles(header.column)}
                     >

--- a/apps/dashboard/src/components/UserOrganizationInvitations/UserOrganizationInvitationTable.tsx
+++ b/apps/dashboard/src/components/UserOrganizationInvitations/UserOrganizationInvitationTable.tsx
@@ -22,7 +22,7 @@ import {
 import { DeclineOrganizationInvitationDialog } from '@/components/UserOrganizationInvitations/DeclineOrganizationInvitationDialog'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationInvitation } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -94,6 +94,7 @@ export function UserOrganizationInvitationTable({
     columnResizeMode: 'onEnd',
     data,
     columns: userOrganizationInvitationColumns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     meta: {
       userOrganizationInvitation: {
         onAccept: onAcceptInvitation,

--- a/apps/dashboard/src/components/VolumeTable.tsx
+++ b/apps/dashboard/src/components/VolumeTable.tsx
@@ -15,6 +15,7 @@ import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { DataTableFacetedFilter, FacetedFilterOption } from '@/components/ui/data-table-faceted-filter'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { MiddleTruncate } from '@/components/ui/middle-truncate'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
@@ -29,8 +30,8 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
-import { cn, getRelativeTimeString, truncateUUID } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { cn, getRelativeTimeString } from '@/lib/utils'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationRolePermissionsEnum, VolumeDto, VolumeState } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -100,8 +101,8 @@ export function VolumeTable({
 
   const [sorting, setSorting] = useState<SortingState>([])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
     meta: {
@@ -207,6 +208,7 @@ export function VolumeTable({
         </div>
       </div>
       <TableContainer
+        table={table}
         className={cn({
           'min-h-[26rem]': isEmpty,
         })}
@@ -250,13 +252,14 @@ export function VolumeTable({
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
+                    header={header}
                     sticky={header.column.getIsPinned()}
                     style={getColumnSizeStyles(header.column)}
                   >
@@ -447,8 +450,8 @@ const columns: ColumnDef<VolumeDto>[] = [
       const id = row.original.id
 
       return (
-        <div className="w-full truncate flex items-center gap-1 group/copy-button">
-          <span className="truncate block text-muted-foreground">{truncateUUID(id)}</span>
+        <div className="w-full min-w-0 flex items-center gap-1 group/copy-button">
+          <MiddleTruncate value={id} start={8} end={4} className="font-mono text-muted-foreground" />
           <CopyButton value={id} size="icon-xs" autoHide tooltipText="Copy ID" />
         </div>
       )

--- a/apps/dashboard/src/components/VolumeTable.tsx
+++ b/apps/dashboard/src/components/VolumeTable.tsx
@@ -31,7 +31,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { cn, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationRolePermissionsEnum, VolumeDto, VolumeState } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -108,9 +108,7 @@ export function VolumeTable({
     meta: {
       volume: { onDelete, processingVolumeAction, deletePermitted },
     },
-    defaultColumn: {
-      minSize: 0,
-    },
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/apps/dashboard/src/components/Webhooks/EndpointEventsTable/EndpointEventsTable.tsx
+++ b/apps/dashboard/src/components/Webhooks/EndpointEventsTable/EndpointEventsTable.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/components/ui/table'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import {
   ColumnFiltersState,
   flexRender,
@@ -56,6 +56,7 @@ export function EndpointEventsTable({ data, loading, onReplay }: EndpointEventsT
     columnResizeMode: 'onEnd',
     data,
     columns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/apps/dashboard/src/components/Webhooks/EndpointEventsTable/EndpointEventsTable.tsx
+++ b/apps/dashboard/src/components/Webhooks/EndpointEventsTable/EndpointEventsTable.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/components/ui/table'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import {
   ColumnFiltersState,
   flexRender,
@@ -52,8 +52,8 @@ export function EndpointEventsTable({ data, loading, onReplay }: EndpointEventsT
   const [globalFilter, setGlobalFilter] = useState('')
   const [selectedEventIndex, setSelectedEventIndex] = useState<number | null>(null)
   const [sheetOpen, setSheetOpen] = useState(false)
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
@@ -144,6 +144,7 @@ export function EndpointEventsTable({ data, loading, onReplay }: EndpointEventsT
         )}
       </div>
       <TableContainer
+        table={table}
         className={cn({ 'min-h-[26rem]': isEmpty })}
         empty={
           isEmpty ? (
@@ -164,7 +165,7 @@ export function EndpointEventsTable({ data, loading, onReplay }: EndpointEventsT
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
@@ -173,6 +174,7 @@ export function EndpointEventsTable({ data, loading, onReplay }: EndpointEventsT
                     <TableHead
                       className="px-2"
                       key={header.id}
+                      header={header}
                       style={getColumnSizeStyles(header.column)}
                       sticky={header.column.getIsPinned()}
                     >

--- a/apps/dashboard/src/components/Webhooks/EndpointEventsTable/columns.tsx
+++ b/apps/dashboard/src/components/Webhooks/EndpointEventsTable/columns.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { FacetedFilterOption } from '@/components/ui/data-table-faceted-filter'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { MiddleTruncate } from '@/components/ui/middle-truncate'
 import { WEBHOOK_EVENTS } from '@/constants/webhook-events'
 import { getRelativeTimeString } from '@/lib/utils'
 import { ColumnDef, RowData, Table } from '@tanstack/react-table'
@@ -37,10 +38,13 @@ const columns: ColumnDef<EndpointMessageOut>[] = [
     cell: ({ row }) => {
       const msgId = row.original.id
       return (
-        <div className="w-full truncate flex items-center gap-2 group/copy-button">
-          <span className="truncate block font-mono text-sm hover:underline focus:underline cursor-pointer">
-            {msgId ?? '-'}
-          </span>
+        <div className="w-full min-w-0 flex items-center gap-2 group/copy-button">
+          <MiddleTruncate
+            value={msgId ?? '-'}
+            start={8}
+            end={4}
+            className="font-mono text-sm hover:underline focus:underline cursor-pointer"
+          />
           {msgId && (
             <span onClick={(e) => e.stopPropagation()}>
               <CopyButton value={msgId} size="icon-xs" autoHide tooltipText="Copy Message ID" />

--- a/apps/dashboard/src/components/Webhooks/WebhooksEndpointTable/WebhooksEndpointTable.tsx
+++ b/apps/dashboard/src/components/Webhooks/WebhooksEndpointTable/WebhooksEndpointTable.tsx
@@ -31,7 +31,7 @@ import {
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { RoutePath } from '@/enums/RoutePath'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import {
   flexRender,
   getCoreRowModel,
@@ -85,6 +85,7 @@ export function WebhooksEndpointTable({
     columnResizeMode: 'onEnd',
     data,
     columns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/apps/dashboard/src/components/Webhooks/WebhooksEndpointTable/WebhooksEndpointTable.tsx
+++ b/apps/dashboard/src/components/Webhooks/WebhooksEndpointTable/WebhooksEndpointTable.tsx
@@ -31,7 +31,7 @@ import {
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { RoutePath } from '@/enums/RoutePath'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import {
   flexRender,
   getCoreRowModel,
@@ -81,8 +81,8 @@ export function WebhooksEndpointTable({
       setDisableEndpoint(null)
     }
   }
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
@@ -145,6 +145,7 @@ export function WebhooksEndpointTable({
         />
       </div>
       <TableContainer
+        table={table}
         className={cn({
           'min-h-[26rem]': isEmpty,
         })}
@@ -184,7 +185,7 @@ export function WebhooksEndpointTable({
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
@@ -193,6 +194,7 @@ export function WebhooksEndpointTable({
                     <TableHead
                       className="px-2"
                       key={header.id}
+                      header={header}
                       style={getColumnSizeStyles(header.column)}
                       sticky={header.column.getIsPinned()}
                     >

--- a/apps/dashboard/src/components/Webhooks/WebhooksMessagesTable/WebhooksMessagesTable.tsx
+++ b/apps/dashboard/src/components/Webhooks/WebhooksMessagesTable/WebhooksMessagesTable.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/components/ui/table'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import {
   ColumnFiltersState,
   flexRender,
@@ -49,8 +49,8 @@ export function WebhooksMessagesTable() {
   const [sheetOpen, setSheetOpen] = useState(false)
 
   const data = messages.data ?? []
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
@@ -139,6 +139,7 @@ export function WebhooksMessagesTable() {
         </Button>
       </div>
       <TableContainer
+        table={table}
         className={cn('max-h-[550px]', {
           'min-h-[26rem]': isEmpty,
         })}
@@ -161,12 +162,17 @@ export function WebhooksMessagesTable() {
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
-                  <TableHead className="px-2" key={header.id} style={getColumnSizeStyles(header.column)}>
+                  <TableHead
+                    className="px-2"
+                    key={header.id}
+                    header={header}
+                    style={getColumnSizeStyles(header.column)}
+                  >
                     {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
                   </TableHead>
                 ))}

--- a/apps/dashboard/src/components/Webhooks/WebhooksMessagesTable/WebhooksMessagesTable.tsx
+++ b/apps/dashboard/src/components/Webhooks/WebhooksMessagesTable/WebhooksMessagesTable.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/components/ui/table'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import {
   ColumnFiltersState,
   flexRender,
@@ -53,6 +53,7 @@ export function WebhooksMessagesTable() {
     columnResizeMode: 'onEnd',
     data,
     columns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/apps/dashboard/src/components/Webhooks/WebhooksMessagesTable/columns.tsx
+++ b/apps/dashboard/src/components/Webhooks/WebhooksMessagesTable/columns.tsx
@@ -6,6 +6,7 @@
 import { TimestampTooltip } from '@/components/TimestampTooltip'
 import { Badge } from '@/components/ui/badge'
 import { FacetedFilterOption } from '@/components/ui/data-table-faceted-filter'
+import { MiddleTruncate } from '@/components/ui/middle-truncate'
 import { WEBHOOK_EVENTS } from '@/constants/webhook-events'
 import { getRelativeTimeString } from '@/lib/utils'
 import { ColumnDef } from '@tanstack/react-table'
@@ -20,10 +21,13 @@ const columns: ColumnDef<MessageOut>[] = [
     cell: ({ row }) => {
       const msgId = row.original.id
       return (
-        <div className="w-full truncate flex items-center gap-2 group/copy-button">
-          <span className="truncate block font-mono text-sm hover:underline focus:underline cursor-pointer">
-            {msgId ?? '-'}
-          </span>
+        <div className="w-full min-w-0 flex items-center gap-2 group/copy-button">
+          <MiddleTruncate
+            value={msgId ?? '-'}
+            start={8}
+            end={4}
+            className="font-mono text-sm hover:underline focus:underline cursor-pointer"
+          />
           {msgId && (
             <span onClick={(e) => e.stopPropagation()}>
               <CopyButton value={msgId} size="icon-xs" autoHide tooltipText="Copy Message ID" />

--- a/apps/dashboard/src/components/snapshots/SnapshotTable/SnapshotTable.tsx
+++ b/apps/dashboard/src/components/snapshots/SnapshotTable/SnapshotTable.tsx
@@ -16,7 +16,7 @@ import { SnapshotSorting } from '@/hooks/queries/useSnapshotsQuery'
 import { useCommandPaletteAnalytics } from '@/hooks/useCommandPaletteAnalytics'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationRolePermissionsEnum, SnapshotDto, SnapshotState } from '@daytona/api-client'
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { Box } from 'lucide-react'
@@ -157,8 +157,8 @@ export function SnapshotTable({
       (snapshot) => !snapshot.general && !loadingSnapshots[snapshot.id] && snapshot.state !== SnapshotState.REMOVING,
     ).length
   }, [data, loadingSnapshots])
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
     defaultColumn: {
@@ -305,6 +305,7 @@ export function SnapshotTable({
         </div>
       </div>
       <TableContainer
+        table={table}
         className={cn({
           'min-h-[26rem]': isEmpty,
         })}
@@ -348,13 +349,14 @@ export function SnapshotTable({
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
+                    header={header}
                     sticky={header.column.getIsPinned()}
                     style={getColumnSizeStyles(header.column)}
                   >

--- a/apps/dashboard/src/components/snapshots/SnapshotTable/SnapshotTable.tsx
+++ b/apps/dashboard/src/components/snapshots/SnapshotTable/SnapshotTable.tsx
@@ -16,7 +16,7 @@ import { SnapshotSorting } from '@/hooks/queries/useSnapshotsQuery'
 import { useCommandPaletteAnalytics } from '@/hooks/useCommandPaletteAnalytics'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationRolePermissionsEnum, SnapshotDto, SnapshotState } from '@daytona/api-client'
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { Box } from 'lucide-react'
@@ -161,9 +161,7 @@ export function SnapshotTable({
     columnResizeMode: 'onEnd',
     data,
     columns,
-    defaultColumn: {
-      minSize: 0,
-    },
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     getCoreRowModel: getCoreRowModel(),
     initialState: {
       columnPinning: {

--- a/apps/dashboard/src/components/snapshots/SnapshotTable/columns.tsx
+++ b/apps/dashboard/src/components/snapshots/SnapshotTable/columns.tsx
@@ -159,6 +159,7 @@ const columns: ColumnDef<SnapshotDto>[] = [
   {
     accessorKey: 'imageName',
     size: 180,
+    minSize: 180,
     enableSorting: false,
     header: 'Image',
     cell: ({ row }) => {

--- a/apps/dashboard/src/components/ui/middle-truncate.tsx
+++ b/apps/dashboard/src/components/ui/middle-truncate.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { cn } from '@/lib/utils'
+
+type MiddleTruncateProps = Omit<React.ComponentProps<'span'>, 'children'> & {
+  end?: number
+  start?: number
+  value?: string | null
+}
+
+function MiddleTruncate({ className, end = 4, start = 8, title, value, ...props }: MiddleTruncateProps) {
+  const text = value ?? ''
+  const startLength = Math.max(0, Math.floor(start))
+  const endLength = Math.max(0, Math.floor(end))
+  const shouldSplit = text.length > startLength + endLength && startLength + endLength > 0
+
+  const startText = shouldSplit ? text.slice(0, startLength) : text
+  const middleText = shouldSplit ? text.slice(startLength, text.length - endLength) : ''
+  const endText = shouldSplit && endLength > 0 ? text.slice(-endLength) : ''
+
+  return (
+    <span
+      className={cn('inline-flex min-w-0 max-w-full overflow-hidden whitespace-nowrap align-bottom', className)}
+      data-slot="middle-truncate"
+      title={title ?? text}
+      {...props}
+    >
+      <span className="shrink-0">{startText}</span>
+      {middleText ? <span className="min-w-0 flex-1 overflow-hidden text-ellipsis">{middleText}</span> : null}
+      {endText ? <span className="shrink-0">{endText}</span> : null}
+    </span>
+  )
+}
+
+export { MiddleTruncate }

--- a/apps/dashboard/src/components/ui/table.css
+++ b/apps/dashboard/src/components/ui/table.css
@@ -51,9 +51,10 @@
 
   [data-slot='table-column-resize-indicator'] {
     position: absolute;
-    inset-block: 0;
+    top: 0;
     left: 0;
     z-index: 30;
+    height: var(--table-column-resize-indicator-height, 100%);
     width: 0;
     opacity: 0;
     pointer-events: none;

--- a/apps/dashboard/src/components/ui/table.css
+++ b/apps/dashboard/src/components/ui/table.css
@@ -1,4 +1,90 @@
 @media (min-width: 768px) {
+  [data-slot='table-head'][data-resizable='true'] {
+    overflow: visible;
+  }
+
+  [data-slot='table-column-resize-handle'] {
+    position: absolute;
+    inset-block: 0;
+    inset-inline-end: -8px;
+    z-index: 20;
+    display: flex;
+    width: 16px;
+    cursor: col-resize;
+    touch-action: none;
+    user-select: none;
+    justify-content: center;
+    outline: none;
+  }
+
+  [data-slot='table-column-resize-handle']::before {
+    content: '';
+    width: 1px;
+    background: transparent;
+    transition:
+      background-color 0.15s ease,
+      opacity 0.15s ease;
+  }
+
+  [data-slot='table-column-resize-handle']::after {
+    content: '';
+    position: absolute;
+    inset-block: 0;
+    inset-inline: -8px;
+  }
+
+  [data-slot='table-head'][data-resizable='true']:hover > [data-slot='table-column-resize-handle']::before {
+    background: var(--muted-foreground);
+    opacity: 0.45;
+  }
+
+  [data-slot='table-column-resize-handle'][data-resizing='true']::before,
+  [data-slot='table-column-resize-handle']:focus-visible::before {
+    background: var(--primary);
+    opacity: 1;
+  }
+
+  [data-slot='table-column-resize-handle']:focus-visible {
+    border-radius: 2px;
+    box-shadow: 0 0 0 2px color-mix(in oklch, var(--ring) 45%, transparent);
+  }
+
+  [data-slot='table-column-resize-indicator'] {
+    position: absolute;
+    inset-block: 0;
+    left: 0;
+    z-index: 30;
+    width: 0;
+    opacity: 0;
+    pointer-events: none;
+    transform: translate3d(-9999px, 0, 0);
+    will-change: transform;
+  }
+
+  [data-column-resizing='true'] > [data-slot='table-column-resize-indicator'] {
+    opacity: 1;
+  }
+
+  [data-column-resize-releasing='true'] > [data-slot='table-column-resize-indicator'] {
+    transition: transform 150ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  [data-slot='table-column-resize-indicator']::before {
+    content: '';
+    position: absolute;
+    inset-block: 0;
+    width: 1px;
+    background: var(--primary);
+    box-shadow: 0 0 0 1px color-mix(in oklch, var(--primary) 20%, transparent);
+    transform: translateX(-0.5px);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [data-column-resize-releasing='true'] > [data-slot='table-column-resize-indicator'] {
+      transition: none;
+    }
+  }
+
   [data-sticky-state='left'] {
     box-shadow: 6px 0 8px -2px rgba(0, 0, 0, 0);
     transition: box-shadow 0.2s ease;
@@ -31,6 +117,11 @@
 }
 
 @media (max-width: 767px) {
+  [data-slot='table-column-resize-handle'],
+  [data-slot='table-column-resize-indicator'] {
+    display: none;
+  }
+
   [data-slot='table-head'][data-sticky-state],
   [data-slot='table-cell'][data-sticky-state] {
     position: static !important;

--- a/apps/dashboard/src/components/ui/table.tsx
+++ b/apps/dashboard/src/components/ui/table.tsx
@@ -6,6 +6,7 @@
 import * as React from 'react'
 
 import { cn } from '@/lib/utils'
+import type { Header, Table as ReactTable } from '@tanstack/react-table'
 import { useEffect, useRef } from 'react'
 import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from './empty'
 import './table.css'
@@ -61,12 +62,12 @@ function useScrollStateRef() {
   return containerRef
 }
 
-function TableContainer({
-  className,
-  children,
-  empty,
-  ...props
-}: React.ComponentProps<'div'> & { empty?: React.ReactNode }) {
+type TableContainerProps<TData> = React.ComponentProps<'div'> & {
+  empty?: React.ReactNode
+  table?: ReactTable<TData>
+}
+
+function TableContainer<TData = unknown>({ className, children, empty, table, ...props }: TableContainerProps<TData>) {
   const containerRef = useScrollStateRef()
 
   return (
@@ -80,6 +81,7 @@ function TableContainer({
       {...props}
     >
       {children}
+      {table ? <div aria-hidden="true" data-slot="table-column-resize-indicator" /> : null}
       {empty}
     </div>
   )
@@ -141,17 +143,321 @@ function getStickySide(sticky?: StickyState) {
   return sticky === 'left' || sticky === 'right' ? sticky : undefined
 }
 
-function TableHead({ className, style, sticky, ...props }: React.ComponentProps<'th'> & { sticky?: StickyState }) {
+function getHeaderResizeLabel<TData>(header: Header<TData, unknown>) {
+  const columnHeader = header.column.columnDef.header
+
+  return typeof columnHeader === 'string' ? columnHeader : header.column.id
+}
+
+function getHeaderResizeBounds<TData>(header: Header<TData, unknown>) {
+  const defaultColumn = header.getContext().table.options.defaultColumn
+
+  return {
+    minSize: header.column.columnDef.minSize ?? defaultColumn?.minSize ?? 20,
+    maxSize: header.column.columnDef.maxSize ?? defaultColumn?.maxSize ?? Number.MAX_SAFE_INTEGER,
+  }
+}
+
+function getHeaderCanResize<TData>(header?: Header<TData, unknown>) {
+  if (!header || header.isPlaceholder || !header.column.getCanResize()) return false
+
+  const { minSize, maxSize } = getHeaderResizeBounds(header)
+
+  return minSize < maxSize
+}
+
+type ColumnResizePreviewState = {
+  directionMultiplier: 1 | -1
+  initialSize: number
+  initialX: number
+  maxSize: number
+  minSize: number
+}
+
+type ColumnResizePreviewPosition = {
+  boundaryX: number
+  limit?: 'max' | 'min'
+  size: number
+  x: number
+}
+
+const COLUMN_RESIZE_LIMIT_RELEASE_MS = 150
+const COLUMN_RESIZE_FALLOFF_DISTANCE = 24
+const COLUMN_RESIZE_FALLOFF_STIFFNESS = 3
+const columnResizeReleaseTimeouts = new WeakMap<HTMLElement, number>()
+
+function clearColumnResizeRelease(container: HTMLElement) {
+  const timeout = columnResizeReleaseTimeouts.get(container)
+
+  if (timeout) {
+    window.clearTimeout(timeout)
+    columnResizeReleaseTimeouts.delete(container)
+  }
+
+  delete container.dataset.columnResizeReleasing
+}
+
+function getColumnResizePointerPosition(container: HTMLElement, clientX: number) {
+  const rect = container.getBoundingClientRect()
+
+  return clientX - rect.left - container.clientLeft + container.scrollLeft
+}
+
+function clampColumnResizeSize(size: number, minSize: number, maxSize: number) {
+  return Math.min(Math.max(size, minSize), maxSize)
+}
+
+function applyColumnResizeFalloff(size: number, minSize: number, maxSize: number, distance: number, stiffness: number) {
+  if (size < minSize) {
+    const overshoot = minSize - size
+    return minSize - (distance * overshoot) / (overshoot + distance * stiffness)
+  }
+
+  if (size > maxSize) {
+    const overshoot = size - maxSize
+    return maxSize + (distance * overshoot) / (overshoot + distance * stiffness)
+  }
+
+  return size
+}
+
+function getColumnResizePreviewPosition(
+  container: HTMLElement,
+  clientX: number,
+  { directionMultiplier, initialSize, initialX, maxSize, minSize }: ColumnResizePreviewState,
+): ColumnResizePreviewPosition {
+  const pointerX = getColumnResizePointerPosition(container, clientX)
+  const rawSize = initialSize + (pointerX - initialX) * directionMultiplier
+  const nextSize = clampColumnResizeSize(rawSize, minSize, maxSize)
+  const limit = rawSize < minSize ? 'min' : rawSize > maxSize ? 'max' : undefined
+  const displaySize = applyColumnResizeFalloff(
+    rawSize,
+    minSize,
+    maxSize,
+    COLUMN_RESIZE_FALLOFF_DISTANCE,
+    COLUMN_RESIZE_FALLOFF_STIFFNESS,
+  )
+  const boundaryX = initialX + (nextSize - initialSize) * directionMultiplier
+
+  return {
+    boundaryX,
+    limit,
+    size: nextSize,
+    x: initialX + (displaySize - initialSize) * directionMultiplier,
+  }
+}
+
+function startColumnResize<TData>(
+  target: HTMLElement,
+  initialClientX: number,
+  pointerId: number,
+  header: Header<TData, unknown>,
+) {
+  const container = target.closest<HTMLElement>('[data-slot="table-container"]')
+  const indicator = container?.querySelector<HTMLElement>('[data-slot="table-column-resize-indicator"]')
+
+  if (!container || !indicator) return
+
+  const table = header.getContext().table
+  const { minSize, maxSize } = getHeaderResizeBounds(header)
+  const previewState: ColumnResizePreviewState = {
+    directionMultiplier: table.options.columnResizeDirection === 'rtl' ? -1 : 1,
+    initialSize: header.getSize(),
+    initialX: getColumnResizePointerPosition(container, initialClientX),
+    maxSize,
+    minSize,
+  }
+
+  let frame = 0
+  let latestClientX = initialClientX
+  let lastPosition: ColumnResizePreviewPosition | undefined
+  let stopped = false
+
+  const commitSize = (nextSize: number) => {
+    table.setColumnSizing((old) => ({
+      ...old,
+      [header.column.id]: nextSize,
+    }))
+  }
+
+  const update = () => {
+    frame = 0
+    const position = getColumnResizePreviewPosition(container, latestClientX, previewState)
+    lastPosition = position
+
+    if (position.limit) {
+      container.dataset.columnResizeLimit = position.limit
+    } else {
+      delete container.dataset.columnResizeLimit
+    }
+
+    indicator.style.transform = `translate3d(${position.x}px, 0, 0)`
+    target.setAttribute('aria-valuenow', String(Math.round(position.size)))
+  }
+
+  const scheduleUpdate = (clientX: number) => {
+    latestClientX = clientX
+    if (frame) return
+
+    frame = requestAnimationFrame(update)
+  }
+
+  const handlePointerMove = (event: PointerEvent) => {
+    if (event.pointerId !== pointerId) return
+
+    event.preventDefault()
+    scheduleUpdate(event.clientX)
+  }
+
+  const stop = () => {
+    if (stopped) return
+
+    stopped = true
+    clearColumnResizeRelease(container)
+    if (frame) {
+      cancelAnimationFrame(frame)
+      frame = 0
+    }
+
+    if (target.hasPointerCapture(pointerId)) {
+      target.releasePointerCapture(pointerId)
+    }
+
+    document.removeEventListener('pointermove', handlePointerMove)
+    document.removeEventListener('pointerup', handlePointerEnd)
+    document.removeEventListener('pointercancel', handlePointerEnd)
+    target.removeEventListener('lostpointercapture', stop)
+    window.removeEventListener('blur', stop)
+
+    commitSize(lastPosition?.size ?? previewState.initialSize)
+    delete target.dataset.resizing
+
+    if (lastPosition?.limit) {
+      container.dataset.columnResizeReleasing = 'true'
+      indicator.style.transform = `translate3d(${lastPosition.boundaryX}px, 0, 0)`
+
+      const releaseTimeout = window.setTimeout(() => {
+        delete container.dataset.columnResizing
+        delete container.dataset.columnResizeLimit
+        delete container.dataset.columnResizeReleasing
+        indicator.style.transform = ''
+        columnResizeReleaseTimeouts.delete(container)
+      }, COLUMN_RESIZE_LIMIT_RELEASE_MS)
+      columnResizeReleaseTimeouts.set(container, releaseTimeout)
+      return
+    }
+
+    delete container.dataset.columnResizing
+    delete container.dataset.columnResizeLimit
+    delete container.dataset.columnResizeReleasing
+    indicator.style.transform = ''
+  }
+
+  const handlePointerEnd = (event: PointerEvent) => {
+    if (event.pointerId !== pointerId) return
+
+    stop()
+  }
+
+  container.dataset.columnResizing = 'true'
+  clearColumnResizeRelease(container)
+  target.dataset.resizing = 'true'
+  target.setPointerCapture(pointerId)
+  update()
+  document.addEventListener('pointermove', handlePointerMove, { passive: false })
+  document.addEventListener('pointerup', handlePointerEnd)
+  document.addEventListener('pointercancel', handlePointerEnd)
+  target.addEventListener('lostpointercapture', stop)
+  window.addEventListener('blur', stop)
+}
+
+function TableColumnResizeHandle<TData>({ header }: { header: Header<TData, unknown> }) {
+  if (!getHeaderCanResize(header)) return null
+
+  const table = header.getContext().table
+  const { minSize, maxSize } = getHeaderResizeBounds(header)
+  const size = header.column.getSize()
+  const label = getHeaderResizeLabel(header)
+
+  const updateColumnSize = (nextSize: number) => {
+    table.setColumnSizing((old) => ({
+      ...old,
+      [header.column.id]: clampColumnResizeSize(nextSize, minSize, maxSize),
+    }))
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Home') {
+      event.preventDefault()
+      event.stopPropagation()
+      header.column.resetSize()
+      return
+    }
+
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const step = event.shiftKey ? 25 : 10
+    const direction = event.key === 'ArrowRight' ? 1 : -1
+    const directionMultiplier = table.options.columnResizeDirection === 'rtl' ? -1 : 1
+
+    updateColumnSize(size + step * direction * directionMultiplier)
+  }
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!event.isPrimary) return
+
+    event.preventDefault()
+    event.stopPropagation()
+    startColumnResize(event.currentTarget, event.clientX, event.pointerId, header)
+  }
+
+  return (
+    <div
+      aria-label={`Resize ${label} column`}
+      aria-orientation="vertical"
+      aria-valuemax={maxSize === Number.MAX_SAFE_INTEGER ? undefined : maxSize}
+      aria-valuemin={minSize}
+      aria-valuenow={Math.round(size)}
+      data-resizing={header.column.getIsResizing() ? 'true' : undefined}
+      data-slot="table-column-resize-handle"
+      onDoubleClick={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        header.column.resetSize()
+      }}
+      onKeyDown={handleKeyDown}
+      onPointerDown={handlePointerDown}
+      role="separator"
+      tabIndex={0}
+      title={`Resize ${label} column`}
+    />
+  )
+}
+
+function TableHead<TData = unknown>({
+  children,
+  className,
+  header,
+  style,
+  sticky,
+  ...props
+}: React.ComponentProps<'th'> & { header?: Header<TData, unknown>; sticky?: StickyState }) {
   const stickySide = getStickySide(sticky)
+  const canResize = getHeaderCanResize(header)
 
   return (
     <th
       data-slot="table-head"
       data-sticky-state={stickySide}
+      data-resizable={canResize ? 'true' : undefined}
       className={cn(
         'text-muted-foreground border-b h-8 px-3 text-left align-middle !font-mono font-medium !uppercase whitespace-nowrap !text-xs [&_*]:!font-mono [&_*]:!uppercase [&_*]:!text-xs bg-table-header [&:has([data-sort])]:text-foreground',
         {
           'sticky z-[2]': sticky,
+          relative: !sticky,
           'left-0': stickySide === 'left',
           'right-0': stickySide === 'right',
         },
@@ -159,7 +465,10 @@ function TableHead({ className, style, sticky, ...props }: React.ComponentProps<
       )}
       style={style}
       {...props}
-    />
+    >
+      {children}
+      {header ? <TableColumnResizeHandle header={header} /> : null}
+    </th>
   )
 }
 

--- a/apps/dashboard/src/components/ui/table.tsx
+++ b/apps/dashboard/src/components/ui/table.tsx
@@ -6,6 +6,7 @@
 import * as React from 'react'
 
 import { cn } from '@/lib/utils'
+import { getColumnSizeBounds } from '@/lib/utils/table'
 import type { Header, Table as ReactTable } from '@tanstack/react-table'
 import { useEffect, useRef } from 'react'
 import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from './empty'
@@ -150,12 +151,7 @@ function getHeaderResizeLabel<TData>(header: Header<TData, unknown>) {
 }
 
 function getHeaderResizeBounds<TData>(header: Header<TData, unknown>) {
-  const defaultColumn = header.getContext().table.options.defaultColumn
-
-  return {
-    minSize: header.column.columnDef.minSize ?? defaultColumn?.minSize ?? 20,
-    maxSize: header.column.columnDef.maxSize ?? defaultColumn?.maxSize ?? Number.MAX_SAFE_INTEGER,
-  }
+  return getColumnSizeBounds(header.column, header.getContext().table.options.defaultColumn)
 }
 
 function getHeaderCanResize<TData>(header?: Header<TData, unknown>) {
@@ -176,7 +172,7 @@ type ColumnResizePreviewState = {
 
 type ColumnResizePreviewPosition = {
   boundaryX: number
-  limit?: 'max' | 'min'
+  isPastBounds: boolean
   size: number
   x: number
 }
@@ -195,6 +191,15 @@ function clearColumnResizeRelease(container: HTMLElement) {
   }
 
   delete container.dataset.columnResizeReleasing
+}
+
+function getColumnResizeAriaValueText(size: number) {
+  return `${Math.round(size)} pixels`
+}
+
+function resetColumnResizeIndicator(indicator: HTMLElement) {
+  indicator.style.transform = ''
+  indicator.style.removeProperty('--table-column-resize-indicator-height')
 }
 
 function getColumnResizePointerPosition(container: HTMLElement, clientX: number) {
@@ -229,7 +234,7 @@ function getColumnResizePreviewPosition(
   const pointerX = getColumnResizePointerPosition(container, clientX)
   const rawSize = initialSize + (pointerX - initialX) * directionMultiplier
   const nextSize = clampColumnResizeSize(rawSize, minSize, maxSize)
-  const limit = rawSize < minSize ? 'min' : rawSize > maxSize ? 'max' : undefined
+  const isPastBounds = rawSize < minSize || rawSize > maxSize
   const displaySize = applyColumnResizeFalloff(
     rawSize,
     minSize,
@@ -241,7 +246,7 @@ function getColumnResizePreviewPosition(
 
   return {
     boundaryX,
-    limit,
+    isPastBounds,
     size: nextSize,
     x: initialX + (displaySize - initialSize) * directionMultiplier,
   }
@@ -285,14 +290,9 @@ function startColumnResize<TData>(
     const position = getColumnResizePreviewPosition(container, latestClientX, previewState)
     lastPosition = position
 
-    if (position.limit) {
-      container.dataset.columnResizeLimit = position.limit
-    } else {
-      delete container.dataset.columnResizeLimit
-    }
-
     indicator.style.transform = `translate3d(${position.x}px, 0, 0)`
     target.setAttribute('aria-valuenow', String(Math.round(position.size)))
+    target.setAttribute('aria-valuetext', getColumnResizeAriaValueText(position.size))
   }
 
   const scheduleUpdate = (clientX: number) => {
@@ -332,15 +332,14 @@ function startColumnResize<TData>(
     commitSize(lastPosition?.size ?? previewState.initialSize)
     delete target.dataset.resizing
 
-    if (lastPosition?.limit) {
+    if (lastPosition?.isPastBounds) {
       container.dataset.columnResizeReleasing = 'true'
       indicator.style.transform = `translate3d(${lastPosition.boundaryX}px, 0, 0)`
 
       const releaseTimeout = window.setTimeout(() => {
         delete container.dataset.columnResizing
-        delete container.dataset.columnResizeLimit
         delete container.dataset.columnResizeReleasing
-        indicator.style.transform = ''
+        resetColumnResizeIndicator(indicator)
         columnResizeReleaseTimeouts.delete(container)
       }, COLUMN_RESIZE_LIMIT_RELEASE_MS)
       columnResizeReleaseTimeouts.set(container, releaseTimeout)
@@ -348,9 +347,8 @@ function startColumnResize<TData>(
     }
 
     delete container.dataset.columnResizing
-    delete container.dataset.columnResizeLimit
     delete container.dataset.columnResizeReleasing
-    indicator.style.transform = ''
+    resetColumnResizeIndicator(indicator)
   }
 
   const handlePointerEnd = (event: PointerEvent) => {
@@ -361,6 +359,7 @@ function startColumnResize<TData>(
 
   container.dataset.columnResizing = 'true'
   clearColumnResizeRelease(container)
+  indicator.style.setProperty('--table-column-resize-indicator-height', `${container.scrollHeight}px`)
   target.dataset.resizing = 'true'
   target.setPointerCapture(pointerId)
   update()
@@ -380,14 +379,30 @@ function TableColumnResizeHandle<TData>({ header }: { header: Header<TData, unkn
   const label = getHeaderResizeLabel(header)
 
   const updateColumnSize = (nextSize: number) => {
+    const size = clampColumnResizeSize(nextSize, minSize, maxSize)
+
     table.setColumnSizing((old) => ({
       ...old,
-      [header.column.id]: clampColumnResizeSize(nextSize, minSize, maxSize),
+      [header.column.id]: size,
     }))
   }
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Home') {
+      event.preventDefault()
+      event.stopPropagation()
+      updateColumnSize(minSize)
+      return
+    }
+
+    if (event.key === 'End' && maxSize !== Number.MAX_SAFE_INTEGER) {
+      event.preventDefault()
+      event.stopPropagation()
+      updateColumnSize(maxSize)
+      return
+    }
+
+    if (event.key === 'Enter') {
       event.preventDefault()
       event.stopPropagation()
       header.column.resetSize()
@@ -407,7 +422,7 @@ function TableColumnResizeHandle<TData>({ header }: { header: Header<TData, unkn
   }
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
-    if (!event.isPrimary) return
+    if (!event.isPrimary || event.button !== 0) return
 
     event.preventDefault()
     event.stopPropagation()
@@ -421,6 +436,7 @@ function TableColumnResizeHandle<TData>({ header }: { header: Header<TData, unkn
       aria-valuemax={maxSize === Number.MAX_SAFE_INTEGER ? undefined : maxSize}
       aria-valuemin={minSize}
       aria-valuenow={Math.round(size)}
+      aria-valuetext={getColumnResizeAriaValueText(size)}
       data-resizing={header.column.getIsResizing() ? 'true' : undefined}
       data-slot="table-column-resize-handle"
       onDoubleClick={(event) => {

--- a/apps/dashboard/src/enums/LocalStorageKey.ts
+++ b/apps/dashboard/src/enums/LocalStorageKey.ts
@@ -7,5 +7,4 @@ export enum LocalStorageKey {
   SelectedOrganizationId = 'SelectedOrganizationId',
   SkipOnboardingPrefix = 'SkipOnboarding_',
   AnnouncementBannerDismissed = 'AnnouncementBannerDismissed',
-  SandboxTableColumnVisibility = 'SandboxTableColumnVisibility',
 }

--- a/apps/dashboard/src/hooks/useStorageState.ts
+++ b/apps/dashboard/src/hooks/useStorageState.ts
@@ -1,0 +1,438 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import {
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+  useCallback,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from 'react'
+
+type StorageStateStorage = Pick<Storage, 'getItem' | 'removeItem' | 'setItem'>
+type StorageStateStorageProvider = () => StorageStateStorage | null | undefined
+type StorageStateInitialValue<TValue> = TValue | (() => TValue)
+
+type StorageStateError = {
+  error: unknown
+  key: string
+  operation: 'read' | 'remove' | 'write'
+}
+
+type UseStorageStateOptions<TValue> = {
+  deserialize?: (storedValue: string) => TValue
+  onError?: (error: StorageStateError) => void
+  serialize?: (value: TValue) => string
+  storage?: StorageStateStorage | StorageStateStorageProvider | null
+}
+
+type StorageStateSnapshot<TValue> = {
+  hasStoredValue: boolean
+  isPersistent: boolean
+  value: TValue
+}
+
+type StorageStateSnapshotReader<TValue> = {
+  clearMemoryValue: () => void
+  getServerSnapshot: () => StorageStateSnapshot<TValue>
+  getSnapshot: () => StorageStateSnapshot<TValue>
+  setMemoryValue: (rawValue: string | null) => void
+}
+
+type StorageStateSnapshotSource = {
+  kind: 'error' | 'memory' | 'storage' | 'unavailable'
+  rawValue: string | null
+  storage: StorageStateStorage | null
+}
+
+type StorageStateChangeListener = () => void
+
+type StorageStateChangeDetail = {
+  isPersistent: boolean
+  key: string
+  rawValue: string | null
+  storage: StorageStateStorage | null
+}
+
+type UseStorageStateResult<TValue> = readonly [
+  TValue,
+  Dispatch<SetStateAction<TValue>>,
+  () => void,
+  {
+    hasStoredValue: boolean
+    isPersistent: boolean
+  },
+]
+
+const getBrowserLocalStorage: StorageStateStorageProvider = () => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  return window.localStorage
+}
+
+const STORAGE_STATE_CHANGE_EVENT = 'daytona:storage-state-change'
+
+function useStorageState<TValue>(
+  key: string,
+  initialValue: StorageStateInitialValue<TValue>,
+  {
+    deserialize = deserializeJson,
+    onError = reportStorageStateError,
+    serialize = serializeJson,
+    storage = getBrowserLocalStorage,
+  }: UseStorageStateOptions<TValue> = {},
+): UseStorageStateResult<TValue> {
+  const initialValueRef = useRef(initialValue)
+  initialValueRef.current = initialValue
+
+  const snapshotReader = useMemo(
+    () =>
+      createStorageSnapshotReader(key, initialValueRef, {
+        deserialize,
+        onError,
+        storage,
+      }),
+    [deserialize, key, onError, storage],
+  )
+
+  const subscribe = useCallback(
+    (listener: StorageStateChangeListener) => subscribeStorageValue(key, storage, snapshotReader, listener),
+    [key, snapshotReader, storage],
+  )
+
+  const snapshot = useSyncExternalStore(subscribe, snapshotReader.getSnapshot, snapshotReader.getServerSnapshot)
+
+  const setValue = useCallback<Dispatch<SetStateAction<TValue>>>(
+    (nextValueOrUpdater) => {
+      const currentSnapshot = snapshotReader.getSnapshot()
+      const nextValue =
+        typeof nextValueOrUpdater === 'function'
+          ? (nextValueOrUpdater as (currentValue: TValue) => TValue)(currentSnapshot.value)
+          : nextValueOrUpdater
+
+      writeStorageValue(key, nextValue, snapshotReader, {
+        onError,
+        serialize,
+        storage,
+      })
+    },
+    [key, onError, serialize, snapshotReader, storage],
+  )
+
+  const removeValue = useCallback(() => {
+    removeStorageValue(key, snapshotReader, { onError, storage })
+  }, [key, onError, snapshotReader, storage])
+
+  return [
+    snapshot.value,
+    setValue,
+    removeValue,
+    {
+      hasStoredValue: snapshot.hasStoredValue,
+      isPersistent: snapshot.isPersistent,
+    },
+  ] as const
+}
+
+function createStorageSnapshotReader<TValue>(
+  key: string,
+  initialValueRef: RefObject<StorageStateInitialValue<TValue>>,
+  {
+    deserialize,
+    onError,
+    storage,
+  }: Required<Pick<UseStorageStateOptions<TValue>, 'deserialize' | 'onError' | 'storage'>>,
+): StorageStateSnapshotReader<TValue> {
+  let cachedServerSnapshot: StorageStateSnapshot<TValue> | null = null
+  let cachedSnapshot: StorageStateSnapshot<TValue> | null = null
+  let cachedSource: StorageStateSnapshotSource | null = null
+  let memoryValue: string | null | undefined
+
+  const getInitialSnapshot = (): StorageStateSnapshot<TValue> => ({
+    hasStoredValue: false,
+    isPersistent: false,
+    value: resolveInitialValue(initialValueRef.current),
+  })
+
+  const getServerSnapshot = () => {
+    if (!cachedServerSnapshot) {
+      cachedServerSnapshot = getInitialSnapshot()
+    }
+
+    return cachedServerSnapshot
+  }
+
+  const getSnapshot = () => {
+    const storageArea = resolveStorage(storage) ?? null
+    let source: StorageStateSnapshotSource
+
+    if (memoryValue !== undefined) {
+      source = {
+        kind: 'memory',
+        rawValue: memoryValue,
+        storage: storageArea,
+      }
+    } else if (!storageArea) {
+      source = {
+        kind: 'unavailable',
+        rawValue: null,
+        storage: null,
+      }
+    } else {
+      try {
+        source = {
+          kind: 'storage',
+          rawValue: storageArea.getItem(key),
+          storage: storageArea,
+        }
+      } catch (error) {
+        source = {
+          kind: 'error',
+          rawValue: null,
+          storage: storageArea,
+        }
+
+        if (!isMatchingSnapshotSource(cachedSource, source)) {
+          onError({ error, key, operation: 'read' })
+        }
+      }
+    }
+
+    if (cachedSnapshot && isMatchingSnapshotSource(cachedSource, source)) {
+      return cachedSnapshot
+    }
+
+    cachedSource = source
+
+    if (source.rawValue === null) {
+      cachedSnapshot = {
+        hasStoredValue: false,
+        isPersistent: source.kind === 'storage',
+        value: resolveInitialValue(initialValueRef.current),
+      }
+
+      return cachedSnapshot
+    }
+
+    try {
+      cachedSnapshot = {
+        hasStoredValue: source.kind === 'storage',
+        isPersistent: source.kind === 'storage',
+        value: deserialize(source.rawValue),
+      }
+    } catch (error) {
+      onError({ error, key, operation: 'read' })
+
+      cachedSnapshot = getInitialSnapshot()
+    }
+
+    return cachedSnapshot
+  }
+
+  return {
+    clearMemoryValue: () => {
+      memoryValue = undefined
+    },
+    getServerSnapshot,
+    getSnapshot,
+    setMemoryValue: (rawValue) => {
+      memoryValue = rawValue
+    },
+  }
+}
+
+function writeStorageValue<TValue>(
+  key: string,
+  value: TValue,
+  snapshotReader: StorageStateSnapshotReader<TValue>,
+  { onError, serialize, storage }: Required<Pick<UseStorageStateOptions<TValue>, 'onError' | 'serialize' | 'storage'>>,
+) {
+  const storageArea = resolveStorage(storage) ?? null
+  let serializedValue: string
+
+  try {
+    serializedValue = serialize(value)
+  } catch (error) {
+    onError({ error, key, operation: 'write' })
+    return false
+  }
+
+  if (!storageArea) {
+    snapshotReader.setMemoryValue(serializedValue)
+    emitStorageValueChange({ isPersistent: false, key, rawValue: serializedValue, storage: storageArea })
+    return false
+  }
+
+  try {
+    storageArea.setItem(key, serializedValue)
+    snapshotReader.clearMemoryValue()
+    emitStorageValueChange({ isPersistent: true, key, rawValue: serializedValue, storage: storageArea })
+    return true
+  } catch (error) {
+    snapshotReader.setMemoryValue(serializedValue)
+    emitStorageValueChange({ isPersistent: false, key, rawValue: serializedValue, storage: storageArea })
+    onError({ error, key, operation: 'write' })
+    return false
+  }
+}
+
+function removeStorageValue<TValue>(
+  key: string,
+  snapshotReader: StorageStateSnapshotReader<TValue>,
+  { onError, storage }: Required<Pick<UseStorageStateOptions<TValue>, 'onError' | 'storage'>>,
+) {
+  const storageArea = resolveStorage(storage) ?? null
+
+  if (!storageArea) {
+    snapshotReader.setMemoryValue(null)
+    emitStorageValueChange({ isPersistent: false, key, rawValue: null, storage: storageArea })
+    return false
+  }
+
+  try {
+    storageArea.removeItem(key)
+    snapshotReader.clearMemoryValue()
+    emitStorageValueChange({ isPersistent: true, key, rawValue: null, storage: storageArea })
+    return true
+  } catch (error) {
+    snapshotReader.setMemoryValue(null)
+    emitStorageValueChange({ isPersistent: false, key, rawValue: null, storage: storageArea })
+    onError({ error, key, operation: 'remove' })
+    return false
+  }
+}
+
+function subscribeStorageValue(
+  key: string,
+  storage: StorageStateStorage | StorageStateStorageProvider | null | undefined,
+  snapshotReader: StorageStateSnapshotReader<unknown>,
+  listener: StorageStateChangeListener,
+) {
+  const storageArea = resolveStorage(storage) ?? null
+
+  const handleStorageStateChange = (event: Event) => {
+    const detail = (event as CustomEvent<StorageStateChangeDetail>).detail
+
+    if (!isStorageStateChangeDetail(detail) || detail.key !== key || detail.storage !== storageArea) {
+      return
+    }
+
+    if (detail.isPersistent) {
+      snapshotReader.clearMemoryValue()
+    } else {
+      snapshotReader.setMemoryValue(detail.rawValue)
+    }
+    listener()
+  }
+
+  const handleBrowserStorageChange = (event: StorageEvent) => {
+    if (!isStorageEventForValue(event, key, storageArea)) {
+      return
+    }
+
+    snapshotReader.clearMemoryValue()
+    listener()
+  }
+
+  if (typeof window === 'undefined') {
+    return () => undefined
+  }
+
+  window.addEventListener(STORAGE_STATE_CHANGE_EVENT, handleStorageStateChange)
+  window.addEventListener('storage', handleBrowserStorageChange)
+
+  return () => {
+    window.removeEventListener(STORAGE_STATE_CHANGE_EVENT, handleStorageStateChange)
+    window.removeEventListener('storage', handleBrowserStorageChange)
+  }
+}
+
+function emitStorageValueChange(detail: StorageStateChangeDetail) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  window.dispatchEvent(new CustomEvent<StorageStateChangeDetail>(STORAGE_STATE_CHANGE_EVENT, { detail }))
+}
+
+function isMatchingSnapshotSource(
+  previousSource: StorageStateSnapshotSource | null,
+  nextSource: StorageStateSnapshotSource,
+) {
+  return (
+    previousSource?.kind === nextSource.kind &&
+    previousSource.rawValue === nextSource.rawValue &&
+    previousSource.storage === nextSource.storage
+  )
+}
+
+function isNativeStorage(storage: StorageStateStorage): storage is Storage {
+  return typeof Storage !== 'undefined' && storage instanceof Storage
+}
+
+function isStorageEventForValue(event: StorageEvent, key: string, storage: StorageStateStorage | null) {
+  if (!storage || !isNativeStorage(storage)) {
+    return false
+  }
+
+  if (event.key !== null && event.key !== key) {
+    return false
+  }
+
+  return !event.storageArea || storage === event.storageArea
+}
+
+function isStorageStateChangeDetail(detail: unknown): detail is StorageStateChangeDetail {
+  return Boolean(
+    detail &&
+      typeof detail === 'object' &&
+      'key' in detail &&
+      'isPersistent' in detail &&
+      'storage' in detail &&
+      'rawValue' in detail &&
+      typeof detail.key === 'string' &&
+      typeof detail.isPersistent === 'boolean' &&
+      (typeof detail.rawValue === 'string' || detail.rawValue === null),
+  )
+}
+
+function resolveStorage(storage: StorageStateStorage | StorageStateStorageProvider | null | undefined) {
+  return typeof storage === 'function' ? storage() : storage
+}
+
+function resolveInitialValue<TValue>(initialValue: StorageStateInitialValue<TValue>) {
+  return typeof initialValue === 'function' ? (initialValue as () => TValue)() : initialValue
+}
+
+function serializeJson<TValue>(value: TValue) {
+  const serializedValue = JSON.stringify(value)
+
+  if (typeof serializedValue !== 'string') {
+    throw new Error('Storage state values must be JSON serializable')
+  }
+
+  return serializedValue
+}
+
+function deserializeJson<TValue>(storedValue: string) {
+  return JSON.parse(storedValue) as TValue
+}
+
+function reportStorageStateError({ error, key, operation }: StorageStateError) {
+  console.error(`Failed to ${operation} storage value for "${key}":`, error)
+}
+
+export { getBrowserLocalStorage, useStorageState }
+export type {
+  StorageStateError,
+  StorageStateStorage,
+  StorageStateStorageProvider,
+  UseStorageStateOptions,
+  UseStorageStateResult,
+}

--- a/apps/dashboard/src/index.css
+++ b/apps/dashboard/src/index.css
@@ -277,6 +277,88 @@
   @apply scrollbar-thin scrollbar-thumb-neutral-300 scrollbar-track-background dark:scrollbar-thumb-neutral-700;
 }
 
+@property --scroll-fade-offset-y-top {
+  syntax: '<percentage>';
+  inherits: true;
+  initial-value: 0%;
+}
+
+@property --scroll-fade-offset-y-bottom {
+  syntax: '<percentage>';
+  inherits: true;
+  initial-value: 100%;
+}
+
+@property --scroll-fade-offset-x-left {
+  syntax: '<percentage>';
+  inherits: true;
+  initial-value: 0%;
+}
+
+@property --scroll-fade-offset-x-right {
+  syntax: '<percentage>';
+  inherits: true;
+  initial-value: 100%;
+}
+
+.scroll-fade {
+  --mask-offset: 20%;
+  --scroll-fade-offset-y-top: 0%;
+  --scroll-fade-offset-y-bottom: 100%;
+  --scroll-fade-mask: linear-gradient(
+    to bottom,
+    transparent,
+    black min(var(--scroll-fade-offset-y-top), var(--mask-offset)),
+    black calc(100% - min(var(--scroll-fade-offset-y-bottom), var(--mask-offset))),
+    transparent
+  );
+  animation: animate-scroll-fade-mask linear both;
+  animation-timeline: scroll(self y);
+  mask-image: var(--scroll-fade-mask);
+  -webkit-mask-image: var(--scroll-fade-mask);
+}
+
+.scroll-fade-horizontal {
+  --mask-offset: 20%;
+  --scroll-fade-offset-x-left: 0%;
+  --scroll-fade-offset-x-right: 100%;
+  --scroll-fade-mask: linear-gradient(
+    to right,
+    transparent,
+    black min(var(--scroll-fade-offset-x-left), var(--mask-offset)),
+    black calc(100% - min(var(--scroll-fade-offset-x-right), var(--mask-offset))),
+    transparent
+  );
+  animation: animate-scroll-fade-mask-horizontal linear both;
+  animation-timeline: scroll(self x);
+  mask-image: var(--scroll-fade-mask);
+  -webkit-mask-image: var(--scroll-fade-mask);
+}
+
+@keyframes animate-scroll-fade-mask {
+  0% {
+    --scroll-fade-offset-y-top: 0%;
+    --scroll-fade-offset-y-bottom: 100%;
+  }
+
+  100% {
+    --scroll-fade-offset-y-top: 100%;
+    --scroll-fade-offset-y-bottom: 0%;
+  }
+}
+
+@keyframes animate-scroll-fade-mask-horizontal {
+  0% {
+    --scroll-fade-offset-x-left: 0%;
+    --scroll-fade-offset-x-right: 100%;
+  }
+
+  100% {
+    --scroll-fade-offset-x-left: 100%;
+    --scroll-fade-offset-x-right: 0%;
+  }
+}
+
 @keyframes skeleton-shimmer {
   0% {
     transform: translateX(-100%);

--- a/apps/dashboard/src/lib/utils/table.ts
+++ b/apps/dashboard/src/lib/utils/table.ts
@@ -3,17 +3,26 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Column } from '@tanstack/react-table'
-import { CSSProperties } from 'react'
+import type { Column, Table } from '@tanstack/react-table'
+import type { CSSProperties } from 'react'
 
 export function getColumnSizeStyles<T>(column: Column<T>): CSSProperties {
   const pinned = column.getIsPinned()
-  const hasMaxSize = column.columnDef.maxSize !== Number.MAX_SAFE_INTEGER
+  const maxSize = column.columnDef.maxSize
+  const hasMaxSize = maxSize !== undefined && maxSize !== Number.MAX_SAFE_INTEGER
 
   return {
-    width: hasMaxSize ? column.getSize() : undefined,
+    width: column.getSize(),
     minWidth: column.columnDef.minSize,
+    maxWidth: hasMaxSize ? maxSize : undefined,
     left: pinned === 'left' ? column.getStart('left') : undefined,
     right: pinned === 'right' ? column.getAfter('right') : undefined,
+  }
+}
+
+export function getTableSizeStyles<T>(table: Table<T>): CSSProperties {
+  return {
+    width: table.getTotalSize(),
+    minWidth: '100%',
   }
 }

--- a/apps/dashboard/src/lib/utils/table.ts
+++ b/apps/dashboard/src/lib/utils/table.ts
@@ -6,14 +6,35 @@
 import type { Column, Table } from '@tanstack/react-table'
 import type { CSSProperties } from 'react'
 
+export const DEFAULT_TABLE_COLUMN_MIN_SIZE = 80
+export const DEFAULT_TABLE_COLUMN = {
+  minSize: DEFAULT_TABLE_COLUMN_MIN_SIZE,
+}
+
+type ColumnSizingDefaults = {
+  maxSize?: number
+  minSize?: number
+}
+
+export function getColumnSizeBounds<T>(column: Column<T>, defaultColumn?: ColumnSizingDefaults) {
+  const maxSize = column.columnDef.maxSize ?? defaultColumn?.maxSize ?? Number.MAX_SAFE_INTEGER
+  const configuredMinSize = column.columnDef.minSize ?? defaultColumn?.minSize ?? DEFAULT_TABLE_COLUMN_MIN_SIZE
+  const minSize = Math.min(Math.max(configuredMinSize, DEFAULT_TABLE_COLUMN_MIN_SIZE), maxSize)
+
+  return {
+    maxSize,
+    minSize,
+  }
+}
+
 export function getColumnSizeStyles<T>(column: Column<T>): CSSProperties {
   const pinned = column.getIsPinned()
-  const maxSize = column.columnDef.maxSize
-  const hasMaxSize = maxSize !== undefined && maxSize !== Number.MAX_SAFE_INTEGER
+  const { maxSize, minSize } = getColumnSizeBounds(column)
+  const hasMaxSize = maxSize !== Number.MAX_SAFE_INTEGER
 
   return {
     width: column.getSize(),
-    minWidth: column.columnDef.minSize,
+    minWidth: minSize,
     maxWidth: hasMaxSize ? maxSize : undefined,
     left: pinned === 'left' ? column.getStart('left') : undefined,
     right: pinned === 'right' ? column.getAfter('right') : undefined,

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "kafkajs": "^2.2.4",
     "linkify-it": "^5.0.1",
     "lucide-react": "^1.17.0",
-    "motion": "^12.23.0",
+    "motion": "^12.40.0",
     "msw": "^2.12.2",
     "nestjs-opensearch": "^1.4.1",
     "nestjs-pino": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21992,7 +21992,7 @@ __metadata:
     lint-staged: "npm:^15.5.0"
     lucide-react: "npm:^1.17.0"
     markdownlint-cli2: "npm:^0.17.2"
-    motion: "npm:^12.23.0"
+    motion: "npm:^12.40.0"
     msw: "npm:^2.12.2"
     nestjs-opensearch: "npm:^1.4.1"
     nestjs-pino: "npm:^4.4.1"
@@ -25329,12 +25329,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@npm:^12.23.18":
-  version: 12.23.18
-  resolution: "framer-motion@npm:12.23.18"
+"framer-motion@npm:^12.40.0":
+  version: 12.40.0
+  resolution: "framer-motion@npm:12.40.0"
   dependencies:
-    motion-dom: "npm:^12.23.18"
-    motion-utils: "npm:^12.23.6"
+    motion-dom: "npm:^12.40.0"
+    motion-utils: "npm:^12.39.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
     "@emotion/is-prop-valid": "*"
@@ -25347,7 +25347,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 10c0/059fed39a1f7c1d277ac9ab94da093e0498d59b29de1a2ae5a040d080b644f34bc8862314d45676dfb93adeae01b6c5c84309b2799075b8d2c028ae1d493808d
+  checksum: 10c0/a1d26908d6661028fcdba0cf200fca18927a4d4eae0b1e64c37dfb7fdea9da66a8991abd0007079e98687060ba9c83db55620c238bc363106a24ff411d22f533
   languageName: node
   linkType: hard
 
@@ -31865,27 +31865,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"motion-dom@npm:^12.23.18":
-  version: 12.23.18
-  resolution: "motion-dom@npm:12.23.18"
+"motion-dom@npm:^12.40.0":
+  version: 12.40.0
+  resolution: "motion-dom@npm:12.40.0"
   dependencies:
-    motion-utils: "npm:^12.23.6"
-  checksum: 10c0/eea2db02f222deb1fb615d8e3c7d9ec3ac970fe27326e3bdf81d92ff0227fab7b7219170aaec0c514ff2a5ceb03c40244e7d7144c3fcac33bed648dd644bfde5
+    motion-utils: "npm:^12.39.0"
+  checksum: 10c0/79da846a36fd5f6762a0fcfa6e0b7128e4d58f7c07d1467a9f789a9cd0b5adbef9bfbde75760901a13cf2bddd9b31e93e4348a714f570c45ca1e2bfabd22859e
   languageName: node
   linkType: hard
 
-"motion-utils@npm:^12.23.6":
-  version: 12.23.6
-  resolution: "motion-utils@npm:12.23.6"
-  checksum: 10c0/c058e8ba6423b3baa63e985bcc669877ee7d9579d938f5348b4e60c5ea1b4b33dd7f4877434436a4a5807f3cf00370d3fd4079a6fdd6309c5c87aa62b311a897
+"motion-utils@npm:^12.39.0":
+  version: 12.39.0
+  resolution: "motion-utils@npm:12.39.0"
+  checksum: 10c0/6d7a2a2cc0797b72410a666a9cc1c201c8e39bf9669670464e433fe1e72af5f0217154c869867b34fbadf3664cf222c0d022bbc4eed7927f201ae971918e7440
   languageName: node
   linkType: hard
 
-"motion@npm:^12.23.0":
-  version: 12.23.18
-  resolution: "motion@npm:12.23.18"
+"motion@npm:^12.40.0":
+  version: 12.40.0
+  resolution: "motion@npm:12.40.0"
   dependencies:
-    framer-motion: "npm:^12.23.18"
+    framer-motion: "npm:^12.40.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
     "@emotion/is-prop-valid": "*"
@@ -31898,7 +31898,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 10c0/e59bf177812086d994e28b83a919312938165b1acc59d8e4c02f505898418582b152227ed5903eddabd2ed1d6fcabeb35c434ab376dc454c0083bc6f733763c7
+  checksum: 10c0/d0c118ed4829f2999c3ab7eb1ee916df70c65e95d262e951b69d3cea67a74e4a1d12e181badf4180e0d01c1ca8a9b109be4ea5456cad04bb58d4510f071af60f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Please include a summary of the change or the feature being introduced. Include relevant motivation and context. List any dependencies that are required for this change.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a unified table configuration experience with resizable, reorderable, pinnable, and hideable columns that persist per table. Applied across dashboard tables with better sizing defaults, resize handles, and middle-truncated IDs for readability.

- **New Features**
  - New `DataTableConfigMenu` to resize, reorder, pin, and toggle columns; settings persist via `useStorageState`.
  - Updated table UI and utils: default column min size, column resize handles, and `getTableSizeStyles` for stable widths; integrated into all major tables.
  - Added `MiddleTruncate` for long IDs (e.g., webhooks, sandboxes, runners) to improve scanning.

- **Dependencies**
  - Bumped `motion` to `^12.40.0`.

<sup>Written for commit fb376c422f1c4fa3586e439b081c8c0e2148c50a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

