### PR TITLE
chore: Pi extension publish

### DIFF
--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -53,6 +53,8 @@ jobs:
             # sdk-typescript is published by its own job; without this flag
             # opencode-plugin's publish would re-publish it via nx dependsOn
             exclude-task-deps: 'true'
+          - name: Pi Extension
+            projects: pi-extension
           - name: Analytics API Client
             projects: analytics-api-client
           - name: Billing API Client


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `pi-extension` to the SDK publish workflow so it can be published via CI alongside other packages.

<sup>Written for commit 5a31cd9e4d6faad34fdf47536f63db19fd21dac2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

