### PR TITLE
feat(docs): add datadog OTel instructions and dashboard example

### DIFF
--- a/apps/docs/src/content/docs/en/observability/otel-collection.mdx
+++ b/apps/docs/src/content/docs/en/observability/otel-collection.mdx
@@ -54,7 +54,7 @@ Sandbox telemetry collection works independently from SDK tracing. You can enabl
 - **SDK tracing only**: Monitor Daytona API operations and SDK calls
 - **Sandbox telemetry only**: Monitor application behavior inside sandboxes
 - **Both**: Get complete end-to-end observability across your entire stack
-:::
+  :::
 
 ### Configure Sandbox Collection
 
@@ -95,14 +95,14 @@ In addition to per-sandbox telemetry, Daytona exports organization-level resourc
 
 ### Exported Metrics
 
-| Metric | Unit | Description |
-| --- | --- | --- |
-| `daytona.sandbox.used_cpu` | cpu cores | Total CPU currently consumed by active sandboxes |
-| `daytona.sandbox.used_ram` | GiB | Total memory currently consumed by active sandboxes |
-| `daytona.sandbox.used_storage` | GiB | Total disk currently consumed by sandboxes |
-| `daytona.sandbox.total_cpu` | cpu cores | Total CPU quota for the organization |
-| `daytona.sandbox.total_ram` | GiB | Total memory quota for the organization |
-| `daytona.sandbox.total_storage` | GiB | Total disk quota for the organization |
+| Metric                          | Unit      | Description                                         |
+| ------------------------------- | --------- | --------------------------------------------------- |
+| `daytona.sandbox.used_cpu`      | cpu cores | Total CPU currently consumed by active sandboxes    |
+| `daytona.sandbox.used_ram`      | GiB       | Total memory currently consumed by active sandboxes |
+| `daytona.sandbox.used_storage`  | GiB       | Total disk currently consumed by sandboxes          |
+| `daytona.sandbox.total_cpu`     | cpu cores | Total CPU quota for the organization                |
+| `daytona.sandbox.total_ram`     | GiB       | Total memory quota for the organization             |
+| `daytona.sandbox.total_storage` | GiB       | Total disk quota for the organization               |
 
 ### Metric Attributes
 
