### PR TITLE
fix(ssh-gateway): preserve runner exit status requests

### DIFF
--- a/apps/ssh-gateway/main.go
+++ b/apps/ssh-gateway/main.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	defaultPort = 2222
-	runnerPort  = 2220
+	defaultPort                = 2222
+	runnerPort                 = 2220
+	channelRequestDrainTimeout = 2 * time.Second
 )
 
 type SSHGateway struct {
@@ -294,45 +295,8 @@ func (g *SSHGateway) handleChannel(newChannel ssh.NewChannel, connClosed <-chan 
 	}
 	defer runnerChannel.Close()
 
-	// Forward requests from client to runner
-	go func() {
-		for req := range clientRequests {
-			if req == nil {
-				return
-			}
-			log.Printf("Client request: %s for runner %s", req.Type, runnerID)
-
-			ok, err := runnerChannel.SendRequest(req.Type, req.WantReply, req.Payload)
-			if req.WantReply {
-				if err != nil {
-					log.Printf("Failed to send request to runner: %v", err)
-					req.Reply(false, []byte(err.Error())) // nolint:errcheck
-				} else {
-					req.Reply(ok, nil) // nolint:errcheck
-				}
-			}
-		}
-	}()
-
-	// Forward requests from runner to client
-	go func() {
-		for req := range runnerRequests {
-			if req == nil {
-				return
-			}
-			log.Printf("Runner request: %s for runner %s", req.Type, runnerID)
-
-			ok, err := clientChannel.SendRequest(req.Type, req.WantReply, req.Payload)
-			if req.WantReply {
-				if err != nil {
-					log.Printf("Failed to send request to client: %v", err)
-					req.Reply(false, []byte(err.Error())) // nolint:errcheck
-				} else {
-					req.Reply(ok, nil) // nolint:errcheck
-				}
-			}
-		}
-	}()
+	forwardChannelRequests(clientRequests, runnerChannel, "Client", "runner", runnerID)
+	runnerRequestsDone := forwardChannelRequests(runnerRequests, clientChannel, "Runner", "client", runnerID)
 
 	// Bidirectional data forwarding.
 	// On client EOF, half-close the runner channel (MSG_CHANNEL_EOF via CloseWrite)
@@ -391,12 +355,46 @@ func (g *SSHGateway) handleChannel(newChannel ssh.NewChannel, connClosed <-chan 
 		}
 	}()
 
