### PR TITLE
Feat/table col resize

### DIFF
--- a/apps/dashboard/src/components/ApiKeyTable.tsx
+++ b/apps/dashboard/src/components/ApiKeyTable.tsx
@@ -6,7 +6,7 @@
 import { CREATE_API_KEY_PERMISSIONS_GROUPS } from '@/constants/CreateApiKeyPermissionsGroups'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { ApiKeyList, ApiKeyListPermissionsEnum, CreateApiKeyPermissionsEnum } from '@daytona/api-client'
 
 import {
@@ -69,14 +69,13 @@ export function ApiKeyTable({ data, loading, isLoadingKey, onRevokeRequest }: Da
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState('')
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
     meta: {
       apiKey: { isLoadingKey, onRevokeRequest },
     },
-    defaultColumn: {
-      minSize: 0,
-    },
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
@@ -172,13 +171,14 @@ export function ApiKeyTable({ data, loading, isLoadingKey, onRevokeRequest }: Da
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
+                    header={header}
                     sticky={header.column.getIsPinned()}
                     style={getColumnSizeStyles(header.column)}
                   >
@@ -265,7 +265,7 @@ const columns: ColumnDef<ApiKeyList>[] = [
     header: 'Key',
     size: 220,
     cell: ({ row }) => {
-      return <div className="truncate">{row.original.value}</div>
+      return <div className="truncate text-muted-foreground">{row.original.value}</div>
     },
   },
   {

--- a/apps/dashboard/src/components/AuditLogTable.tsx
+++ b/apps/dashboard/src/components/AuditLogTable.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/components/ui/table'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn, getMaskedTokenFromParts, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { AuditLog } from '@daytona/api-client'
 import { Column, ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { TextSearch } from 'lucide-react'
@@ -55,8 +55,10 @@ export function AuditLogTable({
   toolbarActions,
 }: Props) {
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: auditLogColumns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     getCoreRowModel: getCoreRowModel(),
     manualPagination: true,
     pageCount: pageCount || 1,
@@ -107,13 +109,17 @@ export function AuditLogTable({
           ) : null
         }
       >
-        <Table>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => {
                   return (
-                    <TableHead key={header.id} style={isEmpty ? undefined : getColumnSizeStyles(header.column)}>
+                    <TableHead
+                      key={header.id}
+                      header={header}
+                      style={isEmpty ? undefined : getColumnSizeStyles(header.column)}
+                    >
                       {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
                     </TableHead>
                   )

--- a/apps/dashboard/src/components/Charges/index.tsx
+++ b/apps/dashboard/src/components/Charges/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { flexRender } from '@tanstack/react-table'
 import { Receipt } from 'lucide-react'
 import { Pagination } from '../Pagination'
@@ -54,13 +54,14 @@ export function ChargesTable({ data, loading, onRowClick }: ChargesTableProps) {
           ) : null
         }
       >
-        <Table className="table-fixed border-separate border-spacing-0" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed border-separate border-spacing-0" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
+                    header={header}
                     sticky={header.column.getIsPinned()}
                     style={getColumnSizeStyles(header.column)}
                   >

--- a/apps/dashboard/src/components/Charges/useChargesTable.ts
+++ b/apps/dashboard/src/components/Charges/useChargesTable.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { DEFAULT_TABLE_COLUMN } from '@/lib/utils/table'
 import { Charge } from '@daytona/billing-api-client'
 import {
   ColumnFiltersState,
@@ -33,8 +34,8 @@ export function useChargesTable({ data }: UseChargesTableProps) {
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 })
 
   const columns = useMemo(() => getColumns(), [])
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
     onColumnFiltersChange: setColumnFilters,
@@ -55,6 +56,7 @@ export function useChargesTable({ data }: UseChargesTableProps) {
       pagination,
     },
     defaultColumn: {
+      ...DEFAULT_TABLE_COLUMN,
       size: 100,
     },
     getRowId: (row, index) => row.id ?? String(index),

--- a/apps/dashboard/src/components/DataTableConfigMenu.tsx
+++ b/apps/dashboard/src/components/DataTableConfigMenu.tsx
@@ -1,0 +1,655 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { Column, ColumnPinningState, Table, VisibilityState } from '@tanstack/react-table'
+import isEqual from 'fast-deep-equal'
+import { Eye, EyeOff, GripVertical, Pin, PinOff, RotateCcw, Settings2Icon } from 'lucide-react'
+import { motion, Reorder, useDragControls } from 'motion/react'
+import { type ComponentProps, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { useDeepCompareMemo } from '@/hooks/useDeepCompareMemo'
+import { useStorageState } from '@/hooks/useStorageState'
+import { cn } from '@/lib/utils'
+import { Button } from './ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from './ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
+
+const DATA_TABLE_CONFIG_STORAGE_PREFIX = 'daytona:data-table-config'
+const DATA_TABLE_CONFIG_VERSION = 1
+const DEFAULT_DATA_TABLE_CONFIG_EXCLUDED_COLUMN_IDS = ['actions', 'select'] as const
+const DATA_TABLE_CONFIG_PIN_SEPARATOR_ID = '__data-table-config-pin-separator__'
+
+type DataTableConfig = {
+  columnOrder: string[]
+  columnPinning: ColumnPinningState
+  columnVisibility: VisibilityState
+}
+
+type DataTableConfigMenuProps<TData> = {
+  align?: ComponentProps<typeof DropdownMenuContent>['align']
+  className?: string
+  excludedColumnIds?: readonly string[]
+  getColumnLabel?: (columnId: string) => string
+  persistenceKey: string
+  table: Table<TData>
+}
+
+function DataTableConfigMenu<TData>({
+  align = 'end',
+  className,
+  excludedColumnIds = DEFAULT_DATA_TABLE_CONFIG_EXCLUDED_COLUMN_IDS,
+  getColumnLabel,
+  persistenceKey,
+  table,
+}: DataTableConfigMenuProps<TData>) {
+  const storageKey = useMemo(() => getTableConfigStorageKey(persistenceKey), [persistenceKey])
+  const initialConfigRef = useRef<DataTableConfig | null>(null)
+  const initialConfigStorageKeyRef = useRef<string | null>(null)
+  const appliedStoredConfigKeyRef = useRef<string | null>(null)
+
+  const [storedConfig, setStoredConfig, removeStoredConfig, { hasStoredValue: hasStoredConfig }] =
+    useStorageState<DataTableConfig | null>(storageKey, null, {
+      deserialize: deserializeTableConfig,
+    })
+
+  if (initialConfigStorageKeyRef.current !== storageKey) {
+    initialConfigRef.current = getCurrentTableConfig(table)
+    initialConfigStorageKeyRef.current = storageKey
+  }
+
+  const excludedColumnIdSet = useMemo(() => new Set(excludedColumnIds), [excludedColumnIds])
+  const columns = table.getAllLeafColumns()
+  const configurableColumns = columns.filter((column) => getColumnCanBeConfigured(column, excludedColumnIdSet))
+  const configurableColumnIds = configurableColumns.map((column) => column.id)
+  const configurableColumnsById = new Map(configurableColumns.map((column) => [column.id, column]))
+  const currentGroupedColumnOrder = useDeepCompareMemo(
+    getGroupedColumnOrder(columns, table.getState().columnOrder, table.getState().columnPinning, configurableColumnIds),
+  )
+  const [localGroupedColumnOrder, setLocalGroupedColumnOrder] = useState(currentGroupedColumnOrder)
+  const localGroupedColumnOrderRef = useRef(localGroupedColumnOrder)
+  const localGroupedColumnState = splitGroupedColumnOrder(localGroupedColumnOrder, configurableColumnIds)
+  const hasPinnedConfigurableColumns = localGroupedColumnState.pinnedColumnIds.length > 0
+  const currentConfig = getCurrentTableConfig(table)
+  const initialConfig = initialConfigRef.current
+  const hasConfigChanges = Boolean(initialConfig && !isEqual(currentConfig, initialConfig))
+
+  useEffect(() => {
+    setLocalGroupedColumnOrder(currentGroupedColumnOrder)
+    localGroupedColumnOrderRef.current = currentGroupedColumnOrder
+  }, [currentGroupedColumnOrder])
+
+  const persistConfig = useCallback(
+    (updates: Partial<DataTableConfig>) => {
+      const nextConfig = normalizeTableConfig(
+        {
+          ...getCurrentTableConfig(table),
+          ...updates,
+        },
+        table.getAllLeafColumns(),
+      )
+
+      if (initialConfigRef.current && isEqual(nextConfig, initialConfigRef.current)) {
+        removeStoredConfig()
+        return
+      }
+
+      setStoredConfig(nextConfig)
+    },
+    [removeStoredConfig, setStoredConfig, table],
+  )
+
+  const applyConfig = useCallback(
+    (config: DataTableConfig) => {
+      const normalizedConfig = normalizeTableConfig(config, table.getAllLeafColumns())
+
+      table.setColumnOrder(normalizedConfig.columnOrder)
+      table.setColumnVisibility(normalizedConfig.columnVisibility)
+      table.setColumnPinning(normalizedConfig.columnPinning)
+    },
+    [table],
+  )
+
+  useEffect(() => {
+    if (appliedStoredConfigKeyRef.current === storageKey) {
+      return
+    }
+
+    appliedStoredConfigKeyRef.current = storageKey
+
+    if (storedConfig) {
+      applyConfig(storedConfig)
+    }
+  }, [applyConfig, storageKey, storedConfig])
+
+  const handleVisibilityToggle = useCallback(
+    (column: Column<TData, unknown>) => {
+      const nextVisibility = {
+        ...table.getState().columnVisibility,
+        [column.id]: !column.getIsVisible(),
+      }
+
+      table.setColumnVisibility(nextVisibility)
+      persistConfig({ columnVisibility: nextVisibility })
+    },
+    [persistConfig, table],
+  )
+
+  const handlePinToggle = useCallback(
+    (column: Column<TData, unknown>) => {
+      const currentPinning = normalizeColumnPinning(table.getState().columnPinning, table.getAllLeafColumns())
+      const nextPinning = getNextColumnPinning(
+        currentPinning,
+        column.id,
+        column.getIsPinned() === 'left' ? false : 'left',
+      )
+
+      table.setColumnPinning(nextPinning)
+      persistConfig({ columnPinning: nextPinning })
+    },
+    [persistConfig, table],
+  )
+
+  const commitGroupedColumnOrder = useCallback(
+    (nextGroupedColumnOrder: string[]) => {
+      const nextConfig = getTableConfigUpdatesFromGroupedOrder(table, nextGroupedColumnOrder, configurableColumnIds)
+
+      table.setColumnOrder(nextConfig.columnOrder)
+      table.setColumnPinning(nextConfig.columnPinning)
+      persistConfig(nextConfig)
+    },
+    [configurableColumnIds, persistConfig, table],
+  )
+
+  const handleLocalReorder = useCallback((nextGroupedColumnOrder: string[]) => {
+    localGroupedColumnOrderRef.current = nextGroupedColumnOrder
+    setLocalGroupedColumnOrder(nextGroupedColumnOrder)
+  }, [])
+
+  const handleDragEnd = useCallback(() => {
+    commitGroupedColumnOrder(localGroupedColumnOrderRef.current)
+  }, [commitGroupedColumnOrder])
+
+  const handleUnpinAll = useCallback(() => {
+    const groupedOrder = splitGroupedColumnOrder(localGroupedColumnOrderRef.current, configurableColumnIds)
+    const nextGroupedColumnOrder = [DATA_TABLE_CONFIG_PIN_SEPARATOR_ID, ...groupedOrder.orderedColumnIds]
+
+    localGroupedColumnOrderRef.current = nextGroupedColumnOrder
+    setLocalGroupedColumnOrder(nextGroupedColumnOrder)
+    commitGroupedColumnOrder(nextGroupedColumnOrder)
+  }, [commitGroupedColumnOrder, configurableColumnIds])
+
+  const handleReset = useCallback(() => {
+    removeStoredConfig()
+
+    const defaultConfig = initialConfigRef.current ?? getCurrentTableConfig(table)
+    applyConfig(defaultConfig)
+  }, [applyConfig, removeStoredConfig, table])
+
+  if (configurableColumns.length === 0) {
+    return null
+  }
+
+  return (
+    <DropdownMenu modal={false}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon-sm"
+              className={cn('relative shrink-0', className)}
+              aria-label="Table settings"
+            >
+              <Settings2Icon className="size-4" />
+              {hasStoredConfig && (
+                <span
+                  aria-hidden="true"
+                  className="absolute right-1 top-1 size-1.5 rounded-full bg-info ring-2 ring-background"
+                />
+              )}
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Table settings</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align={align} className="w-80 p-1.5">
+        <div className="flex items-center justify-between gap-2 px-1 py-1">
+          <DropdownMenuLabel className="px-1 py-0">Columns</DropdownMenuLabel>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2"
+            disabled={!hasConfigChanges}
+            onClick={handleReset}
+          >
+            <RotateCcw className="size-3.5" />
+            Reset
+          </Button>
+        </div>
+        <DropdownMenuSeparator />
+        {hasPinnedConfigurableColumns && (
+          <div className="flex items-center justify-between gap-2 px-2 pb-1 pt-1.5">
+            <div className="text-xs font-medium text-muted-foreground">Pinned</div>
+            <Button type="button" variant="ghost" size="sm" className="h-7 px-2" onClick={handleUnpinAll}>
+              <PinOff className="size-3.5" />
+              Unpin all
+            </Button>
+          </div>
+        )}
+        <motion.div layoutScroll className="scrollbar-sm scroll-fade max-h-80 overflow-y-auto pb-1">
+          <Reorder.Group as="div" axis="y" values={localGroupedColumnOrder} onReorder={handleLocalReorder}>
+            {localGroupedColumnOrder.map((columnId) => {
+              if (columnId === DATA_TABLE_CONFIG_PIN_SEPARATOR_ID) {
+                return <DataTableConfigMenuGroupSeparator key={DATA_TABLE_CONFIG_PIN_SEPARATOR_ID} />
+              }
+
+              const column = configurableColumnsById.get(columnId)
+              if (!column) {
+                return null
+              }
+
+              return (
+                <DataTableConfigMenuItem
+                  key={column.id}
+                  column={column}
+                  label={getColumnLabel?.(column.id) ?? getDefaultColumnLabel(column)}
+                  onDragEnd={handleDragEnd}
+                  onPinToggle={handlePinToggle}
+                  onVisibilityToggle={handleVisibilityToggle}
+                />
+              )
+            })}
+          </Reorder.Group>
+        </motion.div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+type DataTableConfigMenuItemProps<TData> = {
+  column: Column<TData, unknown>
+  label: string
+  onDragEnd: () => void
+  onPinToggle: (column: Column<TData, unknown>) => void
+  onVisibilityToggle: (column: Column<TData, unknown>) => void
+}
+
+function DataTableConfigMenuItem<TData>({
+  column,
+  label,
+  onDragEnd,
+  onPinToggle,
+  onVisibilityToggle,
+}: DataTableConfigMenuItemProps<TData>) {
+  const dragControls = useDragControls()
+  const isPinned = column.getIsPinned() === 'left'
+
+  return (
+    <Reorder.Item
+      as="div"
+      value={column.id}
+      dragControls={dragControls}
+      dragListener={false}
+      onDragEnd={onDragEnd}
+      transition={{ type: 'spring', bounce: 0, duration: 0.12 }}
+      className="relative grid grid-cols-[1.75rem_minmax(0,1fr)_auto] items-center gap-2 rounded-md bg-popover px-1.5 py-1 text-sm hover:bg-accent/60"
+    >
+      <button
+        type="button"
+        aria-label={`Reorder ${label}`}
+        className="flex size-7 cursor-grab touch-none items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground active:cursor-grabbing"
+        onPointerDown={(event) => {
+          if (event.button !== 0) {
+            return
+          }
+
+          dragControls.start(event)
+        }}
+      >
+        <GripVertical className="size-4" />
+      </button>
+
+      <span
+        className={cn('min-w-0 truncate', {
+          'text-muted-foreground': !column.getIsVisible(),
+        })}
+      >
+        {label}
+      </span>
+
+      <div className="flex items-center gap-0.5">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="size-7 text-muted-foreground hover:text-foreground"
+          disabled={!column.getCanHide()}
+          aria-label={`${column.getIsVisible() ? 'Hide' : 'Show'} ${label}`}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onVisibilityToggle(column)
+          }}
+        >
+          {column.getIsVisible() ? <Eye className="size-4" /> : <EyeOff className="size-4" />}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className={cn('size-7 text-muted-foreground hover:text-foreground', {
+            'text-foreground': isPinned,
+          })}
+          disabled={!column.getCanPin()}
+          aria-label={`${isPinned ? 'Unpin' : 'Pin'} ${label}`}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onPinToggle(column)
+          }}
+        >
+          {isPinned ? <PinOff className="size-4" /> : <Pin className="size-4" />}
+        </Button>
+      </div>
+    </Reorder.Item>
+  )
+}
+
+function DataTableConfigMenuGroupSeparator() {
+  return (
+    <Reorder.Item
+      as="div"
+      value={DATA_TABLE_CONFIG_PIN_SEPARATOR_ID}
+      dragListener={false}
+      transition={{ type: 'spring', bounce: 0, duration: 0.12 }}
+      className="cursor-default px-2 pb-1 pt-2 text-xs font-medium text-muted-foreground"
+    >
+      Unpinned
+    </Reorder.Item>
+  )
+}
+
+function getTableConfigStorageKey(persistenceKey: string) {
+  return `${DATA_TABLE_CONFIG_STORAGE_PREFIX}:${persistenceKey}:v${DATA_TABLE_CONFIG_VERSION}`
+}
+
+function getDefaultColumnLabel<TData>(column: Column<TData, unknown>) {
+  return typeof column.columnDef.header === 'string' ? column.columnDef.header : column.id
+}
+
+function getColumnCanBeConfigured<TData>(column: Column<TData, unknown>, excludedColumnIds: Set<string>) {
+  if (excludedColumnIds.has(column.id)) {
+    return false
+  }
+
+  return Boolean(column.columnDef.header || column.columnDef.cell || column.getCanHide() || column.getIsPinned())
+}
+
+function getGroupedColumnOrder<TData>(
+  columns: Column<TData, unknown>[],
+  columnOrder: unknown,
+  columnPinning: unknown,
+  configurableColumnIds: string[],
+) {
+  const configurableColumnIdSet = new Set(configurableColumnIds)
+  const normalizedColumnOrder = normalizeColumnOrder(
+    columnOrder,
+    columns.map((column) => column.id),
+  ).filter((columnId) => configurableColumnIdSet.has(columnId))
+  const normalizedColumnPinning = normalizeColumnPinning(columnPinning, columns)
+  const pinnedColumnIds = new Set(normalizedColumnPinning.left ?? [])
+
+  return [
+    ...normalizedColumnOrder.filter((columnId) => pinnedColumnIds.has(columnId)),
+    DATA_TABLE_CONFIG_PIN_SEPARATOR_ID,
+    ...normalizedColumnOrder.filter((columnId) => !pinnedColumnIds.has(columnId)),
+  ]
+}
+
+function getCurrentTableConfig<TData>(table: Table<TData>): DataTableConfig {
+  const columns = table.getAllLeafColumns()
+  const columnIds = columns.map((column) => column.id)
+
+  return normalizeTableConfig(
+    {
+      columnOrder: normalizeColumnOrder(table.getState().columnOrder, columnIds),
+      columnPinning: table.getState().columnPinning,
+      columnVisibility: table.getState().columnVisibility,
+    },
+    columns,
+  )
+}
+
+function normalizeTableConfig<TData>(config: DataTableConfig, columns: Column<TData, unknown>[]): DataTableConfig {
+  const columnIds = columns.map((column) => column.id)
+  const columnOrder = normalizeColumnOrder(config.columnOrder, columnIds)
+
+  return {
+    columnOrder,
+    columnPinning: orderColumnPinning(normalizeColumnPinning(config.columnPinning, columns), columnOrder),
+    columnVisibility: normalizeColumnVisibility(config.columnVisibility, columns),
+  }
+}
+
+function normalizeColumnOrder(columnOrder: unknown, columnIds: string[]) {
+  const columnIdSet = new Set(columnIds)
+  const orderedIds = Array.isArray(columnOrder)
+    ? columnOrder.filter((columnId): columnId is string => typeof columnId === 'string' && columnIdSet.has(columnId))
+    : []
+  const orderedIdSet = new Set(orderedIds)
+  const remainingIds = columnIds.filter((columnId) => !orderedIdSet.has(columnId))
+
+  return [...orderedIds, ...remainingIds]
+}
+
+function normalizeColumnVisibility<TData>(columnVisibility: unknown, columns: Column<TData, unknown>[]) {
+  const columnsById = new Map(columns.map((column) => [column.id, column]))
+  const normalizedVisibility: VisibilityState = {}
+
+  if (!columnVisibility || typeof columnVisibility !== 'object' || Array.isArray(columnVisibility)) {
+    return normalizedVisibility
+  }
+
+  for (const [columnId, isVisible] of Object.entries(columnVisibility)) {
+    const column = columnsById.get(columnId)
+    if (!column?.getCanHide() || typeof isVisible !== 'boolean') {
+      continue
+    }
+
+    normalizedVisibility[columnId] = isVisible
+  }
+
+  return normalizedVisibility
+}
+
+function normalizeColumnPinning<TData>(columnPinning: unknown, columns: Column<TData, unknown>[]) {
+  const columnsById = new Map(columns.map((column) => [column.id, column]))
+  const usedColumnIds = new Set<string>()
+
+  if (!columnPinning || typeof columnPinning !== 'object' || Array.isArray(columnPinning)) {
+    return {}
+  }
+
+  const pinning = columnPinning as ColumnPinningState
+  const readPinnedIds = (side: 'left' | 'right') => {
+    if (!Array.isArray(pinning[side])) {
+      return []
+    }
+
+    return pinning[side].filter((columnId): columnId is string => {
+      const column = columnsById.get(columnId)
+      if (!column?.getCanPin() || usedColumnIds.has(columnId)) {
+        return false
+      }
+
+      usedColumnIds.add(columnId)
+      return true
+    })
+  }
+
+  return {
+    left: readPinnedIds('left'),
+    right: readPinnedIds('right'),
+  }
+}
+
+function getNextColumnPinning(
+  columnPinning: ColumnPinningState,
+  columnId: string,
+  pinSide: 'left' | 'right' | false,
+): ColumnPinningState {
+  const nextPinning: ColumnPinningState = {
+    left: (columnPinning.left ?? []).filter((pinnedColumnId) => pinnedColumnId !== columnId),
+    right: (columnPinning.right ?? []).filter((pinnedColumnId) => pinnedColumnId !== columnId),
+  }
+
+  if (pinSide) {
+    nextPinning[pinSide] = [...(nextPinning[pinSide] ?? []), columnId]
+  }
+
+  return nextPinning
+}
+
+function getTableConfigUpdatesFromGroupedOrder<TData>(
+  table: Table<TData>,
+  groupedColumnOrder: string[],
+  configurableColumnIds: string[],
+): Pick<DataTableConfig, 'columnOrder' | 'columnPinning'> {
+  const columns = table.getAllLeafColumns()
+  const columnIds = columns.map((column) => column.id)
+  const groupedOrder = splitGroupedColumnOrder(groupedColumnOrder, configurableColumnIds)
+  const currentOrder = normalizeColumnOrder(table.getState().columnOrder, columnIds)
+  const nextOrder = mergeConfigurableColumnOrder(currentOrder, groupedOrder.orderedColumnIds, configurableColumnIds)
+  const nextPinning = getColumnPinningFromGroupedOrder(
+    normalizeColumnPinning(table.getState().columnPinning, columns),
+    configurableColumnIds,
+    groupedOrder.pinnedColumnIds,
+    nextOrder,
+  )
+
+  return {
+    columnOrder: nextOrder,
+    columnPinning: nextPinning,
+  }
+}
+
+function splitGroupedColumnOrder(groupedColumnOrder: string[], configurableColumnIds: string[]) {
+  const normalizedGroupedColumnOrder = normalizeGroupedColumnOrder(groupedColumnOrder, configurableColumnIds)
+  const separatorIndex = normalizedGroupedColumnOrder.indexOf(DATA_TABLE_CONFIG_PIN_SEPARATOR_ID)
+  const pinnedColumnIds = normalizedGroupedColumnOrder.slice(0, separatorIndex)
+  const unpinnedColumnIds = normalizedGroupedColumnOrder.slice(separatorIndex + 1)
+
+  return {
+    orderedColumnIds: [...pinnedColumnIds, ...unpinnedColumnIds],
+    pinnedColumnIds,
+    unpinnedColumnIds,
+  }
+}
+
+function normalizeGroupedColumnOrder(groupedColumnOrder: unknown, configurableColumnIds: string[]) {
+  const configurableColumnIdSet = new Set(configurableColumnIds)
+  const seenColumnIds = new Set<string>()
+  const normalizedGroupedColumnOrder: string[] = []
+  let hasSeparator = false
+
+  if (Array.isArray(groupedColumnOrder)) {
+    for (const columnId of groupedColumnOrder) {
+      if (columnId === DATA_TABLE_CONFIG_PIN_SEPARATOR_ID && !hasSeparator) {
+        normalizedGroupedColumnOrder.push(columnId)
+        hasSeparator = true
+        continue
+      }
+
+      if (typeof columnId !== 'string' || !configurableColumnIdSet.has(columnId) || seenColumnIds.has(columnId)) {
+        continue
+      }
+
+      normalizedGroupedColumnOrder.push(columnId)
+      seenColumnIds.add(columnId)
+    }
+  }
+
+  if (!hasSeparator) {
+    normalizedGroupedColumnOrder.push(DATA_TABLE_CONFIG_PIN_SEPARATOR_ID)
+  }
+
+  for (const columnId of configurableColumnIds) {
+    if (!seenColumnIds.has(columnId)) {
+      normalizedGroupedColumnOrder.push(columnId)
+    }
+  }
+
+  return normalizedGroupedColumnOrder
+}
+
+function mergeConfigurableColumnOrder(
+  columnOrder: string[],
+  nextConfigurableOrder: string[],
+  configurableColumnIds: string[],
+) {
+  const configurableColumnIdSet = new Set(configurableColumnIds)
+  const nextConfigurableIds = normalizeColumnOrder(nextConfigurableOrder, configurableColumnIds)
+  const nextConfigurableIdQueue = [...nextConfigurableIds]
+
+  return columnOrder.map((columnId) => {
+    if (!configurableColumnIdSet.has(columnId)) {
+      return columnId
+    }
+
+    return nextConfigurableIdQueue.shift() ?? columnId
+  })
+}
+
+function getColumnPinningFromGroupedOrder(
+  columnPinning: ColumnPinningState,
+  configurableColumnIds: string[],
+  pinnedColumnIds: string[],
+  columnOrder: string[],
+) {
+  const configurableColumnIdSet = new Set(configurableColumnIds)
+
+  return orderColumnPinning(
+    {
+      left: [
+        ...(columnPinning.left ?? []).filter((columnId) => !configurableColumnIdSet.has(columnId)),
+        ...pinnedColumnIds,
+      ],
+      right: (columnPinning.right ?? []).filter((columnId) => !configurableColumnIdSet.has(columnId)),
+    },
+    columnOrder,
+  )
+}
+
+function orderColumnPinning(columnPinning: ColumnPinningState, columnOrder: string[]) {
+  const columnOrderIndex = new Map(columnOrder.map((columnId, index) => [columnId, index]))
+  const orderPinnedIds = (columnIds: string[] = []) =>
+    columnIds
+      .filter((columnId) => columnOrderIndex.has(columnId))
+      .sort((a, b) => (columnOrderIndex.get(a) ?? 0) - (columnOrderIndex.get(b) ?? 0))
+
+  return {
+    left: orderPinnedIds(columnPinning.left),
+    right: orderPinnedIds(columnPinning.right),
+  }
+}
+
+function deserializeTableConfig(storedConfig: string): DataTableConfig {
+  const parsedConfig = JSON.parse(storedConfig)
+
+  if (!parsedConfig || typeof parsedConfig !== 'object') {
+    throw new Error('Stored table configuration is invalid')
+  }
+
+  return parsedConfig as DataTableConfig
+}
+
+export { DataTableConfigMenu }

--- a/apps/dashboard/src/components/DataTableConfigMenu.tsx
+++ b/apps/dashboard/src/components/DataTableConfigMenu.tsx
@@ -23,7 +23,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
 
 const DATA_TABLE_CONFIG_STORAGE_PREFIX = 'daytona:data-table-config'
-const DATA_TABLE_CONFIG_VERSION = 1
+const DATA_TABLE_CONFIG_VERSION = 2
 const DEFAULT_DATA_TABLE_CONFIG_EXCLUDED_COLUMN_IDS = ['actions', 'select'] as const
 const DATA_TABLE_CONFIG_PIN_SEPARATOR_ID = '__data-table-config-pin-separator__'
 
@@ -448,7 +448,35 @@ function normalizeColumnOrder(columnOrder: unknown, columnIds: string[]) {
   const orderedIdSet = new Set(orderedIds)
   const remainingIds = columnIds.filter((columnId) => !orderedIdSet.has(columnId))
 
-  return [...orderedIds, ...remainingIds]
+  return insertMissingColumnIds(orderedIds, remainingIds, columnIds)
+}
+
+function insertMissingColumnIds(orderedIds: string[], missingIds: string[], columnIds: string[]) {
+  const nextOrder = [...orderedIds]
+
+  for (const missingId of missingIds) {
+    const defaultIndex = columnIds.indexOf(missingId)
+    const previousColumnId = columnIds
+      .slice(0, defaultIndex)
+      .reverse()
+      .find((columnId) => nextOrder.includes(columnId))
+
+    if (previousColumnId) {
+      nextOrder.splice(nextOrder.indexOf(previousColumnId) + 1, 0, missingId)
+      continue
+    }
+
+    const nextColumnId = columnIds.slice(defaultIndex + 1).find((columnId) => nextOrder.includes(columnId))
+
+    if (nextColumnId) {
+      nextOrder.splice(nextOrder.indexOf(nextColumnId), 0, missingId)
+      continue
+    }
+
+    nextOrder.push(missingId)
+  }
+
+  return nextOrder
 }
 
 function normalizeColumnVisibility<TData>(columnVisibility: unknown, columns: Column<TData, unknown>[]) {

--- a/apps/dashboard/src/components/Invoices/index.tsx
+++ b/apps/dashboard/src/components/Invoices/index.tsx
@@ -5,7 +5,7 @@
 
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { flexRender } from '@tanstack/react-table'
 import { FileText } from 'lucide-react'
 import { Pagination } from '../Pagination'
@@ -68,13 +68,14 @@ export function InvoicesTable({
           ) : null
         }
       >
-        <Table className="table-fixed border-separate border-spacing-0" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed border-separate border-spacing-0" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
+                    header={header}
                     sticky={header.column.getIsPinned()}
                     style={getColumnSizeStyles(header.column)}
                   >

--- a/apps/dashboard/src/components/Invoices/useInvoicesTable.ts
+++ b/apps/dashboard/src/components/Invoices/useInvoicesTable.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { DEFAULT_TABLE_COLUMN } from '@/lib/utils/table'
 import { Invoice } from '@daytona/billing-api-client'
 import {
   ColumnFiltersState,
@@ -47,8 +48,8 @@ export function useInvoicesTable({
     },
   ])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: invoiceColumns,
     meta: {
@@ -84,6 +85,7 @@ export function useInvoicesTable({
       },
     },
     defaultColumn: {
+      ...DEFAULT_TABLE_COLUMN,
       size: 100,
     },
     getRowId: (row, index) => row.id ?? String(index),

--- a/apps/dashboard/src/components/OrganizationMembers/OrganizationInvitationTable.tsx
+++ b/apps/dashboard/src/components/OrganizationMembers/OrganizationInvitationTable.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/components/ui/table'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationInvitation, UpdateOrganizationInvitationRoleEnum } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -127,10 +127,11 @@ export function OrganizationInvitationTable({
         : undefined,
     [invitationToUpdate],
   )
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: organizationInvitationColumns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     meta: {
       organizationInvitation: {
         onCancel: handleCancel,
@@ -209,7 +210,7 @@ export function OrganizationInvitationTable({
             ) : null
           }
         >
-          <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+          <Table className="table-fixed" style={getTableSizeStyles(table)}>
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id}>
@@ -217,6 +218,7 @@ export function OrganizationInvitationTable({
                     return (
                       <TableHead
                         key={header.id}
+                        header={header}
                         sticky={header.column.getIsPinned()}
                         style={getColumnSizeStyles(header.column)}
                       >

--- a/apps/dashboard/src/components/OrganizationMembers/OrganizationMemberTable.tsx
+++ b/apps/dashboard/src/components/OrganizationMembers/OrganizationMemberTable.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/components/ui/table'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { capitalize, cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationUser, OrganizationUserRoleEnum } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -82,10 +82,11 @@ export function OrganizationMemberTable({
   const [isUpdateMemberAccessDialogOpen, setIsUpdateMemberAccessDialogOpen] = useState(false)
   const [memberToRemove, setMemberToRemove] = useState<string | null>(null)
   const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false)
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     meta: {
       member: {
         onUpdateMemberRole: (member) => {
@@ -217,13 +218,14 @@ export function OrganizationMemberTable({
             ) : null
           }
         >
-          <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+          <Table className="table-fixed" style={getTableSizeStyles(table)}>
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id}>
                   {headerGroup.headers.map((header) => (
                     <TableHead
                       key={header.id}
+                      header={header}
                       sticky={header.column.getIsPinned()}
                       style={getColumnSizeStyles(header.column)}
                     >

--- a/apps/dashboard/src/components/OrganizationRoles/OrganizationRoleTable.tsx
+++ b/apps/dashboard/src/components/OrganizationRoles/OrganizationRoleTable.tsx
@@ -24,7 +24,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationRole, OrganizationRolePermissionsEnum } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -82,10 +82,11 @@ export function OrganizationRoleTable({
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const [roleToUpdate, setRoleToUpdate] = useState<OrganizationRole | null>(null)
   const [isUpdateDialogOpen, setIsUpdateDialogOpen] = useState(false)
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: organizationRoleColumns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     meta: {
       organizationRole: {
         onUpdate: (role) => {
@@ -199,7 +200,7 @@ export function OrganizationRoleTable({
             ) : null
           }
         >
-          <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+          <Table className="table-fixed" style={getTableSizeStyles(table)}>
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id}>
@@ -207,6 +208,7 @@ export function OrganizationRoleTable({
                     return (
                       <TableHead
                         key={header.id}
+                        header={header}
                         sticky={header.column.getIsPinned()}
                         style={getColumnSizeStyles(header.column)}
                       >

--- a/apps/dashboard/src/components/RegionTable.tsx
+++ b/apps/dashboard/src/components/RegionTable.tsx
@@ -5,7 +5,7 @@
 
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { Region, RegionType } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -28,6 +28,7 @@ import { SearchInput } from './SearchInput'
 import { TimestampTooltip } from './TimestampTooltip'
 import { Button } from './ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './ui/dropdown-menu'
+import { MiddleTruncate } from './ui/middle-truncate'
 import { Skeleton } from './ui/skeleton'
 import {
   Table,
@@ -79,10 +80,11 @@ export function RegionTable({
 }: DataTableProps) {
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState('')
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: regionColumns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     meta: {
       region: {
         deletePermitted,
@@ -159,7 +161,7 @@ export function RegionTable({
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
@@ -168,6 +170,7 @@ export function RegionTable({
                     <TableHead
                       className="px-2"
                       key={header.id}
+                      header={header}
                       style={getColumnSizeStyles(header.column)}
                       sticky={header.column.getIsPinned()}
                     >
@@ -260,8 +263,8 @@ const regionColumns: ColumnDef<Region>[] = [
     size: 300,
     cell: ({ row }) => {
       return (
-        <div className="w-full truncate flex items-center gap-1 group/copy-button">
-          <span className="truncate block">{row.original.id}</span>
+        <div className="w-full min-w-0 flex items-center gap-1 group/copy-button">
+          <MiddleTruncate value={row.original.id} start={8} end={4} className="font-mono" />
           <CopyButton value={row.original.id} size="icon-xs" autoHide tooltipText="Copy ID" />
         </div>
       )

--- a/apps/dashboard/src/components/RegistryTable.tsx
+++ b/apps/dashboard/src/components/RegistryTable.tsx
@@ -6,7 +6,7 @@
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { DockerRegistry, OrganizationRolePermissionsEnum } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -86,14 +86,13 @@ export function RegistryTable({ data, loading, onDelete, onEdit }: DataTableProp
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState('')
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
     meta: {
       registry: { onDelete, onEdit, loading, writePermitted, deletePermitted },
     },
-    defaultColumn: {
-      minSize: 0,
-    },
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
@@ -174,13 +173,14 @@ export function RegistryTable({ data, loading, onDelete, onEdit }: DataTableProp
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
+                    header={header}
                     sticky={header.column.getIsPinned()}
                     style={getColumnSizeStyles(header.column)}
                   >

--- a/apps/dashboard/src/components/RunnerTable.tsx
+++ b/apps/dashboard/src/components/RunnerTable.tsx
@@ -5,7 +5,12 @@
 
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import {
+  DEFAULT_TABLE_COLUMN,
+  DEFAULT_TABLE_COLUMN_MIN_SIZE,
+  getColumnSizeStyles,
+  getTableSizeStyles,
+} from '@/lib/utils/table'
 import { Region, Runner, RunnerState } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -29,6 +34,7 @@ import { SearchInput } from './SearchInput'
 import { Badge, BadgeProps } from './ui/badge'
 import { Button } from './ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './ui/dropdown-menu'
+import { MiddleTruncate } from './ui/middle-truncate'
 import { Skeleton } from './ui/skeleton'
 import { Switch } from './ui/switch'
 import {
@@ -98,10 +104,11 @@ export function RunnerTable({
 }: RunnerTableProps) {
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState('')
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: runnerColumns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     meta: {
       runner: {
         deletePermitted,
@@ -211,7 +218,7 @@ export function RunnerTable({
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
@@ -220,6 +227,7 @@ export function RunnerTable({
                     <TableHead
                       className="px-2"
                       key={header.id}
+                      header={header}
                       style={getColumnSizeStyles(header.column)}
                       sticky={header.column.getIsPinned()}
                     >
@@ -331,8 +339,8 @@ const runnerColumns: ColumnDef<Runner>[] = [
     size: 240,
     cell: ({ row }) => {
       return (
-        <div className="w-full truncate flex items-center gap-1 group/copy-button">
-          <span className="truncate block text-sm">{row.original.id}</span>
+        <div className="w-full min-w-0 flex items-center gap-1 group/copy-button">
+          <MiddleTruncate value={row.original.id} start={8} end={4} className="font-mono text-sm" />
           <CopyButton value={row.original.id} size="icon-xs" autoHide tooltipText="Copy ID" />
         </div>
       )
@@ -365,7 +373,7 @@ const runnerColumns: ColumnDef<Runner>[] = [
   {
     accessorKey: 'unschedulable',
     header: 'Schedulable',
-    size: 60,
+    size: DEFAULT_TABLE_COLUMN_MIN_SIZE,
     cell: ({ row, table }) => {
       const { isLoadingRunner, onToggleEnabled, writePermitted } = getMeta(table)
       const isLoading = isLoadingRunner(row.original)

--- a/apps/dashboard/src/components/SandboxTable/SandboxTable.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTable.tsx
@@ -19,7 +19,7 @@ import {
   getBulkActionCounts,
   isTransitioning,
 } from '@/lib/utils/sandbox'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationRolePermissionsEnum, SandboxListItem, SandboxState } from '@daytona/api-client'
 import {
   flexRender,
@@ -145,8 +145,8 @@ export function SandboxTable({
   const selectableCount = useMemo(() => {
     return data.filter((sandbox) => !sandboxIsLoading[sandbox.id] && sandbox.state !== SandboxState.DESTROYED).length
   }, [sandboxIsLoading, data])
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: visibleColumns,
     manualFiltering: true,
@@ -172,9 +172,7 @@ export function SandboxTable({
       },
     },
     onColumnVisibilityChange: setColumnVisibility,
-    defaultColumn: {
-      minSize: 0,
-    },
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     enableRowSelection: (row) =>
       (writePermitted || deletePermitted) &&
       !sandboxIsLoading[row.original.id] &&
@@ -333,13 +331,14 @@ export function SandboxTable({
           ) : null
         }
       >
-        <Table style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
+                    header={header}
                     sticky={header.column.getIsPinned()}
                     style={getColumnSizeStyles(header.column)}
                   >

--- a/apps/dashboard/src/components/SandboxTable/SandboxTable.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTable.tsx
@@ -4,12 +4,10 @@
  */
 
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
-import { LocalStorageKey } from '@/enums/LocalStorageKey'
 import { RoutePath } from '@/enums/RoutePath'
 import { useAvailableSandboxClassesForOrganization } from '@/hooks/useAvailableSandboxClasses'
 import { useCommandPaletteAnalytics } from '@/hooks/useCommandPaletteAnalytics'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
-import { getLocalStorageItem, setLocalStorageItem } from '@/lib/local-storage'
 import { cn, getRegionFullDisplayName } from '@/lib/utils'
 import {
   filterArchivable,
@@ -22,16 +20,18 @@ import {
 import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationRolePermissionsEnum, SandboxListItem, SandboxState } from '@daytona/api-client'
 import {
+  type ColumnPinningState,
   flexRender,
   getCoreRowModel,
   getFacetedRowModel,
   getFacetedUniqueValues,
+  type OnChangeFn,
   useReactTable,
-  VisibilityState,
+  type VisibilityState,
 } from '@tanstack/react-table'
 import { Container } from 'lucide-react'
 import { AnimatePresence } from 'motion/react'
-import { useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react'
+import { useCallback, useImperativeHandle, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useCommandPaletteActions } from '../CommandPalette'
 import { SelectionToast } from '../SelectionToast'
@@ -58,6 +58,26 @@ import {
   convertTableSortingToApiSorting,
 } from './types'
 import { useSandboxCommands } from './useSandboxCommands'
+
+const DEFAULT_SANDBOX_TABLE_COLUMN_VISIBILITY: VisibilityState = {
+  id: false,
+  isPublic: false,
+  isRecoverable: false,
+  labels: false,
+}
+
+const DEFAULT_SANDBOX_TABLE_COLUMN_PINNING: ColumnPinningState = {
+  left: ['select', 'name'],
+  right: ['actions'],
+}
+
+function getSandboxTableColumnVisibility(columnVisibility: VisibilityState): VisibilityState {
+  return {
+    ...columnVisibility,
+    isPublic: false,
+    isRecoverable: false,
+  }
+}
 
 export function SandboxTable({
   ref,
@@ -103,21 +123,16 @@ export function SandboxTable({
   const writePermitted = authenticatedUserHasPermission(OrganizationRolePermissionsEnum.WRITE_SANDBOXES)
   const deletePermitted = authenticatedUserHasPermission(OrganizationRolePermissionsEnum.DELETE_SANDBOXES)
 
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(() => {
-    const saved = getLocalStorageItem(LocalStorageKey.SandboxTableColumnVisibility)
-    if (saved) {
-      try {
-        return JSON.parse(saved)
-      } catch {
-        return { id: false, labels: false }
-      }
-    }
-    return { id: false, labels: false }
-  })
+  const [columnOrder, setColumnOrder] = useState<string[]>([])
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(DEFAULT_SANDBOX_TABLE_COLUMN_VISIBILITY)
+  const [columnPinning, setColumnPinning] = useState<ColumnPinningState>(DEFAULT_SANDBOX_TABLE_COLUMN_PINNING)
+  const handleColumnVisibilityChange = useCallback<OnChangeFn<VisibilityState>>((updater) => {
+    setColumnVisibility((currentColumnVisibility) => {
+      const nextColumnVisibility = typeof updater === 'function' ? updater(currentColumnVisibility) : updater
 
-  useEffect(() => {
-    setLocalStorageItem(LocalStorageKey.SandboxTableColumnVisibility, JSON.stringify(columnVisibility))
-  }, [columnVisibility])
+      return getSandboxTableColumnVisibility(nextColumnVisibility)
+    })
+  }, [])
 
   const availableSandboxClasses = useAvailableSandboxClassesForOrganization()
   const visibleColumns = useMemo(() => {
@@ -162,16 +177,16 @@ export function SandboxTable({
     },
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
+    onColumnOrderChange: setColumnOrder,
+    onColumnPinningChange: setColumnPinning,
     state: {
       sorting: tableSorting,
       columnFilters: tableFilters,
+      columnOrder,
       columnVisibility,
-      columnPinning: {
-        left: ['select', 'name'],
-        right: ['actions'],
-      },
+      columnPinning,
     },
-    onColumnVisibilityChange: setColumnVisibility,
+    onColumnVisibilityChange: handleColumnVisibilityChange,
     defaultColumn: DEFAULT_TABLE_COLUMN,
     enableRowSelection: (row) =>
       (writePermitted || deletePermitted) &&

--- a/apps/dashboard/src/components/SandboxTable/SandboxTable.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTable.tsx
@@ -5,7 +5,6 @@
 
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { RoutePath } from '@/enums/RoutePath'
-import { useAvailableSandboxClassesForOrganization } from '@/hooks/useAvailableSandboxClasses'
 import { useCommandPaletteAnalytics } from '@/hooks/useCommandPaletteAnalytics'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { cn, getRegionFullDisplayName } from '@/lib/utils'
@@ -64,6 +63,7 @@ const DEFAULT_SANDBOX_TABLE_COLUMN_VISIBILITY: VisibilityState = {
   isPublic: false,
   isRecoverable: false,
   labels: false,
+  sandboxClass: false,
 }
 
 const DEFAULT_SANDBOX_TABLE_COLUMN_PINNING: ColumnPinningState = {
@@ -134,21 +134,8 @@ export function SandboxTable({
     })
   }, [])
 
-  const availableSandboxClasses = useAvailableSandboxClassesForOrganization()
-  const visibleColumns = useMemo(() => {
-    if (availableSandboxClasses.length > 1) {
-      return columns
-    }
-    return columns.filter((column) => column.id !== 'sandboxClass')
-  }, [availableSandboxClasses])
-
   const tableSorting = useMemo(() => convertApiSortingToTableSorting(sorting), [sorting])
-  const tableFilters = useMemo(() => {
-    const visibleColumnIds = new Set(
-      visibleColumns.map((column) => column.id).filter((id): id is string => Boolean(id)),
-    )
-    return convertApiFiltersToTableFilters(filters).filter((filter) => visibleColumnIds.has(filter.id))
-  }, [filters, visibleColumns])
+  const tableFilters = useMemo(() => convertApiFiltersToTableFilters(filters), [filters])
 
   const regionOptions: FacetedFilterOption[] = useMemo(() => {
     return regionsData.map((region) => ({
@@ -163,7 +150,7 @@ export function SandboxTable({
   const table = useReactTable({
     columnResizeMode: 'onEnd',
     data,
-    columns: visibleColumns,
+    columns,
     manualFiltering: true,
     onColumnFiltersChange: (updater) => {
       const newTableFilters = typeof updater === 'function' ? updater(table.getState().columnFilters) : updater
@@ -309,7 +296,7 @@ export function SandboxTable({
           isEmpty ? (
             <TableEmptyState
               overlay
-              colSpan={table.getAllColumns().length}
+              colSpan={table.getVisibleLeafColumns().length}
               message={hasFilters ? 'No matching sandboxes found.' : 'No Sandboxes yet.'}
               icon={<Container />}
               description={

--- a/apps/dashboard/src/components/SandboxTable/SandboxTableHeader.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTableHeader.tsx
@@ -8,7 +8,6 @@ import {
   Calendar,
   CalendarPlus,
   Camera,
-  Columns,
   Cpu,
   Eye,
   Globe,
@@ -20,23 +19,20 @@ import {
   Tag,
   Wrench,
 } from 'lucide-react'
+import { DataTableConfigMenu } from '@/components/DataTableConfigMenu'
 import { cn } from '@/lib/utils'
 import { SearchInput } from '../SearchInput'
 import TooltipButton from '../TooltipButton'
 import { Button } from '../ui/button'
 import {
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuLabel,
   DropdownMenuPortal,
-  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu'
-import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { BooleanFilter, BooleanFilterIndicator } from './filters/BooleanFilter'
 import { CreatedAtFilter, CreatedAtFilterIndicator } from './filters/CreatedAtFilter'
 import { LabelFilter, LabelFilterIndicator } from './filters/LabelFilter'
@@ -55,10 +51,12 @@ const RESOURCE_FILTERS = [
 ]
 
 const SANDBOX_TABLE_COLUMN_LABELS: Record<string, string> = {
+  actions: 'Actions',
+  select: 'Selection',
   name: 'Name',
   id: 'UUID',
   state: 'State',
-  class: 'Class',
+  sandboxClass: 'Class',
   snapshot: 'Snapshot',
   region: 'Region',
   resources: 'Resources',
@@ -66,6 +64,8 @@ const SANDBOX_TABLE_COLUMN_LABELS: Record<string, string> = {
   lastEvent: 'Last Event',
   createdAt: 'Created At',
 }
+
+const SANDBOX_TABLE_CONFIG_EXCLUDED_COLUMN_IDS = ['actions', 'select', 'isPublic', 'isRecoverable'] as const
 
 export function SandboxTableHeader({
   table,
@@ -293,7 +293,12 @@ export function SandboxTableHeader({
           >
             <RefreshCw className={cn('w-4 h-4', { 'animate-spin': isRefreshing })} />
           </TooltipButton>
-          <SandboxTableSettings table={table} />
+          <DataTableConfigMenu
+            table={table}
+            persistenceKey="sandboxes"
+            excludedColumnIds={SANDBOX_TABLE_CONFIG_EXCLUDED_COLUMN_IDS}
+            getColumnLabel={(columnId) => SANDBOX_TABLE_COLUMN_LABELS[columnId] ?? columnId}
+          />
         </div>
       </div>
 
@@ -375,42 +380,5 @@ export function SandboxTableHeader({
         </div>
       ) : null}
     </div>
-  )
-}
-
-function SandboxTableSettings({ table }: Pick<SandboxTableHeaderProps, 'table'>) {
-  const hideableColumns = table.getAllLeafColumns().filter((column) => column.getCanHide())
-
-  if (hideableColumns.length === 0) {
-    return null
-  }
-
-  return (
-    <DropdownMenu modal={false}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="icon-sm" aria-label="Table settings">
-              <Columns className="size-4" />
-            </Button>
-          </DropdownMenuTrigger>
-        </TooltipTrigger>
-        <TooltipContent>Table settings</TooltipContent>
-      </Tooltip>
-      <DropdownMenuContent align="end" className="w-48">
-        <DropdownMenuLabel>Columns</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        {hideableColumns.map((column) => (
-          <DropdownMenuCheckboxItem
-            key={column.id}
-            checked={column.getIsVisible()}
-            onCheckedChange={(checked) => column.toggleVisibility(checked === true)}
-            onSelect={(event) => event.preventDefault()}
-          >
-            {SANDBOX_TABLE_COLUMN_LABELS[column.id] ?? column.id}
-          </DropdownMenuCheckboxItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
   )
 }

--- a/apps/dashboard/src/components/SandboxTable/SandboxTableHeader.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTableHeader.tsx
@@ -20,6 +20,7 @@ import {
   Wrench,
 } from 'lucide-react'
 import { DataTableConfigMenu } from '@/components/DataTableConfigMenu'
+import { useAvailableSandboxClassesForOrganization } from '@/hooks/useAvailableSandboxClasses'
 import { cn } from '@/lib/utils'
 import { SearchInput } from '../SearchInput'
 import TooltipButton from '../TooltipButton'
@@ -78,8 +79,9 @@ export function SandboxTableHeader({
   onRefresh,
   isRefreshing = false,
 }: SandboxTableHeaderProps) {
-  const sandboxClassColumn = table.getAllLeafColumns().find((column) => column.id === 'sandboxClass')
-  const classColumnAvailable = Boolean(sandboxClassColumn)
+  const availableSandboxClasses = useAvailableSandboxClassesForOrganization()
+  const sandboxClassColumn = table.getColumn('sandboxClass')
+  const showClassFilter = availableSandboxClasses.length > 1 && Boolean(sandboxClassColumn)
   const hasStateFilter = ((table.getColumn('state')?.getFilterValue() as string[]) || []).length > 0
   const hasClassFilter = ((sandboxClassColumn?.getFilterValue() as string[]) || []).length > 0
   const hasSnapshotFilter = ((table.getColumn('snapshot')?.getFilterValue() as string[]) || []).length > 0
@@ -139,7 +141,7 @@ export function SandboxTableHeader({
                   </DropdownMenuSubContent>
                 </DropdownMenuPortal>
               </DropdownMenuSub>
-              {classColumnAvailable && (
+              {showClassFilter && (
                 <DropdownMenuSub>
                   <DropdownMenuSubTrigger>
                     <Boxes className="w-4 h-4" />
@@ -320,7 +322,7 @@ export function SandboxTableHeader({
               onChangeSnapshotSearchValue={onChangeSnapshotSearchValue}
             />
           )}
-          {classColumnAvailable && hasClassFilter && (
+          {hasClassFilter && (
             <SandboxClassFilterIndicator
               value={(sandboxClassColumn?.getFilterValue() as string[]) || []}
               onFilterChange={(value) => sandboxClassColumn?.setFilterValue(value)}

--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -11,8 +11,10 @@ import { TimestampTooltip } from '@/components/TimestampTooltip'
 import { SandboxState as SandboxStateComponent } from '@/components/sandboxes/SandboxState'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
+import { MiddleTruncate } from '@/components/ui/middle-truncate'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { getRelativeTimeString, truncateUUID } from '@/lib/utils'
+import { getRelativeTimeString } from '@/lib/utils'
+import { getTableColumnMaxResizeSize } from '@/lib/utils/table'
 import { SandboxDesiredState, SandboxListItem } from '@daytona/api-client'
 import { Column, ColumnDef, RowData, Table } from '@tanstack/react-table'
 import { Loader2 } from 'lucide-react'
@@ -169,8 +171,9 @@ const columns: ColumnDef<SandboxListItem>[] = [
   },
   {
     id: 'id',
-    size: 150,
-    maxSize: 150,
+    size: 240,
+    minSize: 150,
+    maxSize: getTableColumnMaxResizeSize(360),
     enableSorting: false,
     enableHiding: true,
     header: () => <span>UUID</span>,
@@ -178,8 +181,8 @@ const columns: ColumnDef<SandboxListItem>[] = [
     cell: ({ row }) => {
       const id = row.original.id
       return (
-        <div className="w-full truncate flex items-center gap-1 group/copy-button">
-          <span className="truncate block text-muted-foreground">{truncateUUID(id)}</span>
+        <div className="w-full min-w-0 flex items-center gap-1 group/copy-button">
+          <MiddleTruncate value={id} start={8} end={4} className="font-mono text-muted-foreground" />
           <CopyButton value={id} size="icon-xs" autoHide tooltipText="Copy UUID" />
         </div>
       )
@@ -190,7 +193,7 @@ const columns: ColumnDef<SandboxListItem>[] = [
     size: 110,
     minSize: 110,
     enableSorting: false,
-    enableHiding: false,
+    enableHiding: true,
     header: () => <span>State</span>,
     cell: ({ row }) => (
       <SandboxStateCell
@@ -204,9 +207,10 @@ const columns: ColumnDef<SandboxListItem>[] = [
   {
     id: 'sandboxClass',
     size: 64,
+    minSize: 64,
     maxSize: 64,
     enableSorting: false,
-    enableHiding: false,
+    enableHiding: true,
     header: () => <span>Class</span>,
     cell: ({ row }) => {
       const sandboxClass = row.original.sandboxClass
@@ -229,7 +233,7 @@ const columns: ColumnDef<SandboxListItem>[] = [
     id: 'snapshot',
     size: 150,
     enableSorting: false,
-    enableHiding: false,
+    enableHiding: true,
     header: () => <span>Snapshot</span>,
     cell: ({ row }) => (
       <div className="w-full truncate">
@@ -246,7 +250,7 @@ const columns: ColumnDef<SandboxListItem>[] = [
     id: 'region',
     size: 120,
     enableSorting: false,
-    enableHiding: false,
+    enableHiding: true,
     header: () => <span>Region</span>,
     cell: ({ row, table }) => {
       const { getRegionName } = getMeta(table)
@@ -262,7 +266,7 @@ const columns: ColumnDef<SandboxListItem>[] = [
     id: 'resources',
     size: 190,
     enableSorting: false,
-    enableHiding: false,
+    enableHiding: true,
     header: () => <span>Resources</span>,
     cell: ({ row }) => (
       <div className="flex w-full items-center gap-2 truncate">
@@ -291,7 +295,7 @@ const columns: ColumnDef<SandboxListItem>[] = [
   {
     id: 'labels',
     size: 120,
-    maxSize: 120,
+    maxSize: getTableColumnMaxResizeSize(120),
     enableSorting: false,
     enableHiding: true,
     header: () => <span>Labels</span>,
@@ -322,9 +326,9 @@ const columns: ColumnDef<SandboxListItem>[] = [
   {
     id: 'lastEvent',
     size: 140,
-    maxSize: 140,
+    maxSize: getTableColumnMaxResizeSize(140),
     enableSorting: true,
-    enableHiding: false,
+    enableHiding: true,
     header: ({ column }) => <SortableHeader column={column} label="Last Event" />,
     accessorFn: (row) => getLastEvent(row).date,
     cell: ({ row }) => {
@@ -341,9 +345,9 @@ const columns: ColumnDef<SandboxListItem>[] = [
   {
     id: 'createdAt',
     size: 180,
-    maxSize: 180,
+    maxSize: getTableColumnMaxResizeSize(180),
     enableSorting: true,
-    enableHiding: false,
+    enableHiding: true,
     header: ({ column }) => <SortableHeader column={column} label="Created" />,
     accessorFn: (row) => (row.createdAt ? new Date(row.createdAt) : new Date()),
     cell: ({ row }) => {

--- a/apps/dashboard/src/components/UserOrganizationInvitations/UserOrganizationInvitationTable.tsx
+++ b/apps/dashboard/src/components/UserOrganizationInvitations/UserOrganizationInvitationTable.tsx
@@ -22,7 +22,7 @@ import {
 import { DeclineOrganizationInvitationDialog } from '@/components/UserOrganizationInvitations/DeclineOrganizationInvitationDialog'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn, getRelativeTimeString } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationInvitation } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -90,10 +90,11 @@ export function UserOrganizationInvitationTable({
     }
     return false
   }
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns: userOrganizationInvitationColumns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     meta: {
       userOrganizationInvitation: {
         onAccept: onAcceptInvitation,
@@ -172,7 +173,7 @@ export function UserOrganizationInvitationTable({
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
@@ -180,6 +181,7 @@ export function UserOrganizationInvitationTable({
                   return (
                     <TableHead
                       key={header.id}
+                      header={header}
                       sticky={header.column.getIsPinned()}
                       style={getColumnSizeStyles(header.column)}
                     >

--- a/apps/dashboard/src/components/VolumeTable.tsx
+++ b/apps/dashboard/src/components/VolumeTable.tsx
@@ -15,6 +15,7 @@ import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { DataTableFacetedFilter, FacetedFilterOption } from '@/components/ui/data-table-faceted-filter'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { MiddleTruncate } from '@/components/ui/middle-truncate'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
@@ -29,8 +30,13 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
-import { cn, getRelativeTimeString, truncateUUID } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { cn, getRelativeTimeString } from '@/lib/utils'
+import {
+  DEFAULT_TABLE_COLUMN,
+  getColumnSizeStyles,
+  getTableColumnMaxResizeSize,
+  getTableSizeStyles,
+} from '@/lib/utils/table'
 import { OrganizationRolePermissionsEnum, VolumeDto, VolumeState } from '@daytona/api-client'
 import {
   ColumnDef,
@@ -100,16 +106,14 @@ export function VolumeTable({
 
   const [sorting, setSorting] = useState<SortingState>([])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
     meta: {
       volume: { onDelete, processingVolumeAction, deletePermitted },
     },
-    defaultColumn: {
-      minSize: 0,
-    },
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
@@ -250,13 +254,14 @@ export function VolumeTable({
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
+                    header={header}
                     sticky={header.column.getIsPinned()}
                     style={getColumnSizeStyles(header.column)}
                   >
@@ -440,15 +445,15 @@ const columns: ColumnDef<VolumeDto>[] = [
   {
     accessorKey: 'id',
     size: 180,
-    maxSize: 180,
+    maxSize: getTableColumnMaxResizeSize(180),
     header: 'ID',
     enableSorting: false,
     cell: ({ row }) => {
       const id = row.original.id
 
       return (
-        <div className="w-full truncate flex items-center gap-1 group/copy-button">
-          <span className="truncate block text-muted-foreground">{truncateUUID(id)}</span>
+        <div className="w-full min-w-0 flex items-center gap-1 group/copy-button">
+          <MiddleTruncate value={id} start={8} end={4} className="font-mono text-muted-foreground" />
           <CopyButton value={id} size="icon-xs" autoHide tooltipText="Copy ID" />
         </div>
       )

--- a/apps/dashboard/src/components/Webhooks/EndpointEventsTable/EndpointEventsTable.tsx
+++ b/apps/dashboard/src/components/Webhooks/EndpointEventsTable/EndpointEventsTable.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/components/ui/table'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import {
   ColumnFiltersState,
   flexRender,
@@ -52,10 +52,11 @@ export function EndpointEventsTable({ data, loading, onReplay }: EndpointEventsT
   const [globalFilter, setGlobalFilter] = useState('')
   const [selectedEventIndex, setSelectedEventIndex] = useState<number | null>(null)
   const [sheetOpen, setSheetOpen] = useState(false)
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
@@ -164,7 +165,7 @@ export function EndpointEventsTable({ data, loading, onReplay }: EndpointEventsT
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
@@ -173,6 +174,7 @@ export function EndpointEventsTable({ data, loading, onReplay }: EndpointEventsT
                     <TableHead
                       className="px-2"
                       key={header.id}
+                      header={header}
                       style={getColumnSizeStyles(header.column)}
                       sticky={header.column.getIsPinned()}
                     >

--- a/apps/dashboard/src/components/Webhooks/EndpointEventsTable/columns.tsx
+++ b/apps/dashboard/src/components/Webhooks/EndpointEventsTable/columns.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { FacetedFilterOption } from '@/components/ui/data-table-faceted-filter'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { MiddleTruncate } from '@/components/ui/middle-truncate'
 import { WEBHOOK_EVENTS } from '@/constants/webhook-events'
 import { getRelativeTimeString } from '@/lib/utils'
 import { ColumnDef, RowData, Table } from '@tanstack/react-table'
@@ -37,10 +38,13 @@ const columns: ColumnDef<EndpointMessageOut>[] = [
     cell: ({ row }) => {
       const msgId = row.original.id
       return (
-        <div className="w-full truncate flex items-center gap-2 group/copy-button">
-          <span className="truncate block font-mono text-sm hover:underline focus:underline cursor-pointer">
-            {msgId ?? '-'}
-          </span>
+        <div className="w-full min-w-0 flex items-center gap-2 group/copy-button">
+          <MiddleTruncate
+            value={msgId ?? '-'}
+            start={8}
+            end={4}
+            className="font-mono text-sm hover:underline focus:underline cursor-pointer"
+          />
           {msgId && (
             <span onClick={(e) => e.stopPropagation()}>
               <CopyButton value={msgId} size="icon-xs" autoHide tooltipText="Copy Message ID" />

--- a/apps/dashboard/src/components/Webhooks/WebhooksEndpointTable/WebhooksEndpointTable.tsx
+++ b/apps/dashboard/src/components/Webhooks/WebhooksEndpointTable/WebhooksEndpointTable.tsx
@@ -31,7 +31,7 @@ import {
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { RoutePath } from '@/enums/RoutePath'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import {
   flexRender,
   getCoreRowModel,
@@ -81,10 +81,11 @@ export function WebhooksEndpointTable({
       setDisableEndpoint(null)
     }
   }
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
@@ -184,7 +185,7 @@ export function WebhooksEndpointTable({
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
@@ -193,6 +194,7 @@ export function WebhooksEndpointTable({
                     <TableHead
                       className="px-2"
                       key={header.id}
+                      header={header}
                       style={getColumnSizeStyles(header.column)}
                       sticky={header.column.getIsPinned()}
                     >

--- a/apps/dashboard/src/components/Webhooks/WebhooksMessagesTable/WebhooksMessagesTable.tsx
+++ b/apps/dashboard/src/components/Webhooks/WebhooksMessagesTable/WebhooksMessagesTable.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/components/ui/table'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import {
   ColumnFiltersState,
   flexRender,
@@ -49,10 +49,11 @@ export function WebhooksMessagesTable() {
   const [sheetOpen, setSheetOpen] = useState(false)
 
   const data = messages.data ?? []
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
@@ -161,12 +162,17 @@ export function WebhooksMessagesTable() {
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
-                  <TableHead className="px-2" key={header.id} style={getColumnSizeStyles(header.column)}>
+                  <TableHead
+                    className="px-2"
+                    key={header.id}
+                    header={header}
+                    style={getColumnSizeStyles(header.column)}
+                  >
                     {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
                   </TableHead>
                 ))}

--- a/apps/dashboard/src/components/Webhooks/WebhooksMessagesTable/columns.tsx
+++ b/apps/dashboard/src/components/Webhooks/WebhooksMessagesTable/columns.tsx
@@ -6,6 +6,7 @@
 import { TimestampTooltip } from '@/components/TimestampTooltip'
 import { Badge } from '@/components/ui/badge'
 import { FacetedFilterOption } from '@/components/ui/data-table-faceted-filter'
+import { MiddleTruncate } from '@/components/ui/middle-truncate'
 import { WEBHOOK_EVENTS } from '@/constants/webhook-events'
 import { getRelativeTimeString } from '@/lib/utils'
 import { ColumnDef } from '@tanstack/react-table'
@@ -20,10 +21,13 @@ const columns: ColumnDef<MessageOut>[] = [
     cell: ({ row }) => {
       const msgId = row.original.id
       return (
-        <div className="w-full truncate flex items-center gap-2 group/copy-button">
-          <span className="truncate block font-mono text-sm hover:underline focus:underline cursor-pointer">
-            {msgId ?? '-'}
-          </span>
+        <div className="w-full min-w-0 flex items-center gap-2 group/copy-button">
+          <MiddleTruncate
+            value={msgId ?? '-'}
+            start={8}
+            end={4}
+            className="font-mono text-sm hover:underline focus:underline cursor-pointer"
+          />
           {msgId && (
             <span onClick={(e) => e.stopPropagation()}>
               <CopyButton value={msgId} size="icon-xs" autoHide tooltipText="Copy Message ID" />

--- a/apps/dashboard/src/components/snapshots/SnapshotTable/SnapshotTable.tsx
+++ b/apps/dashboard/src/components/snapshots/SnapshotTable/SnapshotTable.tsx
@@ -16,7 +16,7 @@ import { SnapshotSorting } from '@/hooks/queries/useSnapshotsQuery'
 import { useCommandPaletteAnalytics } from '@/hooks/useCommandPaletteAnalytics'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { cn } from '@/lib/utils'
-import { getColumnSizeStyles } from '@/lib/utils/table'
+import { DEFAULT_TABLE_COLUMN, getColumnSizeStyles, getTableSizeStyles } from '@/lib/utils/table'
 import { OrganizationRolePermissionsEnum, SnapshotDto, SnapshotState } from '@daytona/api-client'
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { Box } from 'lucide-react'
@@ -157,13 +157,11 @@ export function SnapshotTable({
       (snapshot) => !snapshot.general && !loadingSnapshots[snapshot.id] && snapshot.state !== SnapshotState.REMOVING,
     ).length
   }, [data, loadingSnapshots])
-
   const table = useReactTable({
+    columnResizeMode: 'onEnd',
     data,
     columns,
-    defaultColumn: {
-      minSize: 0,
-    },
+    defaultColumn: DEFAULT_TABLE_COLUMN,
     getCoreRowModel: getCoreRowModel(),
     initialState: {
       columnPinning: {
@@ -348,13 +346,14 @@ export function SnapshotTable({
           ) : null
         }
       >
-        <Table className="table-fixed" style={{ minWidth: table.getTotalSize() }}>
+        <Table className="table-fixed" style={getTableSizeStyles(table)}>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
+                    header={header}
                     sticky={header.column.getIsPinned()}
                     style={getColumnSizeStyles(header.column)}
                   >

--- a/apps/dashboard/src/components/snapshots/SnapshotTable/columns.tsx
+++ b/apps/dashboard/src/components/snapshots/SnapshotTable/columns.tsx
@@ -6,6 +6,7 @@
 import { CopyButton } from '@/components/CopyButton'
 import { TimestampTooltip } from '@/components/TimestampTooltip'
 import { getRelativeTimeString } from '@/lib/utils'
+import { getTableColumnMaxResizeSize } from '@/lib/utils/table'
 import { SnapshotDto, SnapshotState } from '@daytona/api-client'
 import { ColumnDef, RowData, Table } from '@tanstack/react-table'
 import { Loader2, MoreHorizontal } from 'lucide-react'
@@ -159,6 +160,7 @@ const columns: ColumnDef<SnapshotDto>[] = [
   {
     accessorKey: 'imageName',
     size: 180,
+    minSize: 180,
     enableSorting: false,
     header: 'Image',
     cell: ({ row }) => {
@@ -192,7 +194,7 @@ const columns: ColumnDef<SnapshotDto>[] = [
   {
     accessorKey: 'regionIds',
     size: 140,
-    maxSize: 140,
+    maxSize: getTableColumnMaxResizeSize(140),
     enableSorting: false,
     header: 'Region',
     cell: ({ row, table }) => {
@@ -271,7 +273,7 @@ const columns: ColumnDef<SnapshotDto>[] = [
   {
     accessorKey: 'state',
     size: 120,
-    maxSize: 120,
+    maxSize: getTableColumnMaxResizeSize(120),
     enableSorting: true,
     header: ({ column }) => <SortableHeader column={column} label="State" />,
     cell: ({ row }) => {
@@ -300,7 +302,7 @@ const columns: ColumnDef<SnapshotDto>[] = [
   {
     accessorKey: 'createdAt',
     size: 120,
-    maxSize: 120,
+    maxSize: getTableColumnMaxResizeSize(120),
     enableSorting: true,
     header: ({ column }) => <SortableHeader column={column} label="Created" />,
     cell: ({ row }) => {
@@ -319,7 +321,7 @@ const columns: ColumnDef<SnapshotDto>[] = [
   {
     accessorKey: 'lastUsedAt',
     size: 120,
-    maxSize: 120,
+    maxSize: getTableColumnMaxResizeSize(120),
     enableSorting: true,
     header: ({ column }) => <SortableHeader column={column} label="Last Used" />,
     cell: ({ row }) => {

--- a/apps/dashboard/src/components/ui/middle-truncate.tsx
+++ b/apps/dashboard/src/components/ui/middle-truncate.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Daytona Platforms Inc.
+ * Copyright Daytona Platforms Inc.
  * SPDX-License-Identifier: AGPL-3.0
  */
 

--- a/apps/dashboard/src/components/ui/middle-truncate.tsx
+++ b/apps/dashboard/src/components/ui/middle-truncate.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { cn } from '@/lib/utils'
+
+type MiddleTruncateProps = Omit<React.ComponentProps<'span'>, 'children'> & {
+  end?: number
+  start?: number
+  value?: string | null
+}
+
+function MiddleTruncate({ className, end = 4, start = 8, title, value, ...props }: MiddleTruncateProps) {
+  const text = value ?? ''
+  const startLength = Math.max(0, Math.floor(start))
+  const endLength = Math.max(0, Math.floor(end))
+  const shouldSplit = text.length > startLength + endLength && startLength + endLength > 0
+
+  const startText = shouldSplit ? text.slice(0, startLength) : text
+  const middleText = shouldSplit ? text.slice(startLength, text.length - endLength) : ''
+  const endText = shouldSplit && endLength > 0 ? text.slice(-endLength) : ''
+
+  return (
+    <span
+      className={cn('inline-flex min-w-0 max-w-full overflow-hidden whitespace-nowrap align-bottom', className)}
+      data-slot="middle-truncate"
+      title={title ?? text}
+      {...props}
+    >
+      <span className="shrink-0">{startText}</span>
+      {middleText ? <span className="min-w-0 flex-1 overflow-hidden text-ellipsis">{middleText}</span> : null}
+      {endText ? <span className="shrink-0">{endText}</span> : null}
+    </span>
+  )
+}
+
+export { MiddleTruncate }

--- a/apps/dashboard/src/components/ui/table.css
+++ b/apps/dashboard/src/components/ui/table.css
@@ -1,4 +1,91 @@
 @media (min-width: 768px) {
+  [data-slot='table-head'][data-resizable='true'] {
+    overflow: visible;
+  }
+
+  [data-slot='table-column-resize-handle'] {
+    position: absolute;
+    inset-block: 0;
+    inset-inline-end: -8px;
+    z-index: 20;
+    display: flex;
+    width: 16px;
+    cursor: col-resize;
+    touch-action: none;
+    user-select: none;
+    justify-content: center;
+    outline: none;
+  }
+
+  [data-slot='table-column-resize-handle']::before {
+    content: '';
+    width: 1px;
+    background: transparent;
+    transition:
+      background-color 0.15s ease,
+      opacity 0.15s ease;
+  }
+
+  [data-slot='table-column-resize-handle']::after {
+    content: '';
+    position: absolute;
+    inset-block: 0;
+    inset-inline: -8px;
+  }
+
+  [data-slot='table-head'][data-resizable='true']:hover > [data-slot='table-column-resize-handle']::before {
+    background: var(--muted-foreground);
+    opacity: 0.45;
+  }
+
+  [data-slot='table-column-resize-handle'][data-resizing='true']::before,
+  [data-slot='table-column-resize-handle']:focus-visible::before {
+    background: var(--primary);
+    opacity: 1;
+  }
+
+  [data-slot='table-column-resize-handle']:focus-visible {
+    border-radius: 2px;
+    box-shadow: 0 0 0 2px color-mix(in oklch, var(--ring) 45%, transparent);
+  }
+
+  [data-slot='table-column-resize-indicator'] {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 30;
+    height: var(--table-column-resize-indicator-height, 100%);
+    width: 0;
+    opacity: 0;
+    pointer-events: none;
+    transform: translate3d(-9999px, 0, 0);
+    will-change: transform;
+  }
+
+  [data-column-resizing='true'] > [data-slot='table-column-resize-indicator'] {
+    opacity: 1;
+  }
+
+  [data-column-resize-releasing='true'] > [data-slot='table-column-resize-indicator'] {
+    transition: transform 150ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  [data-slot='table-column-resize-indicator']::before {
+    content: '';
+    position: absolute;
+    inset-block: 0;
+    width: 1px;
+    background: var(--primary);
+    box-shadow: 0 0 0 1px color-mix(in oklch, var(--primary) 20%, transparent);
+    transform: translateX(-0.5px);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [data-column-resize-releasing='true'] > [data-slot='table-column-resize-indicator'] {
+      transition: none;
+    }
+  }
+
   [data-sticky-state='left'] {
     box-shadow: 6px 0 8px -2px rgba(0, 0, 0, 0);
     transition: box-shadow 0.2s ease;
@@ -31,6 +118,11 @@
 }
 
 @media (max-width: 767px) {
+  [data-slot='table-column-resize-handle'],
+  [data-slot='table-column-resize-indicator'] {
+    display: none;
+  }
+
   [data-slot='table-head'][data-sticky-state],
   [data-slot='table-cell'][data-sticky-state] {
     position: static !important;

--- a/apps/dashboard/src/components/ui/table.tsx
+++ b/apps/dashboard/src/components/ui/table.tsx
@@ -6,6 +6,8 @@
 import * as React from 'react'
 
 import { cn } from '@/lib/utils'
+import { getColumnResizeSizeBounds } from '@/lib/utils/table'
+import type { Header } from '@tanstack/react-table'
 import { useEffect, useRef } from 'react'
 import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from './empty'
 import './table.css'
@@ -61,12 +63,11 @@ function useScrollStateRef() {
   return containerRef
 }
 
-function TableContainer({
-  className,
-  children,
-  empty,
-  ...props
-}: React.ComponentProps<'div'> & { empty?: React.ReactNode }) {
+type TableContainerProps = React.ComponentProps<'div'> & {
+  empty?: React.ReactNode
+}
+
+function TableContainer({ className, children, empty, ...props }: TableContainerProps) {
   const containerRef = useScrollStateRef()
 
   return (
@@ -80,6 +81,7 @@ function TableContainer({
       {...props}
     >
       {children}
+      <div aria-hidden="true" data-slot="table-column-resize-indicator" />
       {empty}
     </div>
   )
@@ -141,17 +143,336 @@ function getStickySide(sticky?: StickyState) {
   return sticky === 'left' || sticky === 'right' ? sticky : undefined
 }
 
-function TableHead({ className, style, sticky, ...props }: React.ComponentProps<'th'> & { sticky?: StickyState }) {
+function getHeaderResizeLabel<TData>(header: Header<TData, unknown>) {
+  const columnHeader = header.column.columnDef.header
+
+  return typeof columnHeader === 'string' ? columnHeader : header.column.id
+}
+
+function getHeaderResizeBounds<TData>(header: Header<TData, unknown>) {
+  return getColumnResizeSizeBounds(header.column, header.getContext().table.options.defaultColumn)
+}
+
+function getHeaderCanResize<TData>(header?: Header<TData, unknown>) {
+  if (!header || header.isPlaceholder || !header.column.getCanResize()) return false
+
+  const { minSize, maxSize } = getHeaderResizeBounds(header)
+
+  return minSize < maxSize
+}
+
+type ColumnResizePreviewState = {
+  directionMultiplier: 1 | -1
+  initialSize: number
+  initialX: number
+  maxSize: number
+  minSize: number
+}
+
+type ColumnResizePreviewPosition = {
+  boundaryX: number
+  isPastBounds: boolean
+  size: number
+  x: number
+}
+
+const COLUMN_RESIZE_LIMIT_RELEASE_MS = 150
+const COLUMN_RESIZE_FALLOFF_DISTANCE = 24
+const COLUMN_RESIZE_FALLOFF_STIFFNESS = 3
+const columnResizeReleaseTimeouts = new WeakMap<HTMLElement, number>()
+
+function clearColumnResizeRelease(container: HTMLElement) {
+  const timeout = columnResizeReleaseTimeouts.get(container)
+
+  if (timeout) {
+    window.clearTimeout(timeout)
+    columnResizeReleaseTimeouts.delete(container)
+  }
+
+  delete container.dataset.columnResizeReleasing
+}
+
+function getColumnResizeAriaValueText(size: number) {
+  return `${Math.round(size)} pixels`
+}
+
+function resetColumnResizeIndicator(indicator: HTMLElement) {
+  indicator.style.transform = ''
+  indicator.style.removeProperty('--table-column-resize-indicator-height')
+}
+
+function getColumnResizePointerPosition(container: HTMLElement, clientX: number) {
+  const rect = container.getBoundingClientRect()
+
+  return clientX - rect.left - container.clientLeft + container.scrollLeft
+}
+
+function clampColumnResizeSize(size: number, minSize: number, maxSize: number) {
+  return Math.min(Math.max(size, minSize), maxSize)
+}
+
+function applyColumnResizeFalloff(size: number, minSize: number, maxSize: number, distance: number, stiffness: number) {
+  if (size < minSize) {
+    const overshoot = minSize - size
+    return minSize - (distance * overshoot) / (overshoot + distance * stiffness)
+  }
+
+  if (size > maxSize) {
+    const overshoot = size - maxSize
+    return maxSize + (distance * overshoot) / (overshoot + distance * stiffness)
+  }
+
+  return size
+}
+
+function getColumnResizePreviewPosition(
+  container: HTMLElement,
+  clientX: number,
+  { directionMultiplier, initialSize, initialX, maxSize, minSize }: ColumnResizePreviewState,
+): ColumnResizePreviewPosition {
+  const pointerX = getColumnResizePointerPosition(container, clientX)
+  const rawSize = initialSize + (pointerX - initialX) * directionMultiplier
+  const nextSize = clampColumnResizeSize(rawSize, minSize, maxSize)
+  const isPastBounds = rawSize < minSize || rawSize > maxSize
+  const displaySize = applyColumnResizeFalloff(
+    rawSize,
+    minSize,
+    maxSize,
+    COLUMN_RESIZE_FALLOFF_DISTANCE,
+    COLUMN_RESIZE_FALLOFF_STIFFNESS,
+  )
+  const boundaryX = initialX + (nextSize - initialSize) * directionMultiplier
+
+  return {
+    boundaryX,
+    isPastBounds,
+    size: nextSize,
+    x: initialX + (displaySize - initialSize) * directionMultiplier,
+  }
+}
+
+function startColumnResize<TData>(
+  target: HTMLElement,
+  initialClientX: number,
+  pointerId: number,
+  header: Header<TData, unknown>,
+) {
+  const container = target.closest<HTMLElement>('[data-slot="table-container"]')
+  const indicator = container?.querySelector<HTMLElement>('[data-slot="table-column-resize-indicator"]')
+
+  if (!container || !indicator) return
+
+  const table = header.getContext().table
+  const { minSize, maxSize } = getHeaderResizeBounds(header)
+  const previewState: ColumnResizePreviewState = {
+    directionMultiplier: table.options.columnResizeDirection === 'rtl' ? -1 : 1,
+    initialSize: header.getSize(),
+    initialX: getColumnResizePointerPosition(container, initialClientX),
+    maxSize,
+    minSize,
+  }
+
+  let frame = 0
+  let latestClientX = initialClientX
+  let lastPosition: ColumnResizePreviewPosition | undefined
+  let stopped = false
+
+  const commitSize = (nextSize: number) => {
+    table.setColumnSizing((old) => ({
+      ...old,
+      [header.column.id]: nextSize,
+    }))
+  }
+
+  const update = () => {
+    frame = 0
+    const position = getColumnResizePreviewPosition(container, latestClientX, previewState)
+    lastPosition = position
+
+    indicator.style.transform = `translate3d(${position.x}px, 0, 0)`
+    target.setAttribute('aria-valuenow', String(Math.round(position.size)))
+    target.setAttribute('aria-valuetext', getColumnResizeAriaValueText(position.size))
+  }
+
+  const scheduleUpdate = (clientX: number) => {
+    latestClientX = clientX
+    if (frame) return
+
+    frame = requestAnimationFrame(update)
+  }
+
+  const handlePointerMove = (event: PointerEvent) => {
+    if (event.pointerId !== pointerId) return
+
+    event.preventDefault()
+    scheduleUpdate(event.clientX)
+  }
+
+  const stop = () => {
+    if (stopped) return
+
+    stopped = true
+    clearColumnResizeRelease(container)
+    if (frame) {
+      cancelAnimationFrame(frame)
+      frame = 0
+    }
+
+    if (target.hasPointerCapture(pointerId)) {
+      target.releasePointerCapture(pointerId)
+    }
+
+    document.removeEventListener('pointermove', handlePointerMove)
+    document.removeEventListener('pointerup', handlePointerEnd)
+    document.removeEventListener('pointercancel', handlePointerEnd)
+    target.removeEventListener('lostpointercapture', stop)
+    window.removeEventListener('blur', stop)
+
+    commitSize(lastPosition?.size ?? previewState.initialSize)
+    delete target.dataset.resizing
+
+    if (lastPosition?.isPastBounds) {
+      container.dataset.columnResizeReleasing = 'true'
+      indicator.style.transform = `translate3d(${lastPosition.boundaryX}px, 0, 0)`
+
+      const releaseTimeout = window.setTimeout(() => {
+        delete container.dataset.columnResizing
+        delete container.dataset.columnResizeReleasing
+        resetColumnResizeIndicator(indicator)
+        columnResizeReleaseTimeouts.delete(container)
+      }, COLUMN_RESIZE_LIMIT_RELEASE_MS)
+      columnResizeReleaseTimeouts.set(container, releaseTimeout)
+      return
+    }
+
+    delete container.dataset.columnResizing
+    delete container.dataset.columnResizeReleasing
+    resetColumnResizeIndicator(indicator)
+  }
+
+  const handlePointerEnd = (event: PointerEvent) => {
+    if (event.pointerId !== pointerId) return
+
+    stop()
+  }
+
+  container.dataset.columnResizing = 'true'
+  clearColumnResizeRelease(container)
+  indicator.style.setProperty('--table-column-resize-indicator-height', `${container.scrollHeight}px`)
+  target.dataset.resizing = 'true'
+  target.setPointerCapture(pointerId)
+  update()
+  document.addEventListener('pointermove', handlePointerMove, { passive: false })
+  document.addEventListener('pointerup', handlePointerEnd)
+  document.addEventListener('pointercancel', handlePointerEnd)
+  target.addEventListener('lostpointercapture', stop)
+  window.addEventListener('blur', stop)
+}
+
+function TableColumnResizeHandle<TData>({ header }: { header: Header<TData, unknown> }) {
+  if (!getHeaderCanResize(header)) return null
+
+  const table = header.getContext().table
+  const { minSize, maxSize } = getHeaderResizeBounds(header)
+  const size = header.column.getSize()
+  const label = getHeaderResizeLabel(header)
+
+  const updateColumnSize = (nextSize: number) => {
+    const size = clampColumnResizeSize(nextSize, minSize, maxSize)
+
+    table.setColumnSizing((old) => ({
+      ...old,
+      [header.column.id]: size,
+    }))
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Home') {
+      event.preventDefault()
+      event.stopPropagation()
+      updateColumnSize(minSize)
+      return
+    }
+
+    if (event.key === 'End' && maxSize !== Number.MAX_SAFE_INTEGER) {
+      event.preventDefault()
+      event.stopPropagation()
+      updateColumnSize(maxSize)
+      return
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      event.stopPropagation()
+      header.column.resetSize()
+      return
+    }
+
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const step = event.shiftKey ? 25 : 10
+    const direction = event.key === 'ArrowRight' ? 1 : -1
+    const directionMultiplier = table.options.columnResizeDirection === 'rtl' ? -1 : 1
+
+    updateColumnSize(size + step * direction * directionMultiplier)
+  }
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!event.isPrimary || event.button !== 0) return
+
+    event.preventDefault()
+    event.stopPropagation()
+    startColumnResize(event.currentTarget, event.clientX, event.pointerId, header)
+  }
+
+  return (
+    <div
+      aria-label={`Resize ${label} column`}
+      aria-orientation="vertical"
+      aria-valuemax={maxSize === Number.MAX_SAFE_INTEGER ? undefined : maxSize}
+      aria-valuemin={minSize}
+      aria-valuenow={Math.round(size)}
+      aria-valuetext={getColumnResizeAriaValueText(size)}
+      data-resizing={header.column.getIsResizing() ? 'true' : undefined}
+      data-slot="table-column-resize-handle"
+      onDoubleClick={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        header.column.resetSize()
+      }}
+      onKeyDown={handleKeyDown}
+      onPointerDown={handlePointerDown}
+      role="separator"
+      tabIndex={0}
+      title={`Resize ${label} column`}
+    />
+  )
+}
+
+function TableHead<TData = unknown>({
+  children,
+  className,
+  header,
+  style,
+  sticky,
+  ...props
+}: React.ComponentProps<'th'> & { header?: Header<TData, unknown>; sticky?: StickyState }) {
   const stickySide = getStickySide(sticky)
+  const canResize = getHeaderCanResize(header)
 
   return (
     <th
       data-slot="table-head"
       data-sticky-state={stickySide}
+      data-resizable={canResize ? 'true' : undefined}
       className={cn(
         'text-muted-foreground border-b h-8 px-3 text-left align-middle !font-mono font-medium !uppercase whitespace-nowrap !text-xs [&_*]:!font-mono [&_*]:!uppercase [&_*]:!text-xs bg-table-header [&:has([data-sort])]:text-foreground',
         {
           'sticky z-[2]': sticky,
+          relative: !sticky,
           'left-0': stickySide === 'left',
           'right-0': stickySide === 'right',
         },
@@ -159,7 +480,10 @@ function TableHead({ className, style, sticky, ...props }: React.ComponentProps<
       )}
       style={style}
       {...props}
-    />
+    >
+      {children}
+      {header ? <TableColumnResizeHandle header={header} /> : null}
+    </th>
   )
 }
 

--- a/apps/dashboard/src/enums/LocalStorageKey.ts
+++ b/apps/dashboard/src/enums/LocalStorageKey.ts
@@ -7,5 +7,4 @@ export enum LocalStorageKey {
   SelectedOrganizationId = 'SelectedOrganizationId',
   SkipOnboardingPrefix = 'SkipOnboarding_',
   AnnouncementBannerDismissed = 'AnnouncementBannerDismissed',
-  SandboxTableColumnVisibility = 'SandboxTableColumnVisibility',
 }

--- a/apps/dashboard/src/hooks/useStorageState.ts
+++ b/apps/dashboard/src/hooks/useStorageState.ts
@@ -20,7 +20,7 @@ type StorageStateInitialValue<TValue> = TValue | (() => TValue)
 type StorageStateError = {
   error: unknown
   key: string
-  operation: 'read' | 'remove' | 'subscribe' | 'write'
+  operation: 'remove' | 'subscribe' | 'write'
 }
 
 type UseStorageStateOptions<TValue> = {
@@ -44,7 +44,7 @@ type StorageStateSnapshotReader<TValue> = {
 }
 
 type StorageStateSnapshotSource = {
-  kind: 'error' | 'memory' | 'storage' | 'unavailable'
+  kind: 'memory' | 'storage' | 'unavailable'
   rawValue: string | null
   storage: StorageStateStorage | null
 }
@@ -95,10 +95,9 @@ function useStorageState<TValue>(
     () =>
       createStorageSnapshotReader(key, initialValueRef, {
         deserialize,
-        onError,
         storage,
       }),
-    [deserialize, key, onError, storage],
+    [deserialize, key, storage],
   )
 
   const subscribe = useCallback(
@@ -144,11 +143,7 @@ function useStorageState<TValue>(
 function createStorageSnapshotReader<TValue>(
   key: string,
   initialValueRef: RefObject<StorageStateInitialValue<TValue>>,
-  {
-    deserialize,
-    onError,
-    storage,
-  }: Required<Pick<UseStorageStateOptions<TValue>, 'deserialize' | 'onError' | 'storage'>>,
+  { deserialize, storage }: Required<Pick<UseStorageStateOptions<TValue>, 'deserialize' | 'storage'>>,
 ): StorageStateSnapshotReader<TValue> {
   let cachedServerSnapshot: StorageStateSnapshot<TValue> | null = null
   let cachedSnapshot: StorageStateSnapshot<TValue> | null = null
@@ -170,20 +165,13 @@ function createStorageSnapshotReader<TValue>(
   }
 
   const getSnapshot = () => {
-    const storageResolution = resolveStorage(storage)
-    const storageArea = storageResolution.storage
+    const storageArea = resolveStorage(storage).storage
     let source: StorageStateSnapshotSource
 
     if (memoryValue !== undefined) {
       source = {
         kind: 'memory',
         rawValue: memoryValue,
-        storage: storageArea,
-      }
-    } else if (storageResolution.error) {
-      source = {
-        kind: 'error',
-        rawValue: null,
         storage: storageArea,
       }
     } else if (!storageArea) {
@@ -199,15 +187,11 @@ function createStorageSnapshotReader<TValue>(
           rawValue: storageArea.getItem(key),
           storage: storageArea,
         }
-      } catch (error) {
+      } catch {
         source = {
-          kind: 'error',
+          kind: 'unavailable',
           rawValue: null,
           storage: storageArea,
-        }
-
-        if (!isMatchingSnapshotSource(cachedSource, source)) {
-          onError({ error, key, operation: 'read' })
         }
       }
     }
@@ -217,10 +201,6 @@ function createStorageSnapshotReader<TValue>(
     }
 
     cachedSource = source
-
-    if (storageResolution.error) {
-      onError({ error: storageResolution.error, key, operation: 'read' })
-    }
 
     if (source.rawValue === null) {
       cachedSnapshot = {
@@ -234,13 +214,11 @@ function createStorageSnapshotReader<TValue>(
 
     try {
       cachedSnapshot = {
-        hasStoredValue: source.kind === 'storage',
+        hasStoredValue: source.rawValue !== null,
         isPersistent: source.kind === 'storage',
         value: deserialize(source.rawValue),
       }
-    } catch (error) {
-      onError({ error, key, operation: 'read' })
-
+    } catch {
       cachedSnapshot = getInitialSnapshot()
     }
 

--- a/apps/dashboard/src/hooks/useStorageState.ts
+++ b/apps/dashboard/src/hooks/useStorageState.ts
@@ -1,0 +1,475 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import {
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+  useCallback,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from 'react'
+
+type StorageStateStorage = Pick<Storage, 'getItem' | 'removeItem' | 'setItem'>
+type StorageStateStorageProvider = () => StorageStateStorage | null | undefined
+type StorageStateInitialValue<TValue> = TValue | (() => TValue)
+
+type StorageStateError = {
+  error: unknown
+  key: string
+  operation: 'read' | 'remove' | 'subscribe' | 'write'
+}
+
+type UseStorageStateOptions<TValue> = {
+  deserialize?: (storedValue: string) => TValue
+  onError?: (error: StorageStateError) => void
+  serialize?: (value: TValue) => string
+  storage?: StorageStateStorage | StorageStateStorageProvider | null
+}
+
+type StorageStateSnapshot<TValue> = {
+  hasStoredValue: boolean
+  isPersistent: boolean
+  value: TValue
+}
+
+type StorageStateSnapshotReader<TValue> = {
+  clearMemoryValue: () => void
+  getServerSnapshot: () => StorageStateSnapshot<TValue>
+  getSnapshot: () => StorageStateSnapshot<TValue>
+  setMemoryValue: (rawValue: string | null) => void
+}
+
+type StorageStateSnapshotSource = {
+  kind: 'error' | 'memory' | 'storage' | 'unavailable'
+  rawValue: string | null
+  storage: StorageStateStorage | null
+}
+
+type StorageStateChangeListener = () => void
+
+type StorageStateChangeDetail = {
+  isPersistent: boolean
+  key: string
+  rawValue: string | null
+  storage: StorageStateStorage | null
+}
+
+type UseStorageStateResult<TValue> = readonly [
+  TValue,
+  Dispatch<SetStateAction<TValue>>,
+  () => void,
+  {
+    hasStoredValue: boolean
+    isPersistent: boolean
+  },
+]
+
+const getBrowserLocalStorage: StorageStateStorageProvider = () => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  return window.localStorage
+}
+
+const STORAGE_STATE_CHANGE_EVENT = 'daytona:storage-state-change'
+
+function useStorageState<TValue>(
+  key: string,
+  initialValue: StorageStateInitialValue<TValue>,
+  {
+    deserialize = deserializeJson,
+    onError = reportStorageStateError,
+    serialize = serializeJson,
+    storage = getBrowserLocalStorage,
+  }: UseStorageStateOptions<TValue> = {},
+): UseStorageStateResult<TValue> {
+  const initialValueRef = useRef(initialValue)
+  initialValueRef.current = initialValue
+
+  const snapshotReader = useMemo(
+    () =>
+      createStorageSnapshotReader(key, initialValueRef, {
+        deserialize,
+        onError,
+        storage,
+      }),
+    [deserialize, key, onError, storage],
+  )
+
+  const subscribe = useCallback(
+    (listener: StorageStateChangeListener) =>
+      subscribeStorageValue(key, storage, snapshotReader, listener, { onError }),
+    [key, onError, snapshotReader, storage],
+  )
+
+  const snapshot = useSyncExternalStore(subscribe, snapshotReader.getSnapshot, snapshotReader.getServerSnapshot)
+
+  const setValue = useCallback<Dispatch<SetStateAction<TValue>>>(
+    (nextValueOrUpdater) => {
+      const currentSnapshot = snapshotReader.getSnapshot()
+      const nextValue =
+        typeof nextValueOrUpdater === 'function'
+          ? (nextValueOrUpdater as (currentValue: TValue) => TValue)(currentSnapshot.value)
+          : nextValueOrUpdater
+
+      writeStorageValue(key, nextValue, snapshotReader, {
+        onError,
+        serialize,
+        storage,
+      })
+    },
+    [key, onError, serialize, snapshotReader, storage],
+  )
+
+  const removeValue = useCallback(() => {
+    removeStorageValue(key, snapshotReader, { onError, storage })
+  }, [key, onError, snapshotReader, storage])
+
+  return [
+    snapshot.value,
+    setValue,
+    removeValue,
+    {
+      hasStoredValue: snapshot.hasStoredValue,
+      isPersistent: snapshot.isPersistent,
+    },
+  ] as const
+}
+
+function createStorageSnapshotReader<TValue>(
+  key: string,
+  initialValueRef: RefObject<StorageStateInitialValue<TValue>>,
+  {
+    deserialize,
+    onError,
+    storage,
+  }: Required<Pick<UseStorageStateOptions<TValue>, 'deserialize' | 'onError' | 'storage'>>,
+): StorageStateSnapshotReader<TValue> {
+  let cachedServerSnapshot: StorageStateSnapshot<TValue> | null = null
+  let cachedSnapshot: StorageStateSnapshot<TValue> | null = null
+  let cachedSource: StorageStateSnapshotSource | null = null
+  let memoryValue: string | null | undefined
+
+  const getInitialSnapshot = (): StorageStateSnapshot<TValue> => ({
+    hasStoredValue: false,
+    isPersistent: false,
+    value: resolveInitialValue(initialValueRef.current),
+  })
+
+  const getServerSnapshot = () => {
+    if (!cachedServerSnapshot) {
+      cachedServerSnapshot = getInitialSnapshot()
+    }
+
+    return cachedServerSnapshot
+  }
+
+  const getSnapshot = () => {
+    const storageResolution = resolveStorage(storage)
+    const storageArea = storageResolution.storage
+    let source: StorageStateSnapshotSource
+
+    if (memoryValue !== undefined) {
+      source = {
+        kind: 'memory',
+        rawValue: memoryValue,
+        storage: storageArea,
+      }
+    } else if (storageResolution.error) {
+      source = {
+        kind: 'error',
+        rawValue: null,
+        storage: storageArea,
+      }
+    } else if (!storageArea) {
+      source = {
+        kind: 'unavailable',
+        rawValue: null,
+        storage: null,
+      }
+    } else {
+      try {
+        source = {
+          kind: 'storage',
+          rawValue: storageArea.getItem(key),
+          storage: storageArea,
+        }
+      } catch (error) {
+        source = {
+          kind: 'error',
+          rawValue: null,
+          storage: storageArea,
+        }
+
+        if (!isMatchingSnapshotSource(cachedSource, source)) {
+          onError({ error, key, operation: 'read' })
+        }
+      }
+    }
+
+    if (cachedSnapshot && isMatchingSnapshotSource(cachedSource, source)) {
+      return cachedSnapshot
+    }
+
+    cachedSource = source
+
+    if (storageResolution.error) {
+      onError({ error: storageResolution.error, key, operation: 'read' })
+    }
+
+    if (source.rawValue === null) {
+      cachedSnapshot = {
+        hasStoredValue: false,
+        isPersistent: source.kind === 'storage',
+        value: resolveInitialValue(initialValueRef.current),
+      }
+
+      return cachedSnapshot
+    }
+
+    try {
+      cachedSnapshot = {
+        hasStoredValue: source.kind === 'storage',
+        isPersistent: source.kind === 'storage',
+        value: deserialize(source.rawValue),
+      }
+    } catch (error) {
+      onError({ error, key, operation: 'read' })
+
+      cachedSnapshot = getInitialSnapshot()
+    }
+
+    return cachedSnapshot
+  }
+
+  return {
+    clearMemoryValue: () => {
+      memoryValue = undefined
+    },
+    getServerSnapshot,
+    getSnapshot,
+    setMemoryValue: (rawValue) => {
+      memoryValue = rawValue
+    },
+  }
+}
+
+function writeStorageValue<TValue>(
+  key: string,
+  value: TValue,
+  snapshotReader: StorageStateSnapshotReader<TValue>,
+  { onError, serialize, storage }: Required<Pick<UseStorageStateOptions<TValue>, 'onError' | 'serialize' | 'storage'>>,
+) {
+  const storageResolution = resolveStorage(storage)
+  const storageArea = storageResolution.storage
+  let serializedValue: string
+
+  try {
+    serializedValue = serialize(value)
+  } catch (error) {
+    onError({ error, key, operation: 'write' })
+    return false
+  }
+
+  if (storageResolution.error) {
+    onError({ error: storageResolution.error, key, operation: 'write' })
+  }
+
+  if (!storageArea) {
+    snapshotReader.setMemoryValue(serializedValue)
+    emitStorageValueChange({ isPersistent: false, key, rawValue: serializedValue, storage: storageArea })
+    return false
+  }
+
+  try {
+    storageArea.setItem(key, serializedValue)
+    snapshotReader.clearMemoryValue()
+    emitStorageValueChange({ isPersistent: true, key, rawValue: serializedValue, storage: storageArea })
+    return true
+  } catch (error) {
+    snapshotReader.setMemoryValue(serializedValue)
+    emitStorageValueChange({ isPersistent: false, key, rawValue: serializedValue, storage: storageArea })
+    onError({ error, key, operation: 'write' })
+    return false
+  }
+}
+
+function removeStorageValue<TValue>(
+  key: string,
+  snapshotReader: StorageStateSnapshotReader<TValue>,
+  { onError, storage }: Required<Pick<UseStorageStateOptions<TValue>, 'onError' | 'storage'>>,
+) {
+  const storageResolution = resolveStorage(storage)
+  const storageArea = storageResolution.storage
+
+  if (storageResolution.error) {
+    onError({ error: storageResolution.error, key, operation: 'remove' })
+  }
+
+  if (!storageArea) {
+    snapshotReader.setMemoryValue(null)
+    emitStorageValueChange({ isPersistent: false, key, rawValue: null, storage: storageArea })
+    return false
+  }
+
+  try {
+    storageArea.removeItem(key)
+    snapshotReader.clearMemoryValue()
+    emitStorageValueChange({ isPersistent: true, key, rawValue: null, storage: storageArea })
+    return true
+  } catch (error) {
+    snapshotReader.setMemoryValue(null)
+    emitStorageValueChange({ isPersistent: false, key, rawValue: null, storage: storageArea })
+    onError({ error, key, operation: 'remove' })
+    return false
+  }
+}
+
+function subscribeStorageValue(
+  key: string,
+  storage: StorageStateStorage | StorageStateStorageProvider | null | undefined,
+  snapshotReader: StorageStateSnapshotReader<unknown>,
+  listener: StorageStateChangeListener,
+  { onError }: Required<Pick<UseStorageStateOptions<unknown>, 'onError'>>,
+) {
+  if (typeof window === 'undefined') {
+    return () => undefined
+  }
+
+  const storageResolution = resolveStorage(storage)
+  const storageArea = storageResolution.storage
+
+  if (storageResolution.error) {
+    onError({ error: storageResolution.error, key, operation: 'subscribe' })
+  }
+
+  const handleStorageStateChange = (event: Event) => {
+    const detail = (event as CustomEvent<StorageStateChangeDetail>).detail
+
+    if (!isStorageStateChangeDetail(detail) || detail.key !== key || detail.storage !== storageArea) {
+      return
+    }
+
+    if (detail.isPersistent) {
+      snapshotReader.clearMemoryValue()
+    } else {
+      snapshotReader.setMemoryValue(detail.rawValue)
+    }
+    listener()
+  }
+
+  const handleBrowserStorageChange = (event: StorageEvent) => {
+    if (!isStorageEventForValue(event, key, storageArea)) {
+      return
+    }
+
+    snapshotReader.clearMemoryValue()
+    listener()
+  }
+
+  window.addEventListener(STORAGE_STATE_CHANGE_EVENT, handleStorageStateChange)
+  window.addEventListener('storage', handleBrowserStorageChange)
+
+  return () => {
+    window.removeEventListener(STORAGE_STATE_CHANGE_EVENT, handleStorageStateChange)
+    window.removeEventListener('storage', handleBrowserStorageChange)
+  }
+}
+
+function emitStorageValueChange(detail: StorageStateChangeDetail) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  window.dispatchEvent(new CustomEvent<StorageStateChangeDetail>(STORAGE_STATE_CHANGE_EVENT, { detail }))
+}
+
+function isMatchingSnapshotSource(
+  previousSource: StorageStateSnapshotSource | null,
+  nextSource: StorageStateSnapshotSource,
+) {
+  return (
+    previousSource?.kind === nextSource.kind &&
+    previousSource.rawValue === nextSource.rawValue &&
+    previousSource.storage === nextSource.storage
+  )
+}
+
+function isNativeStorage(storage: StorageStateStorage): storage is Storage {
+  return typeof Storage !== 'undefined' && storage instanceof Storage
+}
+
+function isStorageEventForValue(event: StorageEvent, key: string, storage: StorageStateStorage | null) {
+  if (!storage || !isNativeStorage(storage)) {
+    return false
+  }
+
+  if (event.key !== null && event.key !== key) {
+    return false
+  }
+
+  return !event.storageArea || storage === event.storageArea
+}
+
+function isStorageStateChangeDetail(detail: unknown): detail is StorageStateChangeDetail {
+  return Boolean(
+    detail &&
+      typeof detail === 'object' &&
+      'key' in detail &&
+      'isPersistent' in detail &&
+      'storage' in detail &&
+      'rawValue' in detail &&
+      typeof detail.key === 'string' &&
+      typeof detail.isPersistent === 'boolean' &&
+      (typeof detail.rawValue === 'string' || detail.rawValue === null),
+  )
+}
+
+function resolveStorage(storage: StorageStateStorage | StorageStateStorageProvider | null | undefined) {
+  try {
+    return {
+      storage: (typeof storage === 'function' ? storage() : storage) ?? null,
+    }
+  } catch (error) {
+    return {
+      error,
+      storage: null,
+    }
+  }
+}
+
+function resolveInitialValue<TValue>(initialValue: StorageStateInitialValue<TValue>) {
+  return typeof initialValue === 'function' ? (initialValue as () => TValue)() : initialValue
+}
+
+function serializeJson<TValue>(value: TValue) {
+  const serializedValue = JSON.stringify(value)
+
+  if (typeof serializedValue !== 'string') {
+    throw new Error('Storage state values must be JSON serializable')
+  }
+
+  return serializedValue
+}
+
+function deserializeJson<TValue>(storedValue: string) {
+  return JSON.parse(storedValue) as TValue
+}
+
+function reportStorageStateError({ error, key, operation }: StorageStateError) {
+  console.error(`Failed to ${operation} storage value for "${key}":`, error)
+}
+
+export { getBrowserLocalStorage, useStorageState }
+export type {
+  StorageStateError,
+  StorageStateStorage,
+  StorageStateStorageProvider,
+  UseStorageStateOptions,
+  UseStorageStateResult,
+}

--- a/apps/dashboard/src/index.css
+++ b/apps/dashboard/src/index.css
@@ -277,6 +277,88 @@
   @apply scrollbar-thin scrollbar-thumb-neutral-300 scrollbar-track-background dark:scrollbar-thumb-neutral-700;
 }
 
+@property --scroll-fade-offset-y-top {
+  syntax: '<percentage>';
+  inherits: true;
+  initial-value: 0%;
+}
+
+@property --scroll-fade-offset-y-bottom {
+  syntax: '<percentage>';
+  inherits: true;
+  initial-value: 100%;
+}
+
+@property --scroll-fade-offset-x-left {
+  syntax: '<percentage>';
+  inherits: true;
+  initial-value: 0%;
+}
+
+@property --scroll-fade-offset-x-right {
+  syntax: '<percentage>';
+  inherits: true;
+  initial-value: 100%;
+}
+
+.scroll-fade {
+  --mask-offset: 20%;
+  --scroll-fade-offset-y-top: 0%;
+  --scroll-fade-offset-y-bottom: 100%;
+  --scroll-fade-mask: linear-gradient(
+    to bottom,
+    transparent,
+    black min(var(--scroll-fade-offset-y-top), var(--mask-offset)),
+    black calc(100% - min(var(--scroll-fade-offset-y-bottom), var(--mask-offset))),
+    transparent
+  );
+  animation: animate-scroll-fade-mask linear both;
+  animation-timeline: scroll(self y);
+  mask-image: var(--scroll-fade-mask);
+  -webkit-mask-image: var(--scroll-fade-mask);
+}
+
+.scroll-fade-horizontal {
+  --mask-offset: 20%;
+  --scroll-fade-offset-x-left: 0%;
+  --scroll-fade-offset-x-right: 100%;
+  --scroll-fade-mask: linear-gradient(
+    to right,
+    transparent,
+    black min(var(--scroll-fade-offset-x-left), var(--mask-offset)),
+    black calc(100% - min(var(--scroll-fade-offset-x-right), var(--mask-offset))),
+    transparent
+  );
+  animation: animate-scroll-fade-mask-horizontal linear both;
+  animation-timeline: scroll(self x);
+  mask-image: var(--scroll-fade-mask);
+  -webkit-mask-image: var(--scroll-fade-mask);
+}
+
+@keyframes animate-scroll-fade-mask {
+  0% {
+    --scroll-fade-offset-y-top: 0%;
+    --scroll-fade-offset-y-bottom: 100%;
+  }
+
+  100% {
+    --scroll-fade-offset-y-top: 100%;
+    --scroll-fade-offset-y-bottom: 0%;
+  }
+}
+
+@keyframes animate-scroll-fade-mask-horizontal {
+  0% {
+    --scroll-fade-offset-x-left: 0%;
+    --scroll-fade-offset-x-right: 100%;
+  }
+
+  100% {
+    --scroll-fade-offset-x-left: 100%;
+    --scroll-fade-offset-x-right: 0%;
+  }
+}
+
 @keyframes skeleton-shimmer {
   0% {
     transform: translateX(-100%);

--- a/apps/dashboard/src/index.css
+++ b/apps/dashboard/src/index.css
@@ -312,7 +312,7 @@
     black calc(100% - min(var(--scroll-fade-offset-y-bottom), var(--mask-offset))),
     transparent
   );
-  animation: animate-scroll-fade-mask linear both;
+  animation: animate-scroll-fade-mask 1ms linear both;
   animation-timeline: scroll(self y);
   mask-image: var(--scroll-fade-mask);
   -webkit-mask-image: var(--scroll-fade-mask);
@@ -329,7 +329,7 @@
     black calc(100% - min(var(--scroll-fade-offset-x-right), var(--mask-offset))),
     transparent
   );
-  animation: animate-scroll-fade-mask-horizontal linear both;
+  animation: animate-scroll-fade-mask-horizontal 1ms linear both;
   animation-timeline: scroll(self x);
   mask-image: var(--scroll-fade-mask);
   -webkit-mask-image: var(--scroll-fade-mask);

--- a/apps/dashboard/src/lib/utils/table.ts
+++ b/apps/dashboard/src/lib/utils/table.ts
@@ -3,17 +3,71 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Column } from '@tanstack/react-table'
-import { CSSProperties } from 'react'
+import type { Column, Table } from '@tanstack/react-table'
+import type { CSSProperties } from 'react'
+
+export const DEFAULT_TABLE_COLUMN_MAX_RESIZE_SIZE = 350
+export const DEFAULT_TABLE_COLUMN_MIN_SIZE = 80
+export const TABLE_COLUMN_MAX_RESIZE_SIZE_OFFSET = 100
+export const DEFAULT_TABLE_COLUMN = {
+  minSize: DEFAULT_TABLE_COLUMN_MIN_SIZE,
+}
+
+type ColumnSizingDefaults = {
+  maxSize?: number
+  minSize?: number
+}
+
+function getColumnMaxSize(maxSize: number | undefined, fallbackMaxSize: number) {
+  return maxSize === undefined || maxSize === Number.MAX_SAFE_INTEGER ? fallbackMaxSize : maxSize
+}
+
+export function getTableColumnMaxResizeSize(maxSize: number) {
+  return maxSize + TABLE_COLUMN_MAX_RESIZE_SIZE_OFFSET
+}
+
+export function getColumnSizeBounds<T>(column: Column<T>, defaultColumn?: ColumnSizingDefaults) {
+  const maxSize = column.columnDef.maxSize ?? defaultColumn?.maxSize ?? Number.MAX_SAFE_INTEGER
+  const configuredMinSize = column.columnDef.minSize ?? defaultColumn?.minSize ?? DEFAULT_TABLE_COLUMN_MIN_SIZE
+  const minSize = Math.min(Math.max(configuredMinSize, DEFAULT_TABLE_COLUMN_MIN_SIZE), maxSize)
+
+  return {
+    maxSize,
+    minSize,
+  }
+}
+
+export function getColumnResizeSizeBounds<T>(column: Column<T>, defaultColumn?: ColumnSizingDefaults) {
+  const maxSize = getColumnMaxSize(
+    column.columnDef.maxSize ?? defaultColumn?.maxSize,
+    DEFAULT_TABLE_COLUMN_MAX_RESIZE_SIZE,
+  )
+  const configuredMinSize = column.columnDef.minSize ?? defaultColumn?.minSize ?? DEFAULT_TABLE_COLUMN_MIN_SIZE
+  const minSize = Math.min(Math.max(configuredMinSize, DEFAULT_TABLE_COLUMN_MIN_SIZE), maxSize)
+
+  return {
+    maxSize,
+    minSize,
+  }
+}
 
 export function getColumnSizeStyles<T>(column: Column<T>): CSSProperties {
   const pinned = column.getIsPinned()
-  const hasMaxSize = column.columnDef.maxSize !== Number.MAX_SAFE_INTEGER
+  const { maxSize, minSize } = getColumnSizeBounds(column)
+  const hasMaxSize = maxSize !== Number.MAX_SAFE_INTEGER
 
   return {
-    width: hasMaxSize ? column.getSize() : undefined,
-    minWidth: column.columnDef.minSize,
+    width: column.getSize(),
+    minWidth: minSize,
+    maxWidth: hasMaxSize ? maxSize : undefined,
     left: pinned === 'left' ? column.getStart('left') : undefined,
     right: pinned === 'right' ? column.getAfter('right') : undefined,
+  }
+}
+
+export function getTableSizeStyles<T>(table: Table<T>): CSSProperties {
+  return {
+    width: table.getTotalSize(),
+    minWidth: '100%',
   }
 }

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "kafkajs": "^2.2.4",
     "linkify-it": "^5.0.1",
     "lucide-react": "^1.17.0",
-    "motion": "^12.23.0",
+    "motion": "^12.40.0",
     "msw": "^2.12.2",
     "nestjs-opensearch": "^1.4.1",
     "nestjs-pino": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21992,7 +21992,7 @@ __metadata:
     lint-staged: "npm:^15.5.0"
     lucide-react: "npm:^1.17.0"
     markdownlint-cli2: "npm:^0.17.2"
-    motion: "npm:^12.23.0"
+    motion: "npm:^12.40.0"
     msw: "npm:^2.12.2"
     nestjs-opensearch: "npm:^1.4.1"
     nestjs-pino: "npm:^4.4.1"
@@ -25329,12 +25329,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@npm:^12.23.18":
-  version: 12.23.18
-  resolution: "framer-motion@npm:12.23.18"
+"framer-motion@npm:^12.40.0":
+  version: 12.40.0
+  resolution: "framer-motion@npm:12.40.0"
   dependencies:
-    motion-dom: "npm:^12.23.18"
-    motion-utils: "npm:^12.23.6"
+    motion-dom: "npm:^12.40.0"
+    motion-utils: "npm:^12.39.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
     "@emotion/is-prop-valid": "*"
@@ -25347,7 +25347,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 10c0/059fed39a1f7c1d277ac9ab94da093e0498d59b29de1a2ae5a040d080b644f34bc8862314d45676dfb93adeae01b6c5c84309b2799075b8d2c028ae1d493808d
+  checksum: 10c0/a1d26908d6661028fcdba0cf200fca18927a4d4eae0b1e64c37dfb7fdea9da66a8991abd0007079e98687060ba9c83db55620c238bc363106a24ff411d22f533
   languageName: node
   linkType: hard
 
@@ -31865,27 +31865,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"motion-dom@npm:^12.23.18":
-  version: 12.23.18
-  resolution: "motion-dom@npm:12.23.18"
+"motion-dom@npm:^12.40.0":
+  version: 12.40.0
+  resolution: "motion-dom@npm:12.40.0"
   dependencies:
-    motion-utils: "npm:^12.23.6"
-  checksum: 10c0/eea2db02f222deb1fb615d8e3c7d9ec3ac970fe27326e3bdf81d92ff0227fab7b7219170aaec0c514ff2a5ceb03c40244e7d7144c3fcac33bed648dd644bfde5
+    motion-utils: "npm:^12.39.0"
+  checksum: 10c0/79da846a36fd5f6762a0fcfa6e0b7128e4d58f7c07d1467a9f789a9cd0b5adbef9bfbde75760901a13cf2bddd9b31e93e4348a714f570c45ca1e2bfabd22859e
   languageName: node
   linkType: hard
 
-"motion-utils@npm:^12.23.6":
-  version: 12.23.6
-  resolution: "motion-utils@npm:12.23.6"
-  checksum: 10c0/c058e8ba6423b3baa63e985bcc669877ee7d9579d938f5348b4e60c5ea1b4b33dd7f4877434436a4a5807f3cf00370d3fd4079a6fdd6309c5c87aa62b311a897
+"motion-utils@npm:^12.39.0":
+  version: 12.39.0
+  resolution: "motion-utils@npm:12.39.0"
+  checksum: 10c0/6d7a2a2cc0797b72410a666a9cc1c201c8e39bf9669670464e433fe1e72af5f0217154c869867b34fbadf3664cf222c0d022bbc4eed7927f201ae971918e7440
   languageName: node
   linkType: hard
 
-"motion@npm:^12.23.0":
-  version: 12.23.18
-  resolution: "motion@npm:12.23.18"
+"motion@npm:^12.40.0":
+  version: 12.40.0
+  resolution: "motion@npm:12.40.0"
   dependencies:
-    framer-motion: "npm:^12.23.18"
+    framer-motion: "npm:^12.40.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
     "@emotion/is-prop-valid": "*"
@@ -31898,7 +31898,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 10c0/e59bf177812086d994e28b83a919312938165b1acc59d8e4c02f505898418582b152227ed5903eddabd2ed1d6fcabeb35c434ab376dc454c0083bc6f733763c7
+  checksum: 10c0/d0c118ed4829f2999c3ab7eb1ee916df70c65e95d262e951b69d3cea67a74e4a1d12e181badf4180e0d01c1ca8a9b109be4ea5456cad04bb58d4510f071af60f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds resizable columns to all dashboard tables and a new `DataTableConfigMenu` to show/hide, pin, and reorder columns with per-table persistence. Also unifies table sizing via `getTableSizeStyles`, adds `MiddleTruncate` for long IDs/tokens, and fixes column menu ordering.

- **New Features**
  - Column resizing with mouse/keyboard, resize handle, and live preview indicator in `Table`.
  - Column config menu: `DataTableConfigMenu` for visibility, pinning, and drag-to-reorder; settings persist per table.
  - Shared sizing utils: `DEFAULT_TABLE_COLUMN`, `DEFAULT_TABLE_COLUMN_MIN_SIZE`, `getTableColumnMaxResizeSize`, `getTableSizeStyles`, and updated `getColumnSizeStyles`.
  - `MiddleTruncate` for IDs/tokens; applied across runners, regions, volumes, sandboxes, snapshots, and webhooks.

- **Migration**
  - Set `columnResizeMode: 'onEnd'`, use `defaultColumn: DEFAULT_TABLE_COLUMN`, and apply `getTableSizeStyles(table)` on `<Table>`.
  - Pass `header` to `<TableHead>` and use `getColumnSizeStyles(header.column)`; use `getTableColumnMaxResizeSize(...)` to cap resizable columns.
  - Replace manual ID/token truncation with `MiddleTruncate`.
  - Optional: add `DataTableConfigMenu` in table toolbars; state persists automatically.

<sup>Written for commit 54eb5fbf34fb47604e5681f318ebed852406be10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

