### PR TITLE
fix(api): evict notification sockets when org membership ends

### DIFF
--- a/apps/api/src/notification/emitters/notification-redis.emitter.ts
+++ b/apps/api/src/notification/emitters/notification-redis.emitter.ts
@@ -36,6 +36,13 @@ export class NotificationRedisEmitter extends NotificationEmitter implements OnM
     this.logger.debug('Socket.io Redis emitter initialized (publish-only)')
   }
 
+  evictUserFromOrganization(userId: string, organizationId: string) {
+    // Gateway-disabled deployments only hold a publish-only emitter: it publishes the socketsLeave
+    // request over the Redis adapter and the gateway instances that own the sockets perform the
+    // room removal.
+    this.emitter.in(userId).socketsLeave(organizationId)
+  }
+
   emitSandboxCreated(sandbox: SandboxDto) {
     this.emitter.to(sandbox.organizationId).emit(SandboxEvents.CREATED, sandbox)
   }

--- a/apps/api/src/notification/gateways/notification-emitter.abstract.ts
+++ b/apps/api/src/notification/gateways/notification-emitter.abstract.ts
@@ -35,4 +35,5 @@ export abstract class NotificationEmitter {
     newState: RunnerState,
   ): void
   abstract emitRunnerUnschedulableUpdated(runner: RunnerDto, organizationId: string | null): void
+  abstract evictUserFromOrganization(userId: string, organizationId: string): void
 }

--- a/apps/api/src/notification/gateways/notification.gateway.ts
+++ b/apps/api/src/notification/gateways/notification.gateway.ts
@@ -94,6 +94,9 @@ export class NotificationGateway extends NotificationEmitter implements OnGatewa
 
           // Join the organization room for organization scoped notifications
           if (authContext.organizationId) {
+            if (!(await this.organizationUserService.exists(authContext.organizationId, authContext.userId))) {
+              return next(new UnauthorizedException())
+            }
             await socket.join(authContext.organizationId)
           }
 

--- a/apps/api/src/notification/gateways/notification.gateway.ts
+++ b/apps/api/src/notification/gateways/notification.gateway.ts
@@ -107,6 +107,12 @@ export class NotificationGateway extends NotificationEmitter implements OnGatewa
     })
   }
 
+  evictUserFromOrganization(userId: string, organizationId: string) {
+    // socketsLeave is broadcast to every gateway instance over the Redis adapter, so the user's
+    // sockets leave the organization room regardless of which node currently holds them.
+    this.server.in(userId).socketsLeave(organizationId)
+  }
+
   emitSandboxCreated(sandbox: SandboxDto) {
     this.server.to(sandbox.organizationId).emit(SandboxEvents.CREATED, sandbox)
   }

--- a/apps/api/src/notification/services/notification.service.spec.ts
+++ b/apps/api/src/notification/services/notification.service.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Redis } from 'ioredis'
+import { NotificationService } from './notification.service'
+import { NotificationEmitter } from '../gateways/notification-emitter.abstract'
+import { OrganizationUserRemovedEvent } from '../../organization/events/organization-user-removed.event'
+import { RegionService } from '../../region/services/region.service'
+import { SandboxService } from '../../sandbox/services/sandbox.service'
+
+describe('NotificationService', () => {
+  let service: NotificationService
+  let emitter: jest.Mocked<Pick<NotificationEmitter, 'evictUserFromOrganization'>>
+
+  beforeEach(() => {
+    emitter = { evictUserFromOrganization: jest.fn() }
+    // Only the emitter is exercised by the membership-removal handler; the other dependencies are
+    // not touched on this path.
+    service = new NotificationService(
+      emitter as unknown as NotificationEmitter,
+      undefined as unknown as RegionService,
+      undefined as unknown as SandboxService,
+      undefined as unknown as Redis,
+    )
+  })
+
+  describe('handleOrganizationUserRemoved', () => {
+    it('evicts the removed user from the organization room (userId keyed, org room target)', () => {
+      service.handleOrganizationUserRemoved(new OrganizationUserRemovedEvent('org-1', 'user-1'))
+
+      expect(emitter.evictUserFromOrganization).toHaveBeenCalledTimes(1)
+      expect(emitter.evictUserFromOrganization).toHaveBeenCalledWith('user-1', 'org-1')
+    })
+
+    it('swallows eviction failures so they cannot fail the membership-removal request', () => {
+      emitter.evictUserFromOrganization.mockImplementation(() => {
+        throw new Error('redis down')
+      })
+
+      expect(() =>
+        service.handleOrganizationUserRemoved(new OrganizationUserRemovedEvent('org-1', 'user-1')),
+      ).not.toThrow()
+    })
+  })
+})

