### PR TITLE
Fix computer-use OpenAPI response mismatch

### DIFF
--- a/apps/daemon/pkg/toolbox/computeruse/interface.go
+++ b/apps/daemon/pkg/toolbox/computeruse/interface.go
@@ -203,10 +203,10 @@ type ComputerUseStopResponse struct {
 } //	@name	ComputerUseStopResponse
 
 type ProcessStatus struct {
-	Running     bool
-	Priority    int
-	AutoRestart bool
-	Pid         *int
+	Running     bool `json:"running"`
+	Priority    int  `json:"priority"`
+	AutoRestart bool `json:"autoRestart"`
+	Pid         *int `json:"pid,omitempty"`
 } //	@name	ProcessStatus
 
 type ProcessStatusResponse struct {

--- a/apps/daemon/pkg/toolbox/computeruse/interface_test.go
+++ b/apps/daemon/pkg/toolbox/computeruse/interface_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -61,6 +62,182 @@ func performScreenshotRequest(router *gin.Engine, path string) *httptest.Respons
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	router.ServeHTTP(rr, req)
 	return rr
+}
+
+type swaggerDefinition struct {
+	Properties map[string]json.RawMessage `json:"properties"`
+}
+
+type toolboxSwagger struct {
+	Definitions map[string]swaggerDefinition `json:"definitions"`
+}
+
+func loadToolboxSwagger(t *testing.T) toolboxSwagger {
+	t.Helper()
+
+	specBytes, err := os.ReadFile("../docs/swagger.json")
+	require.NoError(t, err)
+
+	var spec toolboxSwagger
+	require.NoError(t, json.Unmarshal(specBytes, &spec))
+
+	return spec
+}
+
+func swaggerPropertyKeys(t *testing.T, spec toolboxSwagger, definitionName string) []string {
+	t.Helper()
+
+	definition, ok := spec.Definitions[definitionName]
+	require.True(t, ok, "missing OpenAPI definition %s", definitionName)
+
+	keys := make([]string, 0, len(definition.Properties))
+	for key := range definition.Properties {
+		keys = append(keys, key)
+	}
+
+	return keys
+}
+
+func serializedObjectKeys(t *testing.T, value any) []string {
+	t.Helper()
+
+	payload, err := json.Marshal(value)
+	require.NoError(t, err)
+
+	var object map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(payload, &object))
+
+	keys := make([]string, 0, len(object))
+	for key := range object {
+		keys = append(keys, key)
+	}
+
+	return keys
+}
+
+func TestComputerUseResponseJSONMatchesOpenAPISchema(t *testing.T) {
+	spec := loadToolboxSwagger(t)
+	pid := 4312
+
+	tests := []struct {
+		name       string
+		definition string
+		value      any
+	}{
+		{
+			name:       "start response",
+			definition: "ComputerUseStartResponse",
+			value: ComputerUseStartResponse{
+				Message: "started",
+				Status: map[string]ProcessStatus{
+					"xvfb": {Running: true, Priority: 1, AutoRestart: true, Pid: &pid},
+				},
+			},
+		},
+		{
+			name:       "stop response",
+			definition: "ComputerUseStopResponse",
+			value: ComputerUseStopResponse{
+				Message: "stopped",
+				Status: map[string]ProcessStatus{
+					"xvfb": {Running: false, Priority: 1, AutoRestart: true, Pid: &pid},
+				},
+			},
+		},
+		{
+			name:       "screenshot response",
+			definition: "ScreenshotResponse",
+			value: ScreenshotResponse{
+				Screenshot:     "image",
+				CursorPosition: &Position{X: 1, Y: 2},
+				SizeBytes:      42,
+			},
+		},
+		{
+			name:       "mouse position response",
+			definition: "MousePositionResponse",
+			value:      MousePositionResponse{Position: Position{X: 1, Y: 2}},
+		},
+		{
+			name:       "mouse click response",
+			definition: "MouseClickResponse",
+			value:      MouseClickResponse{Position: Position{X: 1, Y: 2}},
+		},
+		{
+			name:       "mouse drag response",
+			definition: "MouseDragResponse",
+			value:      MouseDragResponse{Position: Position{X: 3, Y: 4}},
+		},
+		{
+			name:       "scroll response",
+			definition: "ScrollResponse",
+			value:      ScrollResponse{Success: true},
+		},
+		{
+			name:       "display info response",
+			definition: "DisplayInfoResponse",
+			value: DisplayInfoResponse{
+				Displays: []DisplayInfo{
+					{ID: 1, Position: Position{X: 0, Y: 0}, Size: Size{Width: 1024, Height: 768}, IsActive: true},
+				},
+			},
+		},
+		{
+			name:       "display info",
+			definition: "DisplayInfo",
+			value:      DisplayInfo{ID: 1, Position: Position{X: 0, Y: 0}, Size: Size{Width: 1024, Height: 768}, IsActive: true},
+		},
+		{
+			name:       "windows response",
+			definition: "WindowsResponse",
+			value: WindowsResponse{
+				Windows: []WindowInfo{
+					{ID: 1, Title: "Editor", Position: Position{X: 0, Y: 0}, Size: Size{Width: 1024, Height: 768}, IsActive: true},
+				},
+			},
+		},
+		{
+			name:       "window info",
+			definition: "WindowInfo",
+			value:      WindowInfo{ID: 1, Title: "Editor", Position: Position{X: 0, Y: 0}, Size: Size{Width: 1024, Height: 768}, IsActive: true},
+		},
+		{
+			name:       "computer use status response",
+			definition: "ComputerUseStatusResponse",
+			value:      ComputerUseStatusResponse{Status: "running"},
+		},
+		{
+			name:       "process status",
+			definition: "ProcessStatus",
+			value:      ProcessStatus{Running: true, Priority: 1, AutoRestart: true, Pid: &pid},
+		},
+		{
+			name:       "process status response",
+			definition: "ProcessStatusResponse",
+			value:      ProcessStatusResponse{ProcessName: "xvfb", Running: true},
+		},
+		{
+			name:       "process restart response",
+			definition: "ProcessRestartResponse",
+			value:      ProcessRestartResponse{Message: "restarted", ProcessName: "xvfb"},
+		},
+		{
+			name:       "process logs response",
+			definition: "ProcessLogsResponse",
+			value:      ProcessLogsResponse{ProcessName: "xvfb", Logs: "logs"},
+		},
+		{
+			name:       "process errors response",
+			definition: "ProcessErrorsResponse",
+			value:      ProcessErrorsResponse{ProcessName: "xvfb", Errors: "errors"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, swaggerPropertyKeys(t, spec, tt.definition), serializedObjectKeys(t, tt.value))
+		})
+	}
 }
 
 func TestWrapRegionScreenshotHandlerParsesLowercaseQueryParams(t *testing.T) {

--- a/libs/sdk-go/pkg/daytona/computer_use.go
+++ b/libs/sdk-go/pkg/daytona/computer_use.go
@@ -558,12 +558,8 @@ func (s *ScreenshotService) TakeFullScreen(ctx context.Context, showCursor *bool
 			return nil, errors.ConvertToolboxError(err, httpResp)
 		}
 
-		// Note: Toolbox API returns screenshot but not width/height separately
-		// Width and height would need to be parsed from the image data if needed
 		return &types.ScreenshotResponse{
 			Image:     result.GetScreenshot(),
-			Width:     0, // Not provided by toolbox API
-			Height:    0, // Not provided by toolbox API
 			SizeBytes: convertInt32PtrToIntPtr(result.SizeBytes),
 		}, nil
 	})