-	_, err = io.Copy(clientChannel, runnerChannel)
+	copyRunnerToClient(clientChannel, runnerChannel, runnerRequestsDone, channelRequestDrainTimeout, runnerID)
+
+	log.Printf("Channel closed for runner: %s", runnerID)
+}
+
+func forwardChannelRequests(requests <-chan *ssh.Request, target ssh.Channel, source string, targetName string, runnerID string) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for req := range requests {
+			if req == nil {
+				return
+			}
+			log.Printf("%s request: %s for runner %s", source, req.Type, runnerID)
+
+			ok, err := target.SendRequest(req.Type, req.WantReply, req.Payload)
+			if req.WantReply {
+				if err != nil {
+					log.Printf("Failed to send request to %s: %v", targetName, err)
+					req.Reply(false, []byte(err.Error())) // nolint:errcheck
+				} else {
+					req.Reply(ok, nil) // nolint:errcheck
+				}
+			}
+		}
+	}()
+	return done
+}
+
+func copyRunnerToClient(clientChannel io.Writer, runnerChannel io.Reader, runnerRequestsDone <-chan struct{}, drainTimeout time.Duration, runnerID string) {
+	_, err := io.Copy(clientChannel, runnerChannel)
 	if err != nil {
 		log.Printf("Runner to client copy error: %v", err)
 	}
 
-	log.Printf("Channel closed for runner: %s", runnerID)
+	select {
+	case <-runnerRequestsDone:
+	case <-time.After(drainTimeout):
+		log.Warnf("timed out waiting for runner channel requests to drain for runner: %s", runnerID)
+	}
 }
 
 func (g *SSHGateway) connectToRunner(sandboxId string, runnerDomain string, signer ssh.Signer) (*ssh.Client, error) {

--- a/apps/ssh-gateway/teardown_test.go
+++ b/apps/ssh-gateway/teardown_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rsa"
 	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -32,8 +33,12 @@ func testSigner(t *testing.T) ssh.Signer {
 type channelPair struct {
 	// server is the channel as seen by the SSH server (Accept()-returned).
 	server ssh.Channel
+	// serverRequests receives channel requests sent from client to server.
+	serverRequests <-chan *ssh.Request
 	// client is the channel as seen by the SSH client (OpenChannel()-returned).
 	client ssh.Channel
+	// clientRequests receives channel requests sent from server to client.
+	clientRequests <-chan *ssh.Request
 	// connClosed is closed when the client connection dies — the signal the
 	// production watcher goroutine selects on to hard-close the upstream channel.
 	connClosed chan struct{}
@@ -84,7 +89,12 @@ func newChannelPair(t *testing.T) *channelPair {
 	serverCfg := &ssh.ServerConfig{NoClientAuth: true}
 	serverCfg.AddHostKey(testSigner(t))
 
-	serverChanCh := make(chan ssh.Channel, 1)
+	type acceptedChannel struct {
+		channel  ssh.Channel
+		requests <-chan *ssh.Request
+	}
+
+	serverChanCh := make(chan acceptedChannel, 1)
 	serverConnCh := make(chan *ssh.ServerConn, 1)
 	go func() {
 		sconn, chans, reqs, err := ssh.NewServerConn(srvConn, serverCfg)
@@ -101,8 +111,7 @@ func newChannelPair(t *testing.T) *channelPair {
 		if err != nil {
 			return
 		}
-		go ssh.DiscardRequests(reqs)
-		serverChanCh <- ch
+		serverChanCh <- acceptedChannel{channel: ch, requests: reqs}
 		for range chans {
 		} // drain remaining channels
 	}()
@@ -126,9 +135,8 @@ func newChannelPair(t *testing.T) *channelPair {
 	if err != nil {
 		t.Fatalf("open channel: %v", err)
 	}
-	go ssh.DiscardRequests(chReqs)
 
-	var serverCh ssh.Channel
+	var serverCh acceptedChannel
 	select {
 	case serverCh = <-serverChanCh:
 	case <-time.After(5 * time.Second):
@@ -145,9 +153,11 @@ func newChannelPair(t *testing.T) *channelPair {
 	}()
 
 	return &channelPair{
-		server:     serverCh,
-		client:     clientCh,
-		connClosed: connClosed,
+		server:         serverCh.channel,
+		serverRequests: serverCh.requests,
+		client:         clientCh,
+		clientRequests: chReqs,
+		connClosed:     connClosed,
 		closeConns: func() {
 			cliConn.Close() //nolint:errcheck
 			srvConn.Close() //nolint:errcheck
@@ -155,6 +165,101 @@ func newChannelPair(t *testing.T) *channelPair {
 		closeClient: func() {
 			cliConn.Close() //nolint:errcheck
 		},
+	}
+}
+
+func TestRunnerExitStatusRequestReachesClientAfterRunnerEOF(t *testing.T) {
+	t.Parallel()
+
+	clientPair := newChannelPair(t)
+	defer clientPair.closeConns()
+
+	runnerPair := newChannelPair(t)
+	defer runnerPair.closeConns()
+
+	clientChannel := clientPair.server
+	runnerChannel := runnerPair.client
+
+	runnerRequestsDone := forwardChannelRequests(runnerPair.clientRequests, clientChannel, "Runner", "client", "test-runner")
+	copyDone := make(chan struct{})
+
+	go func() {
+		copyRunnerToClient(clientChannel, runnerChannel, runnerRequestsDone, 5*time.Second, "test-runner")
+		close(copyDone)
+	}()
+
+	payload := []byte{0, 0, 0, 5}
+	if _, err := runnerPair.server.SendRequest("exit-status", false, payload); err != nil {
+		t.Fatalf("runner send exit-status: %v", err)
+	}
+	if err := runnerPair.server.Close(); err != nil {
+		t.Fatalf("runner close: %v", err)
+	}
+
+	select {
+	case req, ok := <-clientPair.clientRequests:
+		if !ok {
+			t.Fatal("client request stream closed before exit-status was forwarded")
+		}
+		if req.Type != "exit-status" {
+			t.Fatalf("client got request %q, want exit-status", req.Type)
+		}
+		if string(req.Payload) != string(payload) {
+			t.Fatalf("client got payload %v, want %v", req.Payload, payload)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("client did not receive forwarded exit-status")
+	}
+
+	select {
+	case <-copyDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner output copy did not finish after runner close")
+	}
+}
+
+type notifyingEOFReader struct {
+	once sync.Once
+	read chan struct{}
+}
+
+func (r *notifyingEOFReader) Read(_ []byte) (int, error) {
+	r.once.Do(func() {
+		close(r.read)
+	})
+	return 0, io.EOF
+}
+
+func TestRunnerOutputWaitsForRequestForwarderAfterEOF(t *testing.T) {
+	t.Parallel()
+
+	requestsDone := make(chan struct{})
+	copyDone := make(chan struct{})
+	runnerOutput := &notifyingEOFReader{read: make(chan struct{})}
+
+	go func() {
+		copyRunnerToClient(io.Discard, runnerOutput, requestsDone, 5*time.Second, "test-runner")
+		close(copyDone)
+	}()
+
+	select {
+	case <-runnerOutput.read:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner output copy did not read from runner channel")
+	}
+
+	select {
+	case <-copyDone:
+		t.Fatal("runner output copy returned before runner requests were drained")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(requestsDone)
+
+	select {
+	case <-copyDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner output copy did not return after runner requests drained")
 	}
 }
 


### PR DESCRIPTION
## Description

The SSH gateway can close the client channel before late runner channel
requests, such as `exit-status`, finish forwarding. When runner stdout/stderr
copy returns first, deferred channel closes can race with the request forwarder
and the client may miss the remote process exit status.

This change makes runner request forwarding waitable and waits for it during
channel teardown after runner output copy returns. The wait is bounded so a
stuck request stream cannot hang teardown forever.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #5027

## Screenshots

Not applicable.

## Notes

Verification:

- `go test ./apps/ssh-gateway -count=1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `apps/ssh-gateway` dropping late runner `exit-status` by waiting for runner→client request forwarding to drain before closing the channel. Adds a bounded timeout to avoid hangs. Addresses #5027.

- **Bug Fixes**
  - Make runner→client request forwarding waitable and wait during teardown; bounded by `channelRequestDrainTimeout`.
  - Extract `forwardChannelRequests` and `copyRunnerToClient`, and add tests to ensure `exit-status` arrives after runner EOF and that output copy waits until requests drain.

<sup>Written for commit 9e6fe0abf91c80fcf464708f824bed128974fee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

