### PR TITLE
fix(api): promise rejection handling in snapshot and sandbox manager

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -153,7 +153,9 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
                   whereCondition: { pending: false, state: sandbox.state },
                 })
 
-                this.syncInstanceState(sandbox.id).catch(this.logger.error)
+                this.syncInstanceState(sandbox.id).catch((err) =>
+                  this.logger.error(`Error syncing instance state for sandbox ${sandbox.id}:`, err),
+                )
               } catch (error) {
                 this.logger.error(`Error processing auto-stop state for sandbox ${sandbox.id}:`, error)
               } finally {
@@ -213,7 +215,9 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
               whereCondition: { pending: false, state: sandbox.state },
             })
 
-            this.syncInstanceState(sandbox.id).catch(this.logger.error)
+            this.syncInstanceState(sandbox.id).catch((err) =>
+              this.logger.error(`Error syncing instance state for sandbox ${sandbox.id}:`, err),
+            )
           } catch (error) {
             this.logger.error(`Error processing auto-archive state for sandbox ${sandbox.id}:`, error)
           } finally {
@@ -276,7 +280,9 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
                   whereCondition: { pending: false, state: sandbox.state },
                 })
 
-                this.syncInstanceState(sandbox.id).catch(this.logger.error)
+                this.syncInstanceState(sandbox.id).catch((err) =>
+                  this.logger.error(`Error syncing instance state for sandbox ${sandbox.id}:`, err),
+                )
               } catch (error) {
                 this.logger.error(`Error processing auto-delete state for sandbox ${sandbox.id}:`, error)
               } finally {
@@ -437,7 +443,9 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
             whereCondition: { pending: false, state: SandboxState.STARTED },
           })
 
-          this.syncInstanceState(sandbox.id).catch(this.logger.error)
+          this.syncInstanceState(sandbox.id).catch((err) =>
+            this.logger.error(`Error syncing instance state for sandbox ${sandbox.id}:`, err),
+          )
         } catch (e) {
           this.logger.error(`Failed to request stop for sandbox ${sandbox.id} on draining runner ${runnerId}`, e)
         } finally {
@@ -955,9 +963,9 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
       },
     })
 
-    await Promise.all(
+    await Promise.allSettled(
       sandboxes.map(async (sandbox) => {
-        this.syncInstanceState(sandbox.id)
+        await this.syncInstanceState(sandbox.id)
       }),
     )
     await this.redisLockProvider.unlock(lockKey)

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -801,38 +801,46 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       return
     }
 
-    const snapshots = await this.snapshotRepository.find({
-      where: {
-        state: SnapshotState.REMOVING,
-      },
-    })
+    try {
+      const snapshots = await this.snapshotRepository.find({
+        where: {
+          state: SnapshotState.REMOVING,
+        },
+      })
 
-    await Promise.all(
-      snapshots.map(async (snapshot) => {
-        const countActiveSnapshots = await this.snapshotRepository.count({
-          where: {
-            state: SnapshotState.ACTIVE,
-            ref: snapshot.ref,
-          },
-        })
+      const results = await Promise.allSettled(
+        snapshots.map(async (snapshot) => {
+          const countActiveSnapshots = await this.snapshotRepository.count({
+            where: {
+              state: SnapshotState.ACTIVE,
+              ref: snapshot.ref,
+            },
+          })
 
-        // Only remove snapshot runners if no other snapshots depend on them
-        if (countActiveSnapshots === 0) {
-          await this.snapshotRunnerRepository.update(
-            {
-              snapshotRef: snapshot.ref,
-            },
-            {
-              state: SnapshotRunnerState.REMOVING,
-            },
-          )
+          // Only remove snapshot runners if no other snapshots depend on them
+          if (countActiveSnapshots === 0) {
+            await this.snapshotRunnerRepository.update(
+              {
+                snapshotRef: snapshot.ref,
+              },
+              {
+                state: SnapshotRunnerState.REMOVING,
+              },
+            )
+          }
+
+          await this.snapshotRepository.remove(snapshot)
+        }),
+      )
+
+      results.forEach((result) => {
+        if (result.status === 'rejected') {
+          this.logger.error(`Error cleaning up snapshot: ${fromAxiosError(result.reason)}`)
         }
-
-        await this.snapshotRepository.remove(snapshot)
-      }),
-    )
-
-    await this.redisLockProvider.unlock(lockKey)
+      })
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
   }
 
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'check-snapshot-state' })
@@ -851,9 +859,9 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       },
     })
 
-    await Promise.all(
+    await Promise.allSettled(
       snapshots.map(async (snapshot) => {
-        this.syncSnapshotState(snapshot.id)
+        await this.syncSnapshotState(snapshot.id)
       }),
     )
   }
@@ -904,7 +912,9 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
 
     await this.redisLockProvider.unlock(lockKey)
     if (syncState === SYNC_AGAIN) {
-      this.syncSnapshotState(snapshotId)
+      void this.syncSnapshotState(snapshotId).catch((err) =>
+        this.logger.error(`Error syncing snapshot state for snapshot ${snapshotId}: ${fromAxiosError(err)}`),
+      )
     }
   }
 

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -859,11 +859,19 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       },
     })
 
-    await Promise.allSettled(
+    const results = await Promise.allSettled(
       snapshots.map(async (snapshot) => {
         await this.syncSnapshotState(snapshot.id)
       }),
     )
+
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        this.logger.error(
+          `Error syncing snapshot state for snapshot ${snapshots[index].id}: ${fromAxiosError(result.reason)}`,
+        )
+      }
+    })
   }
 
   async syncSnapshotState(snapshotId: string): Promise<void> {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves error handling in `SandboxManager` and `SnapshotManager` to prevent unhandled promise rejections and stuck locks. Adds contextual logging and uses `Promise.allSettled` so one failure doesn’t block other work.

- **Bug Fixes**
  - Sandbox: add contextual error logs for `syncInstanceState` with sandbox ID; use `Promise.allSettled` and await calls during background sync.
  - Snapshot cleanup: wrap REMOVING in try/finally to always unlock; use `Promise.allSettled` and log per-snapshot failures with `fromAxiosError`.
  - Snapshot cron/resync: use `Promise.allSettled`, log per-snapshot sync failures, and on `SYNC_AGAIN` safely re-run `syncSnapshotState` with `fromAxiosError`.

<sup>Written for commit da39725d0b24c25fb0ffcd0a8cc369c348880273. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

