### PR TITLE
fix(api): retry failed system default snapshot

### DIFF
--- a/apps/api/src/app.service.ts
+++ b/apps/api/src/app.service.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Injectable, Logger, OnApplicationBootstrap, OnApplicationShutdown } from '@nestjs/common'
+import { Injectable, Logger, NotFoundException, OnApplicationBootstrap, OnApplicationShutdown } from '@nestjs/common'
 import { DockerRegistryService } from './docker-registry/services/docker-registry.service'
 import { RegistryType } from './docker-registry/enums/registry-type.enum'
 import { OrganizationService } from './organization/services/organization.service'
@@ -20,6 +20,8 @@ import { RunnerAdapterFactory } from './sandbox/runner-adapter/runnerAdapter'
 import { RegionType } from './region/enums/region-type.enum'
 import { RunnerState } from './sandbox/enums/runner-state.enum'
 import { OrganizationResourcePermission } from './organization/enums/organization-resource-permission.enum'
+import { SnapshotState } from './sandbox/enums/snapshot-state.enum'
+import { Snapshot } from './sandbox/entities/snapshot.entity'
 
 export const DAYTONA_ADMIN_USER_ID = 'daytona-admin'
 
@@ -315,20 +317,25 @@ Admin user created with API key: ${value}
 
   private async initializeDefaultSnapshot(): Promise<void> {
     const adminPersonalOrg = await this.organizationService.findPersonal(DAYTONA_ADMIN_USER_ID)
+    const defaultSnapshot = this.configService.getOrThrow('defaultSnapshot')
+    let existingSnapshot: Snapshot | undefined
 
     try {
-      const existingSnapshot = await this.snapshotService.getSnapshotByName(
-        this.configService.getOrThrow('defaultSnapshot'),
-        adminPersonalOrg.id,
-      )
-      if (existingSnapshot) {
-        return
+      existingSnapshot = await this.snapshotService.getSnapshotByName(defaultSnapshot, adminPersonalOrg.id)
+    } catch (error) {
+      if (!(error instanceof NotFoundException)) {
+        throw error
       }
-    } catch {
       this.logger.log('Default snapshot not found, creating...')
     }
 
-    const defaultSnapshot = this.configService.getOrThrow('defaultSnapshot')
+    if (existingSnapshot) {
+      if ([SnapshotState.ERROR, SnapshotState.BUILD_FAILED].includes(existingSnapshot.state)) {
+        this.logger.warn(`Default snapshot is in ${existingSnapshot.state} state, retrying...`)
+        await this.snapshotService.retryFailedSnapshot(existingSnapshot.id)
+      }
+      return
+    }
 
     await this.snapshotService.createFromPull(
       adminPersonalOrg,

--- a/apps/api/src/sandbox/services/snapshot.service.spec.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.spec.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { BadRequestException, NotFoundException } from '@nestjs/common'
+import { SnapshotEvents } from '../constants/snapshot-events'
+import { SnapshotState } from '../enums/snapshot-state.enum'
+import { SnapshotService } from './snapshot.service'
+
+describe('SnapshotService.retryFailedSnapshot', () => {
+  const snapshotRepository = {
+    findOne: jest.fn(),
+    update: jest.fn(),
+  }
+  const eventEmitter = {
+    emit: jest.fn(),
+  }
+  const service = new SnapshotService(
+    {} as any,
+    snapshotRepository as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    eventEmitter as any,
+    {} as any,
+  )
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('resets a failed pull snapshot and emits a created event', async () => {
+    const snapshot = {
+      id: 'snapshot-1',
+      state: SnapshotState.ERROR,
+      errorReason: 'registry timeout',
+      initialRunnerId: 'runner-1',
+      ref: 'registry/snapshot@sha256:digest',
+      size: 1,
+    }
+    const retriedSnapshot = {
+      ...snapshot,
+      state: SnapshotState.PENDING,
+      errorReason: null,
+      initialRunnerId: null,
+      ref: null,
+      size: null,
+    }
+    snapshotRepository.findOne.mockResolvedValue(snapshot)
+    snapshotRepository.update.mockResolvedValue(retriedSnapshot)
+
+    await expect(service.retryFailedSnapshot(snapshot.id)).resolves.toBe(retriedSnapshot)
+    expect(snapshotRepository.update).toHaveBeenCalledWith(snapshot.id, {
+      updateData: {
+        state: SnapshotState.PENDING,
+        errorReason: null,
+        initialRunnerId: null,
+        ref: null,
+        size: null,
+      },
+      entity: snapshot,
+    })
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      SnapshotEvents.CREATED,
+      expect.objectContaining({ snapshot: retriedSnapshot }),
+    )
+  })
+
+  it('preserves build metadata when retrying a failed build snapshot', async () => {
+    const snapshot = {
+      id: 'snapshot-1',
+      state: SnapshotState.BUILD_FAILED,
+      errorReason: 'build timeout',
+      initialRunnerId: 'runner-1',
+      ref: 'registry/build@sha256:digest',
+      size: 1,
+      buildInfo: { id: 'build-1' },
+    }
+    snapshotRepository.findOne.mockResolvedValue(snapshot)
+    snapshotRepository.update.mockResolvedValue({ ...snapshot, state: SnapshotState.PENDING })
+
+    await service.retryFailedSnapshot(snapshot.id)
+
+    expect(snapshotRepository.update).toHaveBeenCalledWith(snapshot.id, {
+      updateData: {
+        state: SnapshotState.PENDING,
+        errorReason: null,
+        initialRunnerId: null,
+      },
+      entity: snapshot,
+    })
+  })
+
+  it('rejects snapshots that do not exist or are not failed', async () => {
+    snapshotRepository.findOne.mockResolvedValueOnce(null)
+    await expect(service.retryFailedSnapshot('missing')).rejects.toThrow(NotFoundException)
+
+    snapshotRepository.findOne.mockResolvedValueOnce({
+      id: 'snapshot-1',
+      state: SnapshotState.ACTIVE,
+    })
+    await expect(service.retryFailedSnapshot('snapshot-1')).rejects.toThrow(BadRequestException)
+  })
+})

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -449,6 +449,41 @@ export class SnapshotService {
     await this.snapshotRepository.update(snapshotId, { updateData, entity: snapshot })
   }
 
+  async retryFailedSnapshot(snapshotId: string): Promise<Snapshot> {
+    const snapshot = await this.snapshotRepository.findOne({
+      where: { id: snapshotId },
+    })
+
+    if (!snapshot) {
+      throw new NotFoundException(`Snapshot ${snapshotId} not found`)
+    }
+    if (![SnapshotState.ERROR, SnapshotState.BUILD_FAILED].includes(snapshot.state)) {
+      throw new BadRequestException(`Snapshot ${snapshotId} is not in a failed state`)
+    }
+
+    const updateData: Partial<Snapshot> = {
+      state: SnapshotState.PENDING,
+      errorReason: null,
+      initialRunnerId: null,
+    }
+
+    // Pull snapshots derive their internal reference from the source image. Clear
+    // failed attempt metadata so the retry inspects and pulls the source again.
+    if (!snapshot.buildInfo) {
+      updateData.ref = null
+      updateData.size = null
+    }
+
+    const retriedSnapshot = await this.snapshotRepository.update(snapshotId, {
+      updateData,
+      entity: snapshot,
+    })
+
+    this.eventEmitter.emit(SnapshotEvents.CREATED, new SnapshotCreatedEvent(retriedSnapshot))
+
+    return retriedSnapshot
+  }
+
   async getAllSnapshots(
     organizationId: string,
     page = 1,


### PR DESCRIPTION
## Summary

- retry the system default snapshot during API startup when it is in `error` or `build_failed`
- reset stale runner and pull metadata before reprocessing the failed snapshot
- preserve the existing protection that prevents tenant APIs from deleting general snapshots
- add focused coverage for pull retries, build retries, missing snapshots, and invalid states

## Why

A transient registry failure can leave the system default snapshot permanently stuck in `ERROR`. The initializer previously treated any existing snapshot row as healthy, so restarting the API could neither recreate nor recover it.

## Verification

- `corepack yarn jest apps/api/src/sandbox/services/snapshot.service.spec.ts --runInBand --config apps/api/jest.config.ts`
- `corepack yarn tsc -p apps/api/tsconfig.app.json --noEmit`
- Prettier check for all changed files

Fixes #5076

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover the system default snapshot on API startup by retrying it when stuck in a failed state. This prevents snapshots from staying in `ERROR`/`BUILD_FAILED` after transient registry issues.

- **Bug Fixes**
  - Retry the default snapshot during startup when in `ERROR` or `BUILD_FAILED`.
  - Added `retryFailedSnapshot` to reset `errorReason` and `initialRunnerId`; clear pull-only fields (`ref`, `size`) while preserving build metadata.
  - Emit `SnapshotEvents.CREATED` to re-trigger processing.
  - Treat missing default snapshot as not found and create it as before.
  - Kept protections that block tenant APIs from deleting general snapshots.
  - Added focused tests for pull retries, build retries, missing snapshot, and invalid state.

<sup>Written for commit 5226b4e96a799e44986daa6b26b0fca855d797af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