@@ -285,6 +285,40 @@ OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <BASE64_ENCODED_CREDENTIALS>"
 ```
 
 Setup: Go to [Grafana Cloud Portal](https://grafana.com) → **Connections** → **Add new connection** → Search for **OpenTelemetry (OTLP)** → Follow the wizard to create an access token. The endpoint and headers will be provided in the instrumentation instructions. See the [Grafana dashboard example](https://github.com/daytonaio/daytona/tree/main/examples/otel-dashboards/grafana) for detailed setup steps.
+
+### Datadog
+
+Datadog exposes a native OTLP intake endpoint, so you can send telemetry directly — no Datadog Agent required.
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.datadoghq.com
+OTEL_EXPORTER_OTLP_HEADERS="dd-api-key=YOUR_DATADOG_API_KEY"
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+When configuring Datadog as your [sandbox collection endpoint](#configure-sandbox-collection) in the Dashboard, enter the OTLP endpoint for your Datadog site and add a single header `dd-api-key` with your Datadog API key:
+
+| Datadog Site          | OTLP Endpoint                    |
+| --------------------- | -------------------------------- |
+| US1 (`datadoghq.com`) | `https://otlp.datadoghq.com`     |
+| EU (`datadoghq.eu`)   | `https://otlp.datadoghq.eu`      |
+| US3                   | `https://otlp.us3.datadoghq.com` |
+| US5                   | `https://otlp.us5.datadoghq.com` |
+| AP1                   | `https://otlp.ap1.datadoghq.com` |
+
+Use the base endpoint without a `/v1/...` path — the path is appended automatically. Generate an API key under **Datadog → Organization Settings → API Keys**. See the [Datadog dashboard example](https://github.com/daytonaio/daytona/tree/main/examples/otel-dashboards/datadog) for an importable dashboard and verification steps.
+
+Once data is flowing, your metrics appear under **Metrics → Summary** (search for `daytona.sandbox`), where you can also confirm the exact tag keys (e.g. `service`, `region.id`) Datadog assigned.
+
+:::caution
+
+Datadog's OTLP intake has a few limitations to be aware of:
+
+- **Traces are in Preview** (not GA). Metrics and logs are generally available, but trace ingestion via OTLP may need to be enabled for your account by Datadog — contact your Datadog account team if traces don't appear.
+- **Direct OTLP intake uses HTTP/protobuf only** (no gRPC), so don't append a gRPC port such as `:4317` to the endpoint.
+- **Host metadata is not populated** in the Datadog Infrastructure Host List when sending directly to the OTLP intake endpoint.
+
+:::
 
 ---
 
@@ -515,6 +549,7 @@ Each trace includes valuable metadata such as:
 
 - [New Relic](https://github.com/daytonaio/daytona/tree/main/examples/otel-dashboards/new-relic)
 - [Grafana](https://github.com/daytonaio/daytona/tree/main/examples/otel-dashboards/grafana)
+- [Datadog](https://github.com/daytonaio/daytona/tree/main/examples/otel-dashboards/datadog)
 
 ## Troubleshooting
 

--- a/examples/otel-dashboards/datadog/README.md
+++ b/examples/otel-dashboards/datadog/README.md
@@ -1,0 +1,137 @@
+# Datadog Dashboard for Daytona Sandbox Monitoring
+
+This directory contains a pre-configured Datadog dashboard for monitoring Daytona Sandbox resources (CPU, Memory, Disk) and organization-level quota usage. Metrics are ingested into Datadog via OpenTelemetry (`daytona.sandbox.*`).
+
+## Dashboard Overview
+
+The dashboard is organized into collapsible groups (one per topic):
+
+- **Resource Overview**: High-level view of all sandboxes with aggregate metrics
+- **CPU Details**: Detailed CPU utilization, limits, and a usage heatmap
+- **Memory Details**: Memory usage patterns and limits
+- **Disk Details**: Filesystem usage and space breakdown
+- **Organization Quotas**: Organization-level resource usage vs. quota, by region
+
+## Prerequisites
+
+- A Datadog account with permission to create dashboards
+- A Datadog API key (for sending telemetry — see "Sending Data to Datadog" below)
+- Daytona telemetry flowing into Datadog (see [OpenTelemetry Collection docs](https://www.daytona.io/docs/en/observability/otel-collection/))
+
+## Sending Data to Datadog
+
+Datadog exposes a native OTLP intake endpoint, so you can point Daytona's OTLP destination directly at it — no Datadog Agent required.
+
+1. In the [Daytona Dashboard](https://app.daytona.io), go to **Settings** → **OpenTelemetry** (organization owners only).
+2. Configure the destination:
+   - **OTLP Endpoint**: your Datadog site's OTLP intake URL
+     - US1: `https://otlp.datadoghq.com`
+     - EU: `https://otlp.datadoghq.eu`
+     - US3: `https://otlp.us3.datadoghq.com`
+     - US5: `https://otlp.us5.datadoghq.com`
+     - AP1: `https://otlp.ap1.datadoghq.com`
+   - **Headers**: add `dd-api-key` = `<YOUR_DATADOG_API_KEY>`
+
+> **Note**
+> Datadog's OTLP **metrics** intake requires **delta** temporality for cumulative metric types (counters, histograms). Daytona's sandbox and organization metrics are all **gauges**, so they are accepted as-is. If you also export your own cumulative application metrics from inside sandboxes, configure your SDK to use delta temporality (`OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`). OTLP **traces** intake is in Preview at Datadog and may require enabling for your account.
+
+### How OTel attributes map to Datadog tags
+
+- `service.name` → the reserved **`service`** tag (used to group/filter sandboxes)
+- `region.id` → the **`region.id`** tag (used on the Organization Quotas page)
+- `organization.id` → the **`organization.id`** tag
+
+If a tag doesn't resolve in the dashboard, open **Metrics → Summary**, search for `daytona.sandbox.cpu.utilization`, and confirm the exact tag keys Datadog assigned — then adjust the template variables/queries to match.
+
+## Importing the Dashboard
+
+### Via the Web UI
+
+1. Go to **Dashboards** → **New Dashboard**.
+2. Give it any name, then open the dashboard's settings (gear icon, top right) → **Import dashboard JSON**.
+   - Alternatively, on the **Dashboard List** page, use the **New Dashboard** dropdown → **Import Dashboard JSON file** and upload `dashboard.json`.
+3. Paste the contents of `dashboard.json` (or upload the file) and confirm the import.
+4. Save. The dashboard will be named **"Daytona Sandbox Resource Monitoring"**.
+
+### Via the API
+
+```bash
+curl -X POST "https://api.datadoghq.com/api/v1/dashboard" \
+  -H "Content-Type: application/json" \
+  -H "DD-API-KEY: ${DD_API_KEY}" \
+  -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+  -d @dashboard.json
+```
+
+Use the API host matching your Datadog site (e.g. `api.datadoghq.eu`, `api.us3.datadoghq.com`).
+
+## Template Variables
+
+The dashboard ships with two template variables for filtering:
+
+- **`$service`** — filter by the `service` tag (individual sandbox). Default: `*` (all).
+- **`$region`** — filter by the `region.id` tag (used on the Organization Quotas page). Default: `*` (all).
+
+## Alert Thresholds
+
+The overview tiles and per-resource lists are color-coded with these thresholds:
+
+- **CPU**: Warning at 70%, Critical at 85%
+- **Memory**: Warning at 80%, Critical at 90%
+- **Disk**: Warning at 75%, Critical at 85%
+
+## Metrics Tracked
+
+Per-sandbox metrics (prefixed with `daytona.sandbox.`):
+
+| Metric | Unit | Description |
+| --- | --- | --- |
+| `cpu.utilization` | percent | CPU usage percentage (0–100) |
+| `cpu.limit` | cores | CPU cores limit |
+| `memory.utilization` | percent | Memory usage percentage (0–100) |
+| `memory.usage` | bytes | Memory used |
+| `memory.limit` | bytes | Memory limit |
+| `filesystem.utilization` | percent | Disk usage percentage (0–100) |
+| `filesystem.usage` | bytes | Disk space used |
+| `filesystem.available` | bytes | Disk space available |
+| `filesystem.total` | bytes | Total disk space |
+
+Organization-level quota metrics (also prefixed with `daytona.sandbox.`, tagged by `region.id`):
+
+| Metric | Unit | Description |
+| --- | --- | --- |
+| `used_cpu` / `total_cpu` | cores | CPU consumed / quota |
+| `used_ram` / `total_ram` | GiB | Memory consumed / quota |
+| `used_storage` / `total_storage` | GiB | Storage consumed / quota |
+
+> Memory/disk byte metrics are divided by `1073741824` in the dashboard to display GB.
+
+## Troubleshooting
+
+### No data in widgets
+
+1. Confirm telemetry is reaching Datadog: **Metrics → Summary**, search `daytona.sandbox`.
+2. Check the OTLP endpoint matches your Datadog **site** and the `dd-api-key` header is set.
+3. Verify the `service` / `region.id` tags exist on the metrics (tag keys can differ depending on your collector's attribute mapping). Adjust template variables/queries if needed.
+4. Widen the dashboard time range — sandbox metrics are emitted periodically.
+
+### Import fails
+
+1. Validate the JSON: `jq . dashboard.json`.
+2. Ensure you're pasting into **Import dashboard JSON** (not the raw widget editor).
+
+## Customization
+
+To modify the dashboard:
+
+1. Import it into Datadog.
+2. Edit widgets through the UI.
+3. Export via the dashboard settings (gear) → **Export dashboard JSON**.
+4. Replace `dashboard.json` with your customized version.
+
+## Additional Resources
+
+- [Datadog OpenTelemetry Documentation](https://docs.datadoghq.com/opentelemetry/)
+- [Datadog OTLP Ingestion](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest/)
+- [Datadog Dashboards Documentation](https://docs.datadoghq.com/dashboards/)
+- [Daytona OpenTelemetry Collection](https://www.daytona.io/docs/en/observability/otel-collection/)

--- a/examples/otel-dashboards/datadog/dashboard.json
+++ b/examples/otel-dashboards/datadog/dashboard.json
@@ -1,0 +1,982 @@
+{
+  "title": "Daytona Sandbox Resource Monitoring",
+  "description": "Comprehensive CPU, Memory, and Disk monitoring for Daytona Sandboxes, plus organization-level quota usage. Metrics are ingested via OpenTelemetry (daytona.sandbox.*).",
+  "widgets": [
+    {
+      "definition": {
+        "title": "Resource Overview",
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "title": "Active Sandboxes",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "count_not_null(query1)" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:daytona.sandbox.cpu.utilization{$service} by {service}",
+                      "aggregator": "last"
+                    }
+                  ],
+                  "response_format": "scalar"
+                }
+              ],
+              "autoscale": true,
+              "precision": 0
+            }
+          },
+          {
+            "definition": {
+              "title": "Peak CPU %",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "max:daytona.sandbox.cpu.utilization{$service}",
+                      "aggregator": "max"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "conditional_formats": [
+                    { "comparator": ">=", "value": 85, "palette": "white_on_red" },
+                    { "comparator": ">=", "value": 70, "palette": "white_on_yellow" },
+                    { "comparator": "<", "value": 70, "palette": "white_on_green" }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 1
+            }
+          },
+          {
+            "definition": {
+              "title": "Peak Memory %",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "max:daytona.sandbox.memory.utilization{$service}",
+                      "aggregator": "max"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "conditional_formats": [
+                    { "comparator": ">=", "value": 90, "palette": "white_on_red" },
+                    { "comparator": ">=", "value": 80, "palette": "white_on_yellow" },
+                    { "comparator": "<", "value": 80, "palette": "white_on_green" }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 1
+            }
+          },
+          {
+            "definition": {
+              "title": "Peak Disk %",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "max:daytona.sandbox.filesystem.utilization{$service}",
+                      "aggregator": "max"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "conditional_formats": [
+                    { "comparator": ">=", "value": 85, "palette": "white_on_red" },
+                    { "comparator": ">=", "value": 75, "palette": "white_on_yellow" },
+                    { "comparator": "<", "value": 75, "palette": "white_on_green" }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 1
+            }
+          },
+          {
+            "definition": {
+              "title": "Services Resource Overview",
+              "type": "query_table",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "cpu",
+                      "query": "avg:daytona.sandbox.cpu.utilization{$service} by {service}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "cpu_limit",
+                      "query": "avg:daytona.sandbox.cpu.limit{$service} by {service}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "mem",
+                      "query": "avg:daytona.sandbox.memory.utilization{$service} by {service}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "mem_usage",
+                      "query": "avg:daytona.sandbox.memory.usage{$service} by {service}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "mem_limit",
+                      "query": "avg:daytona.sandbox.memory.limit{$service} by {service}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "disk",
+                      "query": "avg:daytona.sandbox.filesystem.utilization{$service} by {service}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "disk_usage",
+                      "query": "avg:daytona.sandbox.filesystem.usage{$service} by {service}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "disk_total",
+                      "query": "avg:daytona.sandbox.filesystem.total{$service} by {service}",
+                      "aggregator": "last"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "formulas": [
+                    { "formula": "cpu", "alias": "CPU %" },
+                    { "formula": "cpu_limit", "alias": "CPU Cores" },
+                    { "formula": "mem", "alias": "Memory %" },
+                    { "formula": "mem_usage / 1073741824", "alias": "Memory Used (GB)" },
+                    { "formula": "mem_limit / 1073741824", "alias": "Memory Limit (GB)" },
+                    { "formula": "disk", "alias": "Disk %" },
+                    { "formula": "disk_usage / 1073741824", "alias": "Disk Used (GB)" },
+                    { "formula": "disk_total / 1073741824", "alias": "Disk Total (GB)" }
+                  ]
+                }
+              ],
+              "has_search_bar": "auto"
+            }
+          },
+          {
+            "definition": {
+              "title": "CPU Utilization by Service",
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:daytona.sandbox.cpu.utilization{$service} by {service}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "line",
+                  "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+                }
+              ],
+              "yaxis": { "min": "0", "max": "100" }
+            }
+          },
+          {
+            "definition": {
+              "title": "Memory Utilization by Service",
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:daytona.sandbox.memory.utilization{$service} by {service}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "line",
+                  "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+                }
+              ],
+              "yaxis": { "min": "0", "max": "100" }
+            }
+          },
+          {
+            "definition": {
+              "title": "Disk Utilization by Service",
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:daytona.sandbox.filesystem.utilization{$service} by {service}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "line",
+                  "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+                }
+              ],
+              "yaxis": { "min": "0", "max": "100" }
+            }
+          },
+          {
+            "definition": {
+              "title": "Top CPU Consumers",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1", "limit": { "count": 10, "order": "desc" } }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:daytona.sandbox.cpu.utilization{$service} by {service}",
+                      "aggregator": "avg"
+                    }
+                  ],
+                  "response_format": "scalar"
+                }
+              ]
+            }
+          },
+          {
+            "definition": {
+              "title": "Top Memory Consumers",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1", "limit": { "count": 10, "order": "desc" } }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:daytona.sandbox.memory.utilization{$service} by {service}",
+                      "aggregator": "avg"
+                    }
+                  ],
+                  "response_format": "scalar"
+                }
+              ]
+            }
+          },
+          {
+            "definition": {
+              "title": "Top Disk Consumers",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1", "limit": { "count": 10, "order": "desc" } }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:daytona.sandbox.filesystem.utilization{$service} by {service}",
+                      "aggregator": "avg"
+                    }
+                  ],
+                  "response_format": "scalar"
+                }
+              ]
+            }
+          },
+          {
+            "definition": {
+              "title": "Resource Pressure Score",
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "(cpu * 0.33) + (mem * 0.33) + (disk * 0.34)" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "cpu",
+                      "query": "avg:daytona.sandbox.cpu.utilization{$service} by {service}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "mem",
+                      "query": "avg:daytona.sandbox.memory.utilization{$service} by {service}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "disk",
+                      "query": "avg:daytona.sandbox.filesystem.utilization{$service} by {service}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "line",
+                  "style": { "palette": "warm", "line_type": "solid", "line_width": "normal" }
+                }
+              ],
+              "yaxis": { "min": "0", "max": "100" }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "definition": {
+        "title": "CPU Details",
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "title": "CPU Utilization Timeseries",
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:daytona.sandbox.cpu.utilization{$service} by {service}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "line",
+                  "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+                }
+              ],
+              "yaxis": { "min": "0", "max": "100" }
+            }
+          },
+          {
+            "definition": {
+              "title": "Current CPU by Service",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 25, "order": "desc" },
+                      "conditional_formats": [
+                        { "comparator": ">=", "value": 85, "palette": "white_on_red" },
+                        { "comparator": ">=", "value": 70, "palette": "white_on_yellow" },
+                        { "comparator": "<", "value": 70, "palette": "white_on_green" }
+                      ]
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:daytona.sandbox.cpu.utilization{$service} by {service}",
+                      "aggregator": "last"
+                    }
+                  ],
+                  "response_format": "scalar"
+                }
+              ]
+            }
+          },
+          {
+            "definition": {
+              "title": "CPU Limit / Avg / Peak by Service",
+              "type": "query_table",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "cpu_limit",
+                      "query": "avg:daytona.sandbox.cpu.limit{$service} by {service}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "cpu_avg",
+                      "query": "avg:daytona.sandbox.cpu.utilization{$service} by {service}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "cpu_peak",
+                      "query": "max:daytona.sandbox.cpu.utilization{$service} by {service}",
+                      "aggregator": "max"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "formulas": [
+                    { "formula": "cpu_limit", "alias": "CPU Cores Limit" },
+                    { "formula": "cpu_avg", "alias": "Avg CPU %" },
+                    { "formula": "cpu_peak", "alias": "Peak CPU %" }
+                  ]
+                }
+              ],
+              "has_search_bar": "auto"
+            }
+          },
+          {
+            "definition": {
+              "title": "CPU Usage Heatmap",
+              "type": "heatmap",
+              "requests": [
+                { "q": "avg:daytona.sandbox.cpu.utilization{$service} by {service}", "style": { "palette": "dog_classic" } }
+              ],
+              "yaxis": { "min": "0", "max": "100" }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "definition": {
+        "title": "Memory Details",
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "title": "Memory Utilization Timeseries",
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:daytona.sandbox.memory.utilization{$service} by {service}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "line",
+                  "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+                }
+              ],
+              "yaxis": { "min": "0", "max": "100" }
+            }
+          },
+          {
+            "definition": {
+              "title": "Current Memory by Service",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 25, "order": "desc" },
+                      "conditional_formats": [
+                        { "comparator": ">=", "value": 90, "palette": "white_on_red" },
+                        { "comparator": ">=", "value": 80, "palette": "white_on_yellow" },
+                        { "comparator": "<", "value": 80, "palette": "white_on_green" }
+                      ]
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:daytona.sandbox.memory.utilization{$service} by {service}",
+                      "aggregator": "last"
+                    }
+                  ],
+                  "response_format": "scalar"
+                }
+              ]
+            }
+          },
+          {
+            "definition": {
+              "title": "Memory Usage in GB",
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1 / 1073741824" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:daytona.sandbox.memory.usage{$service} by {service}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "area",
+                  "style": { "palette": "cool", "line_type": "solid", "line_width": "normal" }
+                }
+              ]
+            }
+          },
+          {
+            "definition": {
+              "title": "Memory Limits and Usage",
+              "type": "query_table",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "mem_usage",
+                      "query": "avg:daytona.sandbox.memory.usage{$service} by {service}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "mem_limit",
+                      "query": "avg:daytona.sandbox.memory.limit{$service} by {service}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "mem_avg",
+                      "query": "avg:daytona.sandbox.memory.utilization{$service} by {service}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "mem_peak",
+                      "query": "max:daytona.sandbox.memory.utilization{$service} by {service}",
+                      "aggregator": "max"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "formulas": [
+                    { "formula": "mem_usage / 1073741824", "alias": "Used (GB)" },
+                    { "formula": "mem_limit / 1073741824", "alias": "Limit (GB)" },
+                    { "formula": "mem_avg", "alias": "Avg %" },
+                    { "formula": "mem_peak", "alias": "Peak %" }
+                  ]
+                }
+              ],
+              "has_search_bar": "auto"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "definition": {
+        "title": "Disk Details",
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "title": "Disk Utilization Timeseries",
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:daytona.sandbox.filesystem.utilization{$service} by {service}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "line",
+                  "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+                }
+              ],
+              "yaxis": { "min": "0", "max": "100" }
+            }
+          },
+          {
+            "definition": {
+              "title": "Current Disk by Service",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 25, "order": "desc" },
+                      "conditional_formats": [
+                        { "comparator": ">=", "value": 85, "palette": "white_on_red" },
+                        { "comparator": ">=", "value": 75, "palette": "white_on_yellow" },
+                        { "comparator": "<", "value": 75, "palette": "white_on_green" }
+                      ]
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:daytona.sandbox.filesystem.utilization{$service} by {service}",
+                      "aggregator": "last"
+                    }
+                  ],
+                  "response_format": "scalar"
+                }
+              ]
+            }
+          },
+          {
+            "definition": {
+              "title": "Disk Usage in GB",
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    { "formula": "used / 1073741824", "alias": "Used GB" },
+                    { "formula": "total / 1073741824", "alias": "Total GB" }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "used",
+                      "query": "avg:daytona.sandbox.filesystem.usage{$service} by {service}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "total",
+                      "query": "avg:daytona.sandbox.filesystem.total{$service} by {service}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "area",
+                  "style": { "palette": "cool", "line_type": "solid", "line_width": "normal" }
+                }
+              ]
+            }
+          },
+          {
+            "definition": {
+              "title": "Disk Space Breakdown",
+              "type": "query_table",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "disk_usage",
+                      "query": "avg:daytona.sandbox.filesystem.usage{$service} by {service}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "disk_avail",
+                      "query": "avg:daytona.sandbox.filesystem.available{$service} by {service}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "disk_total",
+                      "query": "avg:daytona.sandbox.filesystem.total{$service} by {service}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "disk_avg",
+                      "query": "avg:daytona.sandbox.filesystem.utilization{$service} by {service}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "disk_peak",
+                      "query": "max:daytona.sandbox.filesystem.utilization{$service} by {service}",
+                      "aggregator": "max"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "formulas": [
+                    { "formula": "disk_usage / 1073741824", "alias": "Used (GB)" },
+                    { "formula": "disk_avail / 1073741824", "alias": "Available (GB)" },
+                    { "formula": "disk_total / 1073741824", "alias": "Total (GB)" },
+                    { "formula": "disk_avg", "alias": "Avg %" },
+                    { "formula": "disk_peak", "alias": "Peak %" }
+                  ]
+                }
+              ],
+              "has_search_bar": "auto"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "definition": {
+        "title": "Organization Quotas",
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "title": "CPU Usage vs Quota by Region",
+              "type": "query_table",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "used",
+                      "query": "avg:daytona.sandbox.used_cpu{$region} by {region.id}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "total",
+                      "query": "avg:daytona.sandbox.total_cpu{$region} by {region.id}",
+                      "aggregator": "last"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "formulas": [
+                    { "formula": "used", "alias": "Used CPU" },
+                    { "formula": "total", "alias": "Total CPU" },
+                    { "formula": "(used / total) * 100", "alias": "Quota %" }
+                  ]
+                }
+              ],
+              "has_search_bar": "auto"
+            }
+          },
+          {
+            "definition": {
+              "title": "Memory Usage vs Quota by Region",
+              "type": "query_table",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "used",
+                      "query": "avg:daytona.sandbox.used_ram{$region} by {region.id}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "total",
+                      "query": "avg:daytona.sandbox.total_ram{$region} by {region.id}",
+                      "aggregator": "last"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "formulas": [
+                    { "formula": "used", "alias": "Used RAM (GiB)" },
+                    { "formula": "total", "alias": "Total RAM (GiB)" },
+                    { "formula": "(used / total) * 100", "alias": "Quota %" }
+                  ]
+                }
+              ],
+              "has_search_bar": "auto"
+            }
+          },
+          {
+            "definition": {
+              "title": "Storage Usage vs Quota by Region",
+              "type": "query_table",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "used",
+                      "query": "avg:daytona.sandbox.used_storage{$region} by {region.id}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "total",
+                      "query": "avg:daytona.sandbox.total_storage{$region} by {region.id}",
+                      "aggregator": "last"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "formulas": [
+                    { "formula": "used", "alias": "Used Storage (GiB)" },
+                    { "formula": "total", "alias": "Total Storage (GiB)" },
+                    { "formula": "(used / total) * 100", "alias": "Quota %" }
+                  ]
+                }
+              ],
+              "has_search_bar": "auto"
+            }
+          },
+          {
+            "definition": {
+              "title": "CPU Quota Utilization Over Time",
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "(used / total) * 100" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "used",
+                      "query": "avg:daytona.sandbox.used_cpu{$region} by {region.id}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "total",
+                      "query": "avg:daytona.sandbox.total_cpu{$region} by {region.id}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "line",
+                  "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+                }
+              ],
+              "yaxis": { "min": "0", "max": "100" }
+            }
+          },
+          {
+            "definition": {
+              "title": "Memory Quota Utilization Over Time",
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "(used / total) * 100" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "used",
+                      "query": "avg:daytona.sandbox.used_ram{$region} by {region.id}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "total",
+                      "query": "avg:daytona.sandbox.total_ram{$region} by {region.id}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "line",
+                  "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+                }
+              ],
+              "yaxis": { "min": "0", "max": "100" }
+            }
+          },
+          {
+            "definition": {
+              "title": "Storage Quota Utilization Over Time",
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "(used / total) * 100" }],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "used",
+                      "query": "avg:daytona.sandbox.used_storage{$region} by {region.id}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "total",
+                      "query": "avg:daytona.sandbox.total_storage{$region} by {region.id}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "line",
+                  "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+                }
+              ],
+              "yaxis": { "min": "0", "max": "100" }
+            }
+          },
+          {
+            "definition": {
+              "title": "Organization Resource Summary",
+              "type": "query_table",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "used_cpu",
+                      "query": "avg:daytona.sandbox.used_cpu{$region} by {region.id}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "total_cpu",
+                      "query": "avg:daytona.sandbox.total_cpu{$region} by {region.id}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "used_ram",
+                      "query": "avg:daytona.sandbox.used_ram{$region} by {region.id}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "total_ram",
+                      "query": "avg:daytona.sandbox.total_ram{$region} by {region.id}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "used_storage",
+                      "query": "avg:daytona.sandbox.used_storage{$region} by {region.id}",
+                      "aggregator": "last"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "total_storage",
+                      "query": "avg:daytona.sandbox.total_storage{$region} by {region.id}",
+                      "aggregator": "last"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "formulas": [
+                    { "formula": "used_cpu", "alias": "Used CPU" },
+                    { "formula": "total_cpu", "alias": "Total CPU" },
+                    { "formula": "used_ram", "alias": "Used RAM (GiB)" },
+                    { "formula": "total_ram", "alias": "Total RAM (GiB)" },
+                    { "formula": "used_storage", "alias": "Used Storage (GiB)" },
+                    { "formula": "total_storage", "alias": "Total Storage (GiB)" }
+                  ]
+                }
+              ],
+              "has_search_bar": "auto"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "template_variables": [
+    {
+      "name": "service",
+      "prefix": "service",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "region",
+      "prefix": "region.id",
+      "available_values": [],
+      "default": "*"
+    }
+  ],
+  "layout_type": "ordered",
+  "notify_list": [],
+  "reflow_type": "auto",
+  "tags": []
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Datadog OTLP setup to the OTel collection docs and an importable Datadog dashboard to monitor Daytona sandbox metrics and org quotas.

- **New Features**
  - Docs: Added Datadog configuration with `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS` (`dd-api-key`), `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`, and site-specific endpoints (US1/EU/US3/US5/AP1); clarified to omit `/v1/...`.
  - Docs: Added caveats for Datadog OTLP intake (traces Preview, HTTP/protobuf only, no host metadata) and a link to the Datadog example.
  - Dashboard: New `examples/otel-dashboards/datadog/` with `dashboard.json` and a README covering UI/API import, template vars (`$service`, `$region`), thresholds, and tag mapping.
  - Docs polish: Aligned the exported metrics table for readability.

<sup>Written for commit bcb0de380dc56e934e75701b22fcebdb946ee34e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

