### PR TITLE
feat(dashboard): otel config notice & alignment tweaks

### DIFF
--- a/apps/dashboard/src/components/Organizations/OtelConfigCard.tsx
+++ b/apps/dashboard/src/components/Organizations/OtelConfigCard.tsx
@@ -5,7 +5,7 @@
 
 import TooltipButton from '@/components/TooltipButton'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Field, FieldContent, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
@@ -200,7 +200,7 @@ export const OtelConfigCard: React.FC = () => {
             </form.Field>
           </div>
 
-          <div className="border-b border-border p-4 last:border-b-0">
+          <div className="p-4">
             <form.Field name="headers" validators={headersValidators}>
               {(field) => {
                 const hasErrors = field.state.meta.errors.length > 0
@@ -260,32 +260,40 @@ export const OtelConfigCard: React.FC = () => {
             </form.Field>
           </div>
 
-          <div className="flex justify-end gap-2 p-4">
-            {hasOtelEnabled && (
+          <CardFooter className="flex items-center justify-between gap-2">
+            <p className="min-w-0 text-sm text-muted-foreground text-pretty">Changes take up to 5 minutes to apply.</p>
+            <div className="ml-auto flex shrink-0 gap-2">
+              {hasOtelEnabled && (
+                <form.Subscribe
+                  selector={(state) => state.isSubmitting}
+                  children={(isSubmitting) => (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={handleDisable}
+                      disabled={isSubmitting || disabling}
+                    >
+                      {disabling && <Spinner />}
+                      Disable
+                    </Button>
+                  )}
+                />
+              )}
               <form.Subscribe
-                selector={(state) => state.isSubmitting}
-                children={(isSubmitting) => (
-                  <Button type="button" variant="outline" onClick={handleDisable} disabled={isSubmitting || disabling}>
-                    {disabling && <Spinner />}
-                    Disable
+                selector={(state) => [state.canSubmit, state.isSubmitting]}
+                children={([canSubmit, isSubmitting]) => (
+                  <Button
+                    type="submit"
+                    form="otel-config-form"
+                    disabled={!canSubmit || isSubmitting || saving || disabling}
+                  >
+                    {(isSubmitting || saving) && <Spinner />}
+                    Save
                   </Button>
                 )}
               />
-            )}
-            <form.Subscribe
-              selector={(state) => [state.canSubmit, state.isSubmitting]}
-              children={([canSubmit, isSubmitting]) => (
-                <Button
-                  type="submit"
-                  form="otel-config-form"
-                  disabled={!canSubmit || isSubmitting || saving || disabling}
-                >
-                  {(isSubmitting || saving) && <Spinner />}
-                  Save
-                </Button>
-              )}
-            />
-          </div>
+            </div>
+          </CardFooter>
         </form>
       </CardContent>
     </Card>

--- a/apps/dashboard/src/pages/Wallet.tsx
+++ b/apps/dashboard/src/pages/Wallet.tsx
@@ -464,10 +464,10 @@ const Wallet = () => {
                     </div>
                   </div>
                 </CardContent>
-                <CardFooter className="flex justify-between gap-2">
-                  <div className="flex items-center gap-2 text-muted-foreground">
-                    <InfoIcon className="w-4 h-4 shrink-0" />{' '}
-                    <span className="text-sm ">Setting both values to 0 will disable automatic top-ups.</span>
+                <CardFooter className="flex items-center justify-between gap-2">
+                  <div className="flex min-w-0 items-start gap-2 text-muted-foreground text-pretty">
+                    <InfoIcon className="mt-0.5 w-4 h-4 shrink-0" />
+                    <span className="text-sm">Setting both values to 0 will disable automatic top-ups.</span>
                   </div>
                   <div className="flex gap-2 items-center ml-auto">
                     <Button onClick={handleSetAutomaticTopUp} disabled={automaticTopUpSaveDisabled}>
@@ -544,16 +544,16 @@ const Wallet = () => {
                   </div>
                 </div>
               </CardContent>
-              <CardFooter className="flex justify-between gap-2">
+              <CardFooter className="flex items-center justify-between gap-2">
                 {paymentMethodsLoading ? (
                   <Skeleton className="h-4 w-64 max-w-full" />
                 ) : showMissingPaymentMethodTopUpMessage ? (
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    <CreditCardIcon className="w-4 h-4 shrink-0" />
+                  <div className="flex min-w-0 items-start gap-2 text-sm text-muted-foreground text-pretty">
+                    <CreditCardIcon className="mt-0.5 w-4 h-4 shrink-0" />
                     <span>Add a payment method to top up.</span>
                   </div>
                 ) : (
-                  <div className="text-sm text-muted-foreground">
+                  <div className="min-w-0 text-sm text-muted-foreground text-pretty">
                     You will be redirected to Stripe to complete the payment.
                   </div>
                 )}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a notice to the OTEL settings card and tightened footer layouts for better alignment and wrapping in OTEL and Wallet screens.

- **New Features**
  - Added a footer notice in `OtelConfigCard`: “Changes take up to 5 minutes to apply.”

- **Refactors**
  - Moved OTEL actions into `CardFooter`, aligned buttons, and removed a redundant content divider; improved wrapping with `min-w-0` and `text-pretty`.
  - Adjusted Wallet footers for icon/text alignment and clearer wrapping. No behavior changes.

<sup>Written for commit c9523a2c937f66e345557c304d4112ff1309adc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

