### PR TITLE
fix(api): stop releasing sandbox state-change lock on job completion to avoid create fan-out

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox.action.ts
@@ -12,6 +12,7 @@ import { SandboxState } from '../../enums/sandbox-state.enum'
 import { BackupState } from '../../enums/backup-state.enum'
 import { getStateChangeLockKey } from '../../utils/lock-key.util'
 import { LockCode, RedisLockProvider } from '../../common/redis-lock.provider'
+import { SandboxConflictError } from '../../errors/sandbox-conflict.error'
 
 export const SYNC_AGAIN = 'sync-again'
 export const DONT_SYNC_AGAIN = 'dont-sync-again'
@@ -44,18 +45,21 @@ export abstract class SandboxAction {
     const lockKey = getStateChangeLockKey(sandbox.id)
     const currentLockCode = await this.redisLockProvider.getCode(lockKey)
 
+    // Lost our lock: abort instead of returning. Callers create runner jobs right after the save,
+    // so a silent no-op would still fire them, duplicating containers and leaving a stale runnerId.
+    // Throwing makes that unreachable; syncInstanceState catches SandboxConflictError and breaks.
     if (currentLockCode === null) {
       this.logger.warn(
-        `no lock code found - state update action expired - skipping - sandboxId: ${sandbox.id} - state: ${state}`,
+        `no lock code found - state update action expired - aborting - sandboxId: ${sandbox.id} - state: ${state}`,
       )
-      return
+      throw new SandboxConflictError()
     }
 
     if (expectedLockCode.getCode() !== currentLockCode.getCode()) {
       this.logger.warn(
-        `lock code mismatch - state update action expired - skipping - sandboxId: ${sandbox.id} - state: ${state}`,
+        `lock code mismatch - state update action expired - aborting - sandboxId: ${sandbox.id} - state: ${state}`,
       )
-      return
+      throw new SandboxConflictError()
     }
 
     if (state !== SandboxState.ARCHIVED && !sandbox.pending) {

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -22,9 +22,6 @@ import { sanitizeSandboxError } from '../utils/sanitize-error.util'
 import { OrganizationUsageService } from '../../organization/services/organization-usage.service'
 import { SandboxRepository } from '../repositories/sandbox.repository'
 import { Sandbox } from '../entities/sandbox.entity'
-import { RedisLockProvider } from '../common/redis-lock.provider'
-import { ResourceType } from '../enums/resource-type.enum'
-import { getStateChangeLockKey } from '../utils/lock-key.util'
 import { SandboxEvents } from '../constants/sandbox-events.constants'
 import { SandboxStartedEvent } from '../events/sandbox-started.event'
 import { persistSnapshotFromSandbox } from '../utils/persist-snapshot-from-sandbox.util'
@@ -44,7 +41,6 @@ export class JobStateHandlerService {
     @InjectRepository(SnapshotRunner)
     private readonly snapshotRunnerRepository: Repository<SnapshotRunner>,
     private readonly organizationUsageService: OrganizationUsageService,
-    private readonly redisLockProvider: RedisLockProvider,
     private readonly eventEmitter: EventEmitter2,
     @InjectRepository(Runner)
     private readonly runnerRepository: Repository<Runner>,
@@ -117,17 +113,10 @@ export class JobStateHandlerService {
         break
     }
 
-    switch (job.resourceType) {
-      case ResourceType.SANDBOX: {
-        const lockKey = getStateChangeLockKey(job.resourceId)
-        this.redisLockProvider
-          .unlock(lockKey)
-          .catch((error) => this.logger.error(`Error unlocking Redis lock for sandbox ${job.resourceId}:`, error)) // Clean up lock after job completion
-        break
-      }
-      default:
-        break
-    }
+    // Don't release the state-change lock here: unlock() is an unconditional DEL with no ownership
+    // check, so it can delete a lock still held by a running syncInstanceState loop for this sandbox
+    // (e.g. a DESTROY completing mid-loop), making it fan out duplicate jobs. Each holder releases
+    // its own lock, so no cleanup is needed.
   }
 
   private async handleCreateSandboxJobCompletion(job: Job): Promise<void> {


### PR DESCRIPTION
## Description

Starting a sandbox that needs a new runner held a per-sandbox lock while it fired a DESTROY job for the old container. The DESTROY finished almost instantly → its completion handler deleted that lock (an unconditional delete with no ownership check) → the still-running start loop lost its lock → every state save silently did nothing while it kept creating containers → N duplicate containers on N runners, the DB still pointing at the old empty runner, and the sandbox stuck in error.

This removes that unlock on job completion (each sync already releases its own lock), so the loop keeps its lock and starts the sandbox once. It also makes the save throw instead of returning silently when the lock is gone → no container is ever created without a committed state save.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented duplicate container creation by keeping the sandbox state-change lock during start loops and failing fast if the lock is lost. This stops create fan-out across runners and keeps runner state consistent.

- **Bug Fixes**
  - Removed unconditional lock release on sandbox job completion in `JobStateHandlerService`; each sync now releases its own lock.
  - In `SandboxAction.saveState`, throw `SandboxConflictError` when the lock is missing or mismatched and update logs to "aborting".
  - Ensures no container is created without a committed state save and the sandbox starts exactly once.

<sup>Written for commit a96586efadecff5ede147ece8f63eb49c2fbabff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