--- a/apps/api/src/notification/services/notification.service.spec.ts
+++ b/apps/api/src/notification/services/notification.service.spec.ts
@@ -28,7 +28,7 @@ describe('NotificationService', () => {
 
   describe('handleOrganizationUserRemoved', () => {
     it('evicts the removed user from the organization room (userId keyed, org room target)', () => {
-      service.handleOrganizationUserRemoved(new OrganizationUserRemovedEvent('org-1', 'user-1'))
+      service.handleOrganizationUserRemoved(new OrganizationUserRemovedEvent('user-1', 'org-1'))
 
       expect(emitter.evictUserFromOrganization).toHaveBeenCalledTimes(1)
       expect(emitter.evictUserFromOrganization).toHaveBeenCalledWith('user-1', 'org-1')
@@ -40,7 +40,7 @@ describe('NotificationService', () => {
       })
 
       expect(() =>
-        service.handleOrganizationUserRemoved(new OrganizationUserRemovedEvent('org-1', 'user-1')),
+        service.handleOrganizationUserRemoved(new OrganizationUserRemovedEvent('user-1', 'org-1')),
       ).not.toThrow()
     })
   })

--- a/apps/api/src/notification/services/notification.service.ts
+++ b/apps/api/src/notification/services/notification.service.ts
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Injectable } from '@nestjs/common'
+import { Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
 import { NotificationEmitter } from '../gateways/notification-emitter.abstract'
+import { OrganizationEvents } from '../../organization/constants/organization-events.constant'
+import { OrganizationUserRemovedEvent } from '../../organization/events/organization-user-removed.event'
 import { SandboxEvents } from '../../sandbox/constants/sandbox-events.constants'
 import { SandboxCreatedEvent } from '../../sandbox/events/sandbox-create.event'
 import { SandboxStateUpdatedEvent } from '../../sandbox/events/sandbox-state-updated.event'
@@ -33,12 +35,26 @@ import { SANDBOX_EVENT_CHANNEL } from '../../common/constants/constants'
 
 @Injectable()
 export class NotificationService {
+  private readonly logger = new Logger(NotificationService.name)
+
   constructor(
     private readonly notificationEmitter: NotificationEmitter,
     private readonly regionService: RegionService,
     private readonly sandboxService: SandboxService,
     @InjectRedis() private readonly redis: Redis,
   ) {}
+
+  @OnEvent(OrganizationEvents.USER_REMOVED)
+  handleOrganizationUserRemoved(event: OrganizationUserRemovedEvent) {
+    // The connect-time membership gate blocks new subscriptions; this ejects sockets that were
+    // already subscribed when membership ended. Best-effort: a failure here must not surface on
+    // the request that revoked membership.
+    try {
+      this.notificationEmitter.evictUserFromOrganization(event.userId, event.organizationId)
+    } catch (error) {
+      this.logger.error('Failed to evict user from organization notification room:', error)
+    }
+  }
 
   @OnEvent(SandboxEvents.CREATED)
   async handleSandboxCreated(event: SandboxCreatedEvent) {

--- a/apps/api/src/notification/services/notification.service.ts
+++ b/apps/api/src/notification/services/notification.service.ts
@@ -46,9 +46,9 @@ export class NotificationService {
 
   @OnEvent(OrganizationEvents.USER_REMOVED)
   handleOrganizationUserRemoved(event: OrganizationUserRemovedEvent) {
-    // The connect-time membership gate blocks new subscriptions; this ejects sockets that were
-    // already subscribed when membership ended. Best-effort: a failure here must not surface on
-    // the request that revoked membership.
+    // The gateway's connect-time membership check (NotificationGateway -> OrganizationUserService.exists)
+    // blocks new and reconnecting subscriptions; this ejects sockets that were already subscribed when
+    // membership ended. Best-effort: a failure here must not surface on the request that revoked membership.
     try {
       this.notificationEmitter.evictUserFromOrganization(event.userId, event.organizationId)
     } catch (error) {

--- a/apps/api/src/organization/constants/organization-events.constant.ts
+++ b/apps/api/src/organization/constants/organization-events.constant.ts
@@ -12,4 +12,5 @@ export const OrganizationEvents = {
   SUSPENDED_SANDBOX_STOPPED: 'organization.suspended-sandbox-stopped',
   SUSPENDED_SNAPSHOT_DEACTIVATED: 'organization.suspended-snapshot-deactivated',
   PERMISSIONS_UNASSIGNED: 'permissions.unassigned',
+  USER_REMOVED: 'organization.user.removed',
 } as const

--- a/apps/api/src/organization/events/organization-user-removed.event.ts
+++ b/apps/api/src/organization/events/organization-user-removed.event.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export class OrganizationUserRemovedEvent {
+  constructor(
+    public readonly organizationId: string,
+    public readonly userId: string,
+  ) {}
+}

--- a/apps/api/src/organization/events/organization-user-removed.event.ts
+++ b/apps/api/src/organization/events/organization-user-removed.event.ts
@@ -5,7 +5,7 @@
 
 export class OrganizationUserRemovedEvent {
   constructor(
-    public readonly organizationId: string,
     public readonly userId: string,
+    public readonly organizationId: string,
   ) {}
 }

--- a/apps/api/src/organization/services/organization-user.service.spec.ts
+++ b/apps/api/src/organization/services/organization-user.service.spec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { DataSource, Repository } from 'typeorm'
+import { EventEmitter2 } from '@nestjs/event-emitter'
+import { OrganizationUserService } from './organization-user.service'
+import { OrganizationRoleService } from './organization-role.service'
+import { UserService } from '../../user/user.service'
+import { OrganizationUser } from '../entities/organization-user.entity'
+import { OrganizationMemberRole } from '../enums/organization-member-role.enum'
+import { OrganizationEvents } from '../constants/organization-events.constant'
+import { OrganizationUserRemovedEvent } from '../events/organization-user-removed.event'
+
+describe('OrganizationUserService', () => {
+  let service: OrganizationUserService
+  let findOne: jest.Mock
+  let remove: jest.Mock
+  let count: jest.Mock
+  let emit: jest.Mock
+
+  beforeEach(() => {
+    findOne = jest.fn()
+    remove = jest.fn()
+    count = jest.fn().mockResolvedValue(2)
+    emit = jest.fn()
+    const repo = { findOne, manager: { remove, count } }
+    service = new OrganizationUserService(
+      repo as unknown as Repository<OrganizationUser>,
+      undefined as unknown as OrganizationRoleService,
+      undefined as unknown as UserService,
+      { emit, emitAsync: jest.fn() } as unknown as EventEmitter2,
+      undefined as unknown as DataSource,
+    )
+  })
+
+  describe('delete', () => {
+    it('emits USER_REMOVED(userId, organizationId) after the membership row is removed', async () => {
+      findOne.mockResolvedValue({
+        organizationId: 'org-1',
+        userId: 'user-1',
+        role: OrganizationMemberRole.OWNER,
+      } as unknown as OrganizationUser)
+
+      await service.delete('org-1', 'user-1')
+
+      expect(remove).toHaveBeenCalledTimes(1)
+      expect(emit).toHaveBeenCalledWith(
+        OrganizationEvents.USER_REMOVED,
+        expect.objectContaining({ userId: 'user-1', organizationId: 'org-1' }),
+      )
+      expect(emit.mock.calls[0][1]).toBeInstanceOf(OrganizationUserRemovedEvent)
+      // ordering matters: the eviction event must fire only after the removal has committed
+      expect(remove.mock.invocationCallOrder[0]).toBeLessThan(emit.mock.invocationCallOrder[0])
+    })
+
+    it('does not emit USER_REMOVED when the membership does not exist', async () => {
+      findOne.mockResolvedValue(null)
+
+      await expect(service.delete('org-1', 'user-1')).rejects.toThrow()
+      expect(emit).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/api/src/organization/services/organization-user.service.ts
+++ b/apps/api/src/organization/services/organization-user.service.ts
@@ -153,9 +153,10 @@ export class OrganizationUserService {
 
     // Membership is revoked: eject the user's live notification sockets from the organization room
     // so they stop receiving its realtime events. Emitted after the removal has committed (the
-    // repository manager autocommits) so a concurrent reconnect cannot re-join the room against a
-    // still-present row. Covers both admin removal and voluntary leave, which both route here.
-    this.eventEmitter.emit(OrganizationEvents.USER_REMOVED, new OrganizationUserRemovedEvent(organizationId, userId))
+    // repository manager autocommits) so the gateway's connect-time membership check
+    // (OrganizationUserService.exists) sees the row gone and a concurrent reconnect cannot re-join.
+    // Covers both admin removal and voluntary leave, which both route here.
+    this.eventEmitter.emit(OrganizationEvents.USER_REMOVED, new OrganizationUserRemovedEvent(userId, organizationId))
   }
 
   private async removeWithEntityManager(

--- a/apps/api/src/organization/services/organization-user.service.ts
+++ b/apps/api/src/organization/services/organization-user.service.ts
@@ -16,6 +16,7 @@ import { OrganizationMemberRole } from '../enums/organization-member-role.enum'
 import { OrganizationResourcePermission } from '../enums/organization-resource-permission.enum'
 import { OrganizationInvitationAcceptedEvent } from '../events/organization-invitation-accepted.event'
 import { OrganizationResourcePermissionsUnassignedEvent } from '../events/organization-resource-permissions-unassigned.event'
+import { OrganizationUserRemovedEvent } from '../events/organization-user-removed.event'
 import { OnAsyncEvent } from '../../common/decorators/on-async-event.decorator'
 import { UserService } from '../../user/user.service'
 import { UserEvents } from '../../user/constants/user-events.constant'
@@ -149,6 +150,15 @@ export class OrganizationUserService {
     }
 
     await this.removeWithEntityManager(this.organizationUserRepository.manager, organizationUser)
+
+    // Membership is revoked: eject the user's live notification sockets from the organization room
+    // so they stop receiving its realtime events. Emitted after the removal has committed (the
+    // repository manager autocommits) so a concurrent reconnect cannot re-join the room against a
+    // still-present row. Covers both admin removal and voluntary leave, which both route here.
+    this.eventEmitter.emit(
+      OrganizationEvents.USER_REMOVED,
+      new OrganizationUserRemovedEvent(organizationId, userId),
+    )
   }
 
   private async removeWithEntityManager(

--- a/apps/api/src/organization/services/organization-user.service.ts
+++ b/apps/api/src/organization/services/organization-user.service.ts
@@ -155,10 +155,7 @@ export class OrganizationUserService {
     // so they stop receiving its realtime events. Emitted after the removal has committed (the
     // repository manager autocommits) so a concurrent reconnect cannot re-join the room against a
     // still-present row. Covers both admin removal and voluntary leave, which both route here.
-    this.eventEmitter.emit(
-      OrganizationEvents.USER_REMOVED,
-      new OrganizationUserRemovedEvent(organizationId, userId),
-    )
+    this.eventEmitter.emit(OrganizationEvents.USER_REMOVED, new OrganizationUserRemovedEvent(organizationId, userId))
   }
 
   private async removeWithEntityManager(


### PR DESCRIPTION
## What
The notification WebSocket gateway authorizes the organization-room subscription only at connection time. A user removed from an organization (or who leaves) keeps receiving that org's realtime events on an already-open socket until it disconnects.

## Change
- Emit `OrganizationEvents.USER_REMOVED` after the membership row is removed in `OrganizationUserService.delete()` (covers admin removal and voluntary leave, which both route through it).
- `NotificationService` listens and drops the user's sockets from the org room via a new `evictUserFromOrganization` on the `NotificationEmitter` abstraction.
- Implemented on both the gateway (`socketsLeave` on the live `Server`) and the publish-only emitter (propagated to gateway instances over the Redis adapter), so it works whether or not `NOTIFICATION_GATEWAY_DISABLED` is set.

## Tests
Added `notification.service.spec.ts` covering the eviction wiring and best-effort failure handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending org notifications to users after their membership ends by evicting their WebSocket connections and blocking reconnects without membership. Works in both gateway and publish-only (`NOTIFICATION_GATEWAY_DISABLED`) deployments.

- **Bug Fixes**
  - Emit `OrganizationEvents.USER_REMOVED` after membership deletion in `OrganizationUserService.delete()`.
  - Gate API-key socket subscriptions on org membership at connect time.
  - `NotificationService` listens and calls `NotificationEmitter.evictUserFromOrganization(userId, orgId)`; errors are swallowed.
  - Eviction implemented in the gateway (`socketsLeave`) and Redis emitter to propagate across nodes; tests cover event emission, eviction, and failure handling.

<sup>Written for commit 2425479957ceb20faca20938dae08f4a5a6c01e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