@@ -602,12 +598,8 @@ func (s *ScreenshotService) TakeRegion(ctx context.Context, region types.Screens
 			return nil, errors.ConvertToolboxError(err, httpResp)
 		}
 
-		// Note: Toolbox API returns screenshot but not width/height separately
-		// The region dimensions are known from the request parameters
 		return &types.ScreenshotResponse{
 			Image:     result.GetScreenshot(),
-			Width:     region.Width,
-			Height:    region.Height,
 			SizeBytes: convertInt32PtrToIntPtr(result.SizeBytes),
 		}, nil
 	})

--- a/libs/sdk-go/pkg/daytona/computer_use_test.go
+++ b/libs/sdk-go/pkg/daytona/computer_use_test.go
@@ -366,7 +366,6 @@ func TestScreenshotAndDisplayServices(t *testing.T) {
 		require.NotNil(t, full.SizeBytes)
 		region, err := ss.TakeRegion(context.Background(), types.ScreenshotRegion{X: 1, Y: 2, Width: 3, Height: 4}, nil)
 		require.NoError(t, err)
-		assert.Equal(t, 3, region.Width)
 		assert.Equal(t, "region-image", region.Image)
 	})
 

--- a/libs/sdk-go/pkg/types/types.go
+++ b/libs/sdk-go/pkg/types/types.go
@@ -294,9 +294,7 @@ type ScreenshotOptions struct {
 
 type ScreenshotResponse struct {
 	Image     string // base64-encoded image data
-	Width     int
-	Height    int
-	SizeBytes *int // Size in bytes
+	SizeBytes *int   // Size in bytes
 }
 
 type LspLanguageID string

--- a/libs/sdk-python/src/daytona/_async/computer_use.py
+++ b/libs/sdk-python/src/daytona/_async/computer_use.py
@@ -317,7 +317,7 @@ class AsyncScreenshot:
         Example:
             ```python
             screenshot = await sandbox.computer_use.screenshot.take_full_screen()
-            print(f"Screenshot size: {screenshot.width}x{screenshot.height}")
+            print(f"Screenshot bytes: {screenshot.size_bytes}")
 
             # With cursor visible
             with_cursor = await sandbox.computer_use.screenshot.take_full_screen(True)
@@ -342,7 +342,7 @@ class AsyncScreenshot:
             ```python
             region = ScreenshotRegion(x=100, y=100, width=300, height=200)
             screenshot = await sandbox.computer_use.screenshot.take_region(region)
-            print(f"Captured region: {screenshot.region.width}x{screenshot.region.height}")
+            print(f"Screenshot bytes: {screenshot.size_bytes}")
             ```
         """
         response = await self._api_client.take_region_screenshot(
@@ -445,8 +445,7 @@ class AsyncDisplay:
         Example:
             ```python
             info = await sandbox.computer_use.display.get_info()
-            print(f"Primary display: {info.primary_display.width}x{info.primary_display.height}")
-            print(f"Total displays: {info.total_displays}")
+            print(f"Total displays: {len(info.displays)}")
             for i, display in enumerate(info.displays):
                 print(f"Display {i}: {display.width}x{display.height} at {display.x},{display.y}")
             ```
@@ -465,7 +464,7 @@ class AsyncDisplay:
         Example:
             ```python
             windows = await sandbox.computer_use.display.get_windows()
-            print(f"Found {windows.count} open windows:")
+            print(f"Found {len(windows.windows)} open windows:")
             for window in windows.windows:
                 print(f"- {window.title} (ID: {window.id})")
             ```

--- a/libs/sdk-python/src/daytona/_sync/computer_use.py
+++ b/libs/sdk-python/src/daytona/_sync/computer_use.py
@@ -316,7 +316,7 @@ class Screenshot:
         Example:
             ```python
             screenshot = sandbox.computer_use.screenshot.take_full_screen()
-            print(f"Screenshot size: {screenshot.width}x{screenshot.height}")
+            print(f"Screenshot bytes: {screenshot.size_bytes}")
 
             # With cursor visible
             with_cursor = sandbox.computer_use.screenshot.take_full_screen(True)
@@ -341,7 +341,7 @@ class Screenshot:
             ```python
             region = ScreenshotRegion(x=100, y=100, width=300, height=200)
             screenshot = sandbox.computer_use.screenshot.take_region(region)
-            print(f"Captured region: {screenshot.region.width}x{screenshot.region.height}")
+            print(f"Screenshot bytes: {screenshot.size_bytes}")
             ```
         """
         response = self._api_client.take_region_screenshot(
@@ -444,8 +444,7 @@ class Display:
         Example:
             ```python
             info = sandbox.computer_use.display.get_info()
-            print(f"Primary display: {info.primary_display.width}x{info.primary_display.height}")
-            print(f"Total displays: {info.total_displays}")
+            print(f"Total displays: {len(info.displays)}")
             for i, display in enumerate(info.displays):
                 print(f"Display {i}: {display.width}x{display.height} at {display.x},{display.y}")
             ```
@@ -464,7 +463,7 @@ class Display:
         Example:
             ```python
             windows = sandbox.computer_use.display.get_windows()
-            print(f"Found {windows.count} open windows:")
+            print(f"Found {len(windows.windows)} open windows:")
             for window in windows.windows:
                 print(f"- {window.title} (ID: {window.id})")
             ```

--- a/libs/sdk-python/tests/test_async_computer_use.py
+++ b/libs/sdk-python/tests/test_async_computer_use.py
@@ -69,14 +69,14 @@ class TestAsyncComputerUse:
     @pytest.mark.asyncio
     async def test_screenshot_methods_delegate_to_api(self):
         computer_use, api_client = _make_async_computer_use()
-        api_client.take_screenshot.return_value = MagicMock(width=1920)
-        api_client.take_region_screenshot.return_value = MagicMock(width=300)
+        api_client.take_screenshot.return_value = MagicMock(screenshot="full-image")
+        api_client.take_region_screenshot.return_value = MagicMock(screenshot="region-image")
         api_client.take_compressed_screenshot.return_value = MagicMock(size_bytes=123)
         api_client.take_compressed_region_screenshot.return_value = MagicMock(size_bytes=456)
         region = ScreenshotRegion(x=10, y=20, width=300, height=200)
 
-        assert (await computer_use.screenshot.take_full_screen(show_cursor=True)).width == 1920
-        assert (await computer_use.screenshot.take_region(region)).width == 300
+        assert (await computer_use.screenshot.take_full_screen(show_cursor=True)).screenshot == "full-image"
+        assert (await computer_use.screenshot.take_region(region)).screenshot == "region-image"
         assert (await computer_use.screenshot.take_compressed()).size_bytes == 123
         assert (
             await computer_use.screenshot.take_compressed(
@@ -90,15 +90,15 @@ class TestAsyncComputerUse:
     @pytest.mark.asyncio
     async def test_display_and_recording_methods_delegate_to_api(self, tmp_path: Path):
         computer_use, api_client = _make_async_computer_use()
-        api_client.get_display_info.return_value = MagicMock(total_displays=1)
-        api_client.get_windows.return_value = MagicMock(count=2)
+        api_client.get_display_info.return_value = MagicMock(displays=[MagicMock(id=1)])
+        api_client.get_windows.return_value = MagicMock(windows=[MagicMock(id=1), MagicMock(id=2)])
         api_client.start_recording.return_value = MagicMock(id="rec-1")
         api_client.stop_recording.return_value = MagicMock(id="rec-1")
         api_client.list_recordings.return_value = MagicMock(recordings=[])
         api_client.get_recording.return_value = MagicMock(id="rec-1")
 
-        assert (await computer_use.display.get_info()).total_displays == 1
-        assert (await computer_use.display.get_windows()).count == 2
+        assert len((await computer_use.display.get_info()).displays) == 1
+        assert len((await computer_use.display.get_windows()).windows) == 2
         assert (await computer_use.recording.start("label")).id == "rec-1"
         assert (await computer_use.recording.stop("rec-1")).id == "rec-1"
         assert (await computer_use.recording.list()).recordings == []

--- a/libs/sdk-python/tests/test_computer_use.py
+++ b/libs/sdk-python/tests/test_computer_use.py
@@ -76,14 +76,14 @@ class TestComputerUse:
 
     def test_screenshot_methods_delegate_to_api(self):
         computer_use, api_client = _make_computer_use()
-        api_client.take_screenshot.return_value = MagicMock(width=1920)
-        api_client.take_region_screenshot.return_value = MagicMock(width=300)
+        api_client.take_screenshot.return_value = MagicMock(screenshot="full-image")
+        api_client.take_region_screenshot.return_value = MagicMock(screenshot="region-image")
         api_client.take_compressed_screenshot.return_value = MagicMock(size_bytes=123)
         api_client.take_compressed_region_screenshot.return_value = MagicMock(size_bytes=456)
         region = ScreenshotRegion(x=10, y=20, width=300, height=200)
 
-        assert computer_use.screenshot.take_full_screen(show_cursor=True).width == 1920
-        assert computer_use.screenshot.take_region(region).width == 300
+        assert computer_use.screenshot.take_full_screen(show_cursor=True).screenshot == "full-image"
+        assert computer_use.screenshot.take_region(region).screenshot == "region-image"
         assert computer_use.screenshot.take_compressed().size_bytes == 123
         assert (
             computer_use.screenshot.take_compressed(
@@ -102,11 +102,11 @@ class TestComputerUse:
 
     def test_display_methods_delegate_to_api(self):
         computer_use, api_client = _make_computer_use()
-        api_client.get_display_info.return_value = MagicMock(total_displays=1)
-        api_client.get_windows.return_value = MagicMock(count=2)
+        api_client.get_display_info.return_value = MagicMock(displays=[MagicMock(id=1)])
+        api_client.get_windows.return_value = MagicMock(windows=[MagicMock(id=1), MagicMock(id=2)])
 
-        assert computer_use.display.get_info().total_displays == 1
-        assert computer_use.display.get_windows().count == 2
+        assert len(computer_use.display.get_info().displays) == 1
+        assert len(computer_use.display.get_windows().windows) == 2
 
     def test_recording_service_methods_delegate_to_api(self, tmp_path: Path):
         computer_use, api_client = _make_computer_use()

--- a/libs/sdk-ruby/lib/daytona/computer_use.rb
+++ b/libs/sdk-ruby/lib/daytona/computer_use.rb
@@ -243,12 +243,12 @@ module Daytona
       # Takes a screenshot of the entire screen.
       #
       # @param show_cursor [Boolean] Whether to show the cursor in the screenshot. Defaults to false
-      # @return [DaytonaApiClient::ScreenshotResponse] Screenshot data with base64 encoded image
+      # @return [DaytonaToolboxApiClient::ScreenshotResponse] Screenshot data with base64 encoded image
       # @raise [Daytona::Sdk::Error] If the operation fails
       #
       # @example
       #   screenshot = sandbox.computer_use.screenshot.take_full_screen
-      #   puts "Screenshot size: #{screenshot.width}x#{screenshot.height}"
+      #   puts "Screenshot bytes: #{screenshot.size_bytes}"
       #
       #   # With cursor visible
       #   with_cursor = sandbox.computer_use.screenshot.take_full_screen(show_cursor: true)
@@ -262,13 +262,13 @@ module Daytona
       #
       # @param region [ScreenshotRegion] The region to capture
       # @param show_cursor [Boolean] Whether to show the cursor in the screenshot. Defaults to false
-      # @return [DaytonaApiClient::RegionScreenshotResponse] Screenshot data with base64 encoded image
+      # @return [DaytonaToolboxApiClient::ScreenshotResponse] Screenshot data with base64 encoded image
       # @raise [Daytona::Sdk::Error] If the operation fails
       #
       # @example
       #   region = ScreenshotRegion.new(x: 100, y: 100, width: 300, height: 200)
       #   screenshot = sandbox.computer_use.screenshot.take_region(region)
-      #   puts "Captured region: #{screenshot.region.width}x#{screenshot.region.height}"
+      #   puts "Screenshot bytes: #{screenshot.size_bytes}"
       def take_region(region:, show_cursor: false)
         toolbox_api.take_region_screenshot(region.height, region.width, region.y, region.x, show_cursor:)
       rescue StandardError => e
@@ -278,7 +278,7 @@ module Daytona
       # Takes a compressed screenshot of the entire screen.
       #
       # @param options [ScreenshotOptions, nil] Compression and display options
-      # @return [DaytonaApiClient::CompressedScreenshotResponse] Compressed screenshot data
+      # @return [DaytonaToolboxApiClient::ScreenshotResponse] Compressed screenshot data
       # @raise [Daytona::Sdk::Error] If the operation fails
       #
       # @example
@@ -311,7 +311,7 @@ module Daytona
       #
       # @param region [ScreenshotRegion] The region to capture
       # @param options [ScreenshotOptions, nil] Compression and display options
-      # @return [DaytonaApiClient::CompressedScreenshotResponse] Compressed screenshot data
+      # @return [DaytonaToolboxApiClient::ScreenshotResponse] Compressed screenshot data
       # @raise [Daytona::Sdk::Error] If the operation fails
       #
       # @example
@@ -368,13 +368,12 @@ module Daytona
 
       # Gets information about the displays.
       #
-      # @return [DaytonaToolboxApiClient::DisplayInfoResponse] Display information including primary display and all available displays
+      # @return [DaytonaToolboxApiClient::DisplayInfoResponse] Display information for all available displays
       # @raise [Daytona::Sdk::Error] If the operation fails
       #
       # @example
       #   info = sandbox.computer_use.display.get_info
-      #   puts "Primary display: #{info.primary_display.width}x#{info.primary_display.height}"
-      #   puts "Total displays: #{info.total_displays}"
+      #   puts "Total displays: #{info.displays.length}"
       #   info.displays.each_with_index do |display, i|
       #     puts "Display #{i}: #{display.width}x#{display.height} at #{display.x},#{display.y}"
       #   end
@@ -391,7 +390,7 @@ module Daytona
       #
       # @example
       #   windows = sandbox.computer_use.display.get_windows
-      #   puts "Found #{windows.count} open windows:"
+      #   puts "Found #{windows.windows.length} open windows:"
       #   windows.windows.each do |window|
       #     puts "- #{window.title} (ID: #{window.id})"
       #   end

--- a/libs/sdk-typescript/src/ComputerUse.ts
+++ b/libs/sdk-typescript/src/ComputerUse.ts
@@ -333,7 +333,7 @@ export class Screenshot {
    * @example
    * ```typescript
    * const screenshot = await sandbox.computerUse.screenshot.takeFullScreen();
-   * console.log(`Screenshot size: ${screenshot.width}x${screenshot.height}`);
+   * console.log(`Screenshot bytes: ${screenshot.sizeBytes ?? 'unknown'}`);
    *
    * // With cursor visible
    * const withCursor = await sandbox.computerUse.screenshot.takeFullScreen(true);
@@ -356,7 +356,7 @@ export class Screenshot {
    * ```typescript
    * const region = { x: 100, y: 100, width: 300, height: 200 };
    * const screenshot = await sandbox.computerUse.screenshot.takeRegion(region);
-   * console.log(`Captured region: ${screenshot.region.width}x${screenshot.region.height}`);
+   * console.log(`Screenshot bytes: ${screenshot.sizeBytes ?? 'unknown'}`);
    * ```
    */
   @WithInstrumentation()
@@ -458,8 +458,7 @@ export class Display {
    * @example
    * ```typescript
    * const info = await sandbox.computerUse.display.getInfo();
-   * console.log(`Primary display: ${info.primary_display.width}x${info.primary_display.height}`);
-   * console.log(`Total displays: ${info.total_displays}`);
+   * console.log(`Total displays: ${info.displays.length}`);
    * info.displays.forEach((display, index) => {
    *   console.log(`Display ${index}: ${display.width}x${display.height} at ${display.x},${display.y}`);
    * });
@@ -479,7 +478,7 @@ export class Display {
    * @example
    * ```typescript
    * const windows = await sandbox.computerUse.display.getWindows();
-   * console.log(`Found ${windows.count} open windows:`);
+   * console.log(`Found ${windows.windows.length} open windows:`);
    * windows.windows.forEach(window => {
    *   console.log(`- ${window.title} (ID: ${window.id})`);
    * });

--- a/libs/sdk-typescript/src/__tests__/ComputerUse.test.ts
+++ b/libs/sdk-typescript/src/__tests__/ComputerUse.test.ts
@@ -59,12 +59,12 @@ describe('ComputerUse', () => {
     apiClient.click.mockResolvedValue(createApiResponse({ success: true }))
     apiClient.drag.mockResolvedValue(createApiResponse({ success: true }))
     apiClient.scroll.mockResolvedValue(createApiResponse({ success: true }))
-    apiClient.takeScreenshot.mockResolvedValue(createApiResponse({ data: 'a' }))
-    apiClient.takeRegionScreenshot.mockResolvedValue(createApiResponse({ data: 'b' }))
-    apiClient.takeCompressedScreenshot.mockResolvedValue(createApiResponse({ data: 'c' }))
-    apiClient.takeCompressedRegionScreenshot.mockResolvedValue(createApiResponse({ data: 'd' }))
-    apiClient.getDisplayInfo.mockResolvedValue(createApiResponse({ total_displays: 1 }))
-    apiClient.getWindows.mockResolvedValue(createApiResponse({ count: 0, windows: [] }))
+    apiClient.takeScreenshot.mockResolvedValue(createApiResponse({ screenshot: 'a' }))
+    apiClient.takeRegionScreenshot.mockResolvedValue(createApiResponse({ screenshot: 'b' }))
+    apiClient.takeCompressedScreenshot.mockResolvedValue(createApiResponse({ screenshot: 'c' }))
+    apiClient.takeCompressedRegionScreenshot.mockResolvedValue(createApiResponse({ screenshot: 'd' }))
+    apiClient.getDisplayInfo.mockResolvedValue(createApiResponse({ displays: [] }))
+    apiClient.getWindows.mockResolvedValue(createApiResponse({ windows: [] }))
 
     await expect(computerUse.mouse.getPosition()).resolves.toEqual({ x: 1, y: 2 })
     await expect(computerUse.mouse.move(10, 20)).resolves.toEqual({ x: 10, y: 20 })
@@ -76,15 +76,17 @@ describe('ComputerUse', () => {
     await computerUse.keyboard.press('Enter', ['ctrl'])
     await computerUse.keyboard.hotkey('ctrl+c')
 
-    await expect(computerUse.screenshot.takeFullScreen()).resolves.toEqual({ data: 'a' })
-    await expect(computerUse.screenshot.takeRegion({ x: 1, y: 2, width: 3, height: 4 })).resolves.toEqual({ data: 'b' })
-    await expect(computerUse.screenshot.takeCompressed()).resolves.toEqual({ data: 'c' })
+    await expect(computerUse.screenshot.takeFullScreen()).resolves.toEqual({ screenshot: 'a' })
+    await expect(computerUse.screenshot.takeRegion({ x: 1, y: 2, width: 3, height: 4 })).resolves.toEqual({
+      screenshot: 'b',
+    })
+    await expect(computerUse.screenshot.takeCompressed()).resolves.toEqual({ screenshot: 'c' })
     await expect(
       computerUse.screenshot.takeCompressedRegion({ x: 1, y: 2, width: 3, height: 4 }, { format: 'png' }),
-    ).resolves.toEqual({ data: 'd' })
+    ).resolves.toEqual({ screenshot: 'd' })
 
-    await expect(computerUse.display.getInfo()).resolves.toEqual({ total_displays: 1 })
-    await expect(computerUse.display.getWindows()).resolves.toEqual({ count: 0, windows: [] })
+    await expect(computerUse.display.getInfo()).resolves.toEqual({ displays: [] })
+    await expect(computerUse.display.getWindows()).resolves.toEqual({ windows: [] })
   })
 
   it('sends default mouse and keyboard payloads', async () => {


### PR DESCRIPTION
## Description

Fixes the computer-use response mismatch between daemon wire JSON, OpenAPI, and SDK wrapper docs/tests.

Changes:
- Add JSON tags to `ProcessStatus` so daemon responses serialize as `running`, `priority`,`autoRestart`, and `pid`, matching the OpenAPI spec and generated clients.
- Add a spec-vs-wire regression test for computer-use response structs against `apps/daemon/pkg/toolbox/docs/swagger.json`.
- Remove SDK references to response fields the daemon does not send, including screenshot `width`/`height`, window `count`, and display `primary_display` / `total_displays`.
- Stop the Go SDK from synthesizing screenshot `Width`/`Height` values that are not present on the wire.

No new runtime dependencies are required.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

This PR fixes daytonaio/daytona#5005

## Notes

Verification:
- `nix develop .#go --command go test ./apps/daemon/pkg/toolbox/computeruse ./libs/sdk-go/pkg/daytona`
- `nix develop .#go --command go test ./apps/daemon/pkg/toolbox/computeruse -run
TestComputerUseResponseJSONMatchesOpenAPISchema -v`
- `nix develop .#node --command yarn jest --config libs/sdk-typescript/jest.config.js libs/sdk-
typescript/src/__tests__/ComputerUse.test.ts --runInBand`
- `nix develop .#python --command poetry run pytest libs/sdk-python/tests -k computer_use`
- `git diff --check`

Regenerating the toolbox OpenAPI/spec clients produced no net diff because the generated spec already
used the lower-camel response fields; the daemon wire JSON was the mismatched side.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the computer-use daemon JSON with the OpenAPI schema and SDKs, fixing field name mismatches and removing fields not present on the wire. Adds a regression test to prevent future spec-vs-wire drift.

- **Bug Fixes**
  - Tagged `ProcessStatus` JSON fields to `running`, `priority`, `autoRestart`, `pid` (omit when empty) to match the OpenAPI and generated clients.
  - Added a spec-vs-wire test against `apps/daemon/pkg/toolbox/docs/swagger.json` to validate response structs.
  - Updated SDKs (`libs/sdk-go`, `libs/sdk-python`, `libs/sdk-ruby`, `libs/sdk-typescript`) and tests/docs to stop using fields the daemon does not send:
    - Removed synthetic screenshot `width`/`height`; Go `ScreenshotResponse` now returns `Image` and `SizeBytes` only.
    - Replaced display `primary_display`/`total_displays` with the `displays` array.
    - Replaced window `count` with the `windows` array.
    - Standardized screenshot field to `screenshot` in examples/tests where applicable.

- **Migration**
  - Do not read screenshot `width`/`height`; derive from image data if needed. Use `screenshot`/`Image` and `sizeBytes`/`SizeBytes`.
  - Use `displays.length` and `windows.length` instead of `total_displays` or `count`.
  - Expect `ProcessStatus` response keys in lower camel case; `pid` may be absent when null.

<sup>Written for commit 17961e0eff2c5926262f45fc1d898b057a767b4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

