### PR TITLE
feat(api,sdk): sandbox domain allow list

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,4 +28,5 @@ libs
 !libs/sdk-go
 !libs/runner-proto
 !libs/billing-api-client
+!libs/netleash
 Dockerfile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,9 @@ nix develop .#go --command bash -c "golangci-lint run ./apps/runner/..."
 # Generate swagger docs
 nix develop .#go --command bash -c "swag init -g apps/daemon/cmd/main.go"
 
+# Generate netleash eBPF bindings (clang + libbpf + kernel headers are in the go shell)
+nix develop .#go --command bash -c "cd libs/netleash && make generate"
+
 # Tidy all modules
 nix develop .#go --command bash -c 'for d in apps/*/go.mod libs/*/go.mod; do (cd "$(dirname "$d")" && go mod tidy); done'
 ```

--- a/apps/api/src/interceptors/metrics.interceptor.ts
+++ b/apps/api/src/interceptors/metrics.interceptor.ts
@@ -550,6 +550,8 @@ export class MetricsInterceptor implements NestInterceptor, OnApplicationShutdow
       sandbox_network_block_all: response.networkBlockAll,
       sandbox_network_allow_list_set_request: !!request.networkAllowList,
       sandbox_network_allow_list_set: !!response.networkAllowList,
+      sandbox_domain_allow_list_set_request: !!request.domainAllowList,
+      sandbox_domain_allow_list_set: !!response.domainAllowList,
     }
 
     if (request.buildInfo) {

--- a/apps/api/src/migrations/pre-deploy/1781740800000-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1781740800000-migration.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1781740800000 implements MigrationInterface {
+  name = 'Migration1781740800000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "sandbox" ADD "domainAllowList" character varying`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "sandbox" DROP COLUMN "domainAllowList"`)
+  }
+}

--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -269,6 +269,7 @@ export class SandboxController {
         buildInfo: req.body?.buildInfo,
         networkBlockAll: req.body?.networkBlockAll,
         networkAllowList: req.body?.networkAllowList,
+        domainAllowList: req.body?.domainAllowList,
         linkedSandbox: req.body?.linkedSandbox,
       }),
     },
@@ -1097,6 +1098,7 @@ export class SandboxController {
       body: (req: TypedRequest<UpdateSandboxNetworkSettingsDto>) => ({
         networkBlockAll: req.body?.networkBlockAll,
         networkAllowList: req.body?.networkAllowList,
+        domainAllowList: req.body?.domainAllowList,
       }),
     },
   })
@@ -1110,13 +1112,18 @@ export class SandboxController {
         'Network access is restricted and cannot be overridden at the sandbox level. See https://www.daytona.io/docs/en/network-limits/#tier-based-network-restrictions',
       )
     }
-    if (networkSettings.networkBlockAll === undefined && networkSettings.networkAllowList === undefined) {
-      throw new BadRequestError('At least one of networkBlockAll or networkAllowList must be provided')
+    if (
+      networkSettings.networkBlockAll === undefined &&
+      networkSettings.networkAllowList === undefined &&
+      networkSettings.domainAllowList === undefined
+    ) {
+      throw new BadRequestError('At least one of networkBlockAll, networkAllowList or domainAllowList must be provided')
     }
     const sandbox = await this.sandboxService.updateNetworkSettings(
       sandboxIdOrName,
       networkSettings.networkBlockAll,
       networkSettings.networkAllowList,
+      networkSettings.domainAllowList,
       authContext.organizationId,
     )
     return this.sandboxService.toSandboxDto(sandbox)

--- a/apps/api/src/sandbox/dto/create-sandbox.dto.ts
+++ b/apps/api/src/sandbox/dto/create-sandbox.dto.ts
@@ -95,6 +95,14 @@ export class CreateSandboxDto {
   networkAllowList?: string
 
   @ApiPropertyOptional({
+    description: 'Comma-separated list of allowed domains for the sandbox',
+    example: 'example.com,*.daytona.io',
+  })
+  @IsOptional()
+  @IsString()
+  domainAllowList?: string
+
+  @ApiPropertyOptional({
     description: 'The target (region) where the sandbox will be created',
     example: 'us',
   })

--- a/apps/api/src/sandbox/dto/sandbox.dto.ts
+++ b/apps/api/src/sandbox/dto/sandbox.dto.ts
@@ -109,6 +109,12 @@ export class SandboxDto {
   })
   networkAllowList?: string
 
+  @ApiPropertyOptional({
+    description: 'Comma-separated list of allowed domains for the sandbox',
+    example: 'example.com,*.daytona.io',
+  })
+  domainAllowList?: string
+
   @ApiProperty({
     description: 'The target environment for the sandbox',
     example: 'local',
@@ -328,6 +334,7 @@ export class SandboxDto {
       public: sandbox.public,
       networkBlockAll: sandbox.networkBlockAll,
       networkAllowList: sandbox.networkAllowList,
+      domainAllowList: sandbox.domainAllowList,
       labels: sandbox.labels,
       volumes: sandbox.volumes,
       state: this.getSandboxState(sandbox),

--- a/apps/api/src/sandbox/dto/update-sandbox-network-settings.dto.ts
+++ b/apps/api/src/sandbox/dto/update-sandbox-network-settings.dto.ts
@@ -23,4 +23,12 @@ export class UpdateSandboxNetworkSettingsDto {
   @ValidateIf((_, value) => value !== undefined)
   @IsString()
   networkAllowList?: string
+
+  @ApiPropertyOptional({
+    description: 'Comma-separated list of allowed domains for the sandbox',
+    example: 'example.com,*.daytona.io',
+  })
+  @ValidateIf((_, value) => value !== undefined)
+  @IsString()
+  domainAllowList?: string
 }

--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -131,6 +131,9 @@ export class Sandbox {
   @Column({ nullable: true })
   networkAllowList?: string
 
+  @Column({ nullable: true })
+  domainAllowList?: string
+
   @Column('jsonb', { nullable: true })
   labels: { [key: string]: string }
 

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -556,6 +556,9 @@ export class SandboxStartAction extends SandboxAction {
           sandbox.volumes.map((v) => ({ volumeId: v.volumeId, mountPath: v.mountPath, subpath: v.subpath })),
         )
       }
+      if (sandbox.domainAllowList) {
+        metadata['domainAllowList'] = sandbox.domainAllowList
+      }
 
       try {
         await runnerAdapter.startSandbox(sandbox.id, sandbox.authToken, metadata)

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -122,6 +122,7 @@ export interface RunnerAdapter {
     networkBlockAll?: boolean,
     networkAllowList?: string,
     networkLimitEgress?: boolean,
+    domainAllowList?: string,
   ): Promise<void>
 
   forkSandbox(sourceSandboxId: string, newSandboxId: string): Promise<void>

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -223,6 +223,7 @@ export class RunnerAdapterV0 implements RunnerAdapter {
       })),
       networkBlockAll: sandbox.networkBlockAll,
       networkAllowList: sandbox.networkAllowList,
+      domainAllowList: sandbox.domainAllowList,
       metadata: metadata,
       authToken: sandbox.authToken,
       otelEndpoint,
@@ -411,11 +412,13 @@ export class RunnerAdapterV0 implements RunnerAdapter {
     networkBlockAll?: boolean,
     networkAllowList?: string,
     networkLimitEgress?: boolean,
+    domainAllowList?: string,
   ): Promise<void> {
     const updateNetworkSettingsDto: UpdateNetworkSettingsDTO = {
       networkBlockAll: networkBlockAll,
       networkAllowList: networkAllowList,
       networkLimitEgress: networkLimitEgress,
+      domainAllowList: domainAllowList,
     }
 
     await this.sandboxApiClient.updateNetworkSettings(sandboxId, updateNetworkSettingsDto)

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -184,6 +184,7 @@ export class RunnerAdapterV2 implements RunnerAdapter {
       })),
       networkBlockAll: sandbox.networkBlockAll,
       networkAllowList: sandbox.networkAllowList,
+      domainAllowList: sandbox.domainAllowList,
       metadata: metadata,
       authToken: sandbox.authToken,
       otelEndpoint: otelEndpoint,
@@ -530,11 +531,13 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     networkBlockAll?: boolean,
     networkAllowList?: string,
     networkLimitEgress?: boolean,
+    domainAllowList?: string,
   ): Promise<void> {
     const payload: UpdateNetworkSettingsDTO = {
       networkBlockAll: networkBlockAll,
       networkAllowList: networkAllowList,
       networkLimitEgress: networkLimitEgress,
+      domainAllowList: domainAllowList,
     }
 
     await this.jobService.createJob(

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -61,7 +61,7 @@ import { WarmPool } from '../entities/warm-pool.entity'
 import { SandboxDto, SandboxVolume } from '../dto/sandbox.dto'
 import { isValidUuid } from '../../common/utils/uuid'
 import { RunnerAdapter, RunnerAdapterFactory } from '../runner-adapter/runnerAdapter'
-import { validateNetworkAllowList } from '../utils/network-validation.util'
+import { validateDomainAllowList, validateNetworkAllowList } from '../utils/network-validation.util'
 import { OrganizationUsageService } from '../../organization/services/organization-usage.service'
 import { SshAccess } from '../entities/ssh-access.entity'
 import { SshAccessDto, SshAccessValidationDto } from '../dto/ssh-access.dto'
@@ -656,6 +656,10 @@ export class SandboxService {
         sandbox.networkAllowList = this.resolveNetworkAllowList(createSandboxDto.networkAllowList)
       }
 
+      if (createSandboxDto.domainAllowList !== undefined) {
+        sandbox.domainAllowList = this.resolveDomainAllowList(createSandboxDto.domainAllowList)
+      }
+
       if (createSandboxDto.autoStopInterval !== undefined) {
         sandbox.autoStopInterval = this.resolveAutoStopInterval(createSandboxDto.autoStopInterval)
       }
@@ -797,6 +801,10 @@ export class SandboxService {
       updateData.networkAllowList = this.resolveNetworkAllowList(createSandboxDto.networkAllowList)
     }
 
+    if (createSandboxDto.domainAllowList !== undefined) {
+      updateData.domainAllowList = this.resolveDomainAllowList(createSandboxDto.domainAllowList)
+    }
+
     if (!warmPoolSandbox.runnerId) {
       throw new SandboxError('Runner not found for warm pool sandbox')
     }
@@ -804,6 +812,7 @@ export class SandboxService {
     if (
       createSandboxDto.networkBlockAll !== undefined ||
       createSandboxDto.networkAllowList !== undefined ||
+      createSandboxDto.domainAllowList !== undefined ||
       organization.sandboxLimitedNetworkEgress
     ) {
       const runner = await this.runnerService.findOneOrFail(warmPoolSandbox.runnerId)
@@ -813,6 +822,7 @@ export class SandboxService {
         createSandboxDto.networkBlockAll,
         createSandboxDto.networkAllowList,
         organization.sandboxLimitedNetworkEgress,
+        updateData.domainAllowList ?? undefined,
       )
     }
 
@@ -915,6 +925,10 @@ export class SandboxService {
 
       if (createSandboxDto.networkAllowList !== undefined) {
         sandbox.networkAllowList = this.resolveNetworkAllowList(createSandboxDto.networkAllowList)
+      }
+
+      if (createSandboxDto.domainAllowList !== undefined) {
+        sandbox.domainAllowList = this.resolveDomainAllowList(createSandboxDto.domainAllowList)
       }
 
       if (createSandboxDto.autoStopInterval !== undefined) {
@@ -3054,6 +3068,7 @@ export class SandboxService {
     sandboxIdOrName: string,
     networkBlockAll?: boolean,
     networkAllowList?: string,
+    domainAllowList?: string,
     organizationId?: string,
   ): Promise<Sandbox> {
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organizationId)
@@ -3061,6 +3076,17 @@ export class SandboxService {
     const updateData: Partial<Sandbox> = {}
     let effectiveNetworkBlockAll = sandbox.networkBlockAll
     let effectiveNetworkAllowList = sandbox.networkAllowList
+    let effectiveDomainAllowList = sandbox.domainAllowList
+
+    if (domainAllowList !== undefined) {
+      if (domainAllowList.trim() === '') {
+        updateData.domainAllowList = null
+        effectiveDomainAllowList = null
+      } else {
+        updateData.domainAllowList = this.resolveDomainAllowList(domainAllowList)
+        effectiveDomainAllowList = updateData.domainAllowList
+      }
+    }
 
     if (networkBlockAll !== undefined) {
       updateData.networkBlockAll = networkBlockAll
@@ -3096,6 +3122,8 @@ export class SandboxService {
           sandbox.id,
           effectiveNetworkBlockAll,
           effectiveNetworkAllowList ?? undefined,
+          undefined,
+          effectiveDomainAllowList ?? undefined,
         )
       }
     }
@@ -3289,6 +3317,16 @@ export class SandboxService {
     }
 
     return networkAllowList
+  }
+
+  private resolveDomainAllowList(domainAllowList: string): string {
+    try {
+      validateDomainAllowList(domainAllowList)
+    } catch (error) {
+      throw new BadRequestError(error instanceof Error ? error.message : 'Invalid domain allow list')
+    }
+
+    return domainAllowList
   }
 
   // Resolves each volumeId (which may be a volume name) to the volume's UUID — the

--- a/apps/api/src/sandbox/utils/network-validation.util.ts
+++ b/apps/api/src/sandbox/utils/network-validation.util.ts
@@ -36,3 +36,27 @@ export function validateNetworkAllowList(networkAllowList: string): void {
     throw new Error(`Network allow list cannot contain more than 10 networks`)
   }
 }
+
+/**
+ * Validates domain allow list to ensure valid domain names are allowed
+ * @param domainAllowList - Comma-separated string of domains (optionally prefixed with a `*.` wildcard)
+ * @throws Error if any domain is invalid or the list is too long
+ */
+export function validateDomainAllowList(domainAllowList: string): void {
+  const domains = domainAllowList.split(',').map((domain: string) => domain.trim())
+
+  // Hostname label format, optionally prefixed with a single `*.` wildcard (e.g. "*.daytona.io")
+  const domainRegex = /^(\*\.)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/
+
+  for (const domain of domains) {
+    if (!domain) continue // Skip empty entries
+
+    if (!domainRegex.test(domain)) {
+      throw new Error(`Invalid domain: "${domain}". Must be a valid domain name`)
+    }
+  }
+
+  if (domains.length > 10) {
+    throw new Error(`Domain allow list cannot contain more than 10 domains`)
+  }
+}

--- a/apps/cli/go.mod
+++ b/apps/cli/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/creack/pty v1.1.23 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/go-connections v0.5.0 // indirect
+	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -82,7 +82,7 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
-	gotest.tools/v3 v3.5.1 // indirect
+	gotest.tools/v3 v3.5.2 // indirect
 )
 
 require (

--- a/apps/cli/go.sum
+++ b/apps/cli/go.sum
@@ -52,8 +52,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
 github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
-github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
+github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
+github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -195,5 +195,4 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
-gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
+gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=

--- a/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
@@ -657,7 +657,7 @@ for sandbox, err := range client.ListSeq(ctx, &ListSandboxesQuery{...}) {
 
 CodeInterpreterService provides Python code execution capabilities for a sandbox.
 
-CodeInterpreterService enables running Python code in isolated execution contexts with support for streaming output, persistent state, and environment variables. It uses WebSockets for real\-time output streaming. Access through [Sandbox.CodeInterpreter](<#Sandbox>).
+CodeInterpreterService enables running Python code in isolated execution contexts with support for streaming output, persistent state, and environment variables. It uses WebSockets for real\-time output streaming. Access through \[Sandbox.CodeInterpreter\].
 
 Example:
 
@@ -699,7 +699,7 @@ func NewCodeInterpreterService(toolboxClient *toolbox.APIClient, otel *otelState
 
 NewCodeInterpreterService creates a new CodeInterpreterService.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access CodeInterpreterService through [Sandbox.CodeInterpreter](<#Sandbox>) rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access CodeInterpreterService through \[Sandbox.CodeInterpreter\] rather than creating it directly.
 
 <a name="CodeInterpreterService.CreateContext"></a>
 ### func \(\*CodeInterpreterService\) CreateContext
@@ -834,7 +834,7 @@ Returns [OutputChannels](<#OutputChannels>) for receiving streamed output, or an
 
 ComputerUseService provides desktop automation operations for a sandbox.
 
-ComputerUseService enables GUI automation including mouse control, keyboard input, screenshots, display management, and screen recording. The desktop environment must be started before using these features. Access through [Sandbox.ComputerUse](<#Sandbox>).
+ComputerUseService enables GUI automation including mouse control, keyboard input, screenshots, display management, and screen recording. The desktop environment must be started before using these features. Access through \[Sandbox.ComputerUse\].
 
 Example:
 
@@ -875,7 +875,7 @@ func NewComputerUseService(toolboxClient *toolbox.APIClient, otel *otelState) *C
 
 NewComputerUseService creates a new ComputerUseService.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ComputerUseService through [Sandbox.ComputerUse](<#Sandbox>) rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ComputerUseService through \[Sandbox.ComputerUse\] rather than creating it directly.
 
 <a name="ComputerUseService.Accessibility"></a>
 ### func \(\*ComputerUseService\) Accessibility
@@ -1521,7 +1521,7 @@ WithDownloadProgress returns an option that enables progress tracking for stream
 
 FileSystemService provides file system operations for a sandbox.
 
-FileSystemService enables file and directory management including creating, reading, writing, moving, and deleting files. It also supports file searching and permission management. Access through [Sandbox.FileSystem](<#Sandbox>).
+FileSystemService enables file and directory management including creating, reading, writing, moving, and deleting files. It also supports file searching and permission management. Access through \[Sandbox.FileSystem\].
 
 Example:
 
@@ -1554,7 +1554,7 @@ func NewFileSystemService(toolboxClient *toolbox.APIClient, otel *otelState) *Fi
 
 NewFileSystemService creates a new FileSystemService with the provided toolbox client.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access FileSystemService through [Sandbox.FileSystem](<#Sandbox>) rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access FileSystemService through \[Sandbox.FileSystem\] rather than creating it directly.
 
 <a name="FileSystemService.CreateFolder"></a>
 ### func \(\*FileSystemService\) CreateFolder
@@ -1960,7 +1960,7 @@ err := sandbox.FileSystem.UploadFileStream(ctx, f, "/home/user/big.bin",
 
 GitService provides Git operations for a sandbox.
 
-GitService enables common Git workflows including cloning repositories, staging and committing changes, managing branches, and syncing with remote repositories. It is accessed through the [Sandbox.Git](<#Sandbox>) field.
+GitService enables common Git workflows including cloning repositories, staging and committing changes, managing branches, and syncing with remote repositories. It is accessed through the \[Sandbox.Git\] field.
 
 Example:
 
@@ -1994,7 +1994,7 @@ func NewGitService(toolboxClient *toolbox.APIClient, otel *otelState) *GitServic
 
 NewGitService creates a new GitService with the provided toolbox client.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access GitService through [Sandbox.Git](<#Sandbox>) rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access GitService through \[Sandbox.Git\] rather than creating it directly.
 
 <a name="GitService.Add"></a>
 ### func \(\*GitService\) Add
@@ -2859,7 +2859,7 @@ type OutputChannels struct {
 
 ProcessService provides process execution operations for a sandbox.
 
-ProcessService enables command execution, session management, and PTY \(pseudo\-terminal\) operations. It supports both synchronous command execution and interactive terminal sessions. Access through [Sandbox.Process](<#Sandbox>).
+ProcessService enables command execution, session management, and PTY \(pseudo\-terminal\) operations. It supports both synchronous command execution and interactive terminal sessions. Access through \[Sandbox.Process\].
 
 Example:
 
@@ -2894,7 +2894,7 @@ func NewProcessService(toolboxClient *toolbox.APIClient, otel *otelState, langua
 
 NewProcessService creates a new ProcessService with the provided toolbox client.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ProcessService through [Sandbox.Process](<#Sandbox>) rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ProcessService through \[Sandbox.Process\] rather than creating it directly.
 
 <a name="ProcessService.CodeRun"></a>
 ### func \(\*ProcessService\) CodeRun

--- a/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
@@ -657,7 +657,7 @@ for sandbox, err := range client.ListSeq(ctx, &ListSandboxesQuery{...}) {
 
 CodeInterpreterService provides Python code execution capabilities for a sandbox.
 
-CodeInterpreterService enables running Python code in isolated execution contexts with support for streaming output, persistent state, and environment variables. It uses WebSockets for real\-time output streaming. Access through \[Sandbox.CodeInterpreter\].
+CodeInterpreterService enables running Python code in isolated execution contexts with support for streaming output, persistent state, and environment variables. It uses WebSockets for real\-time output streaming. Access through [Sandbox.CodeInterpreter](<#Sandbox>).
 
 Example:
 
@@ -699,7 +699,7 @@ func NewCodeInterpreterService(toolboxClient *toolbox.APIClient, otel *otelState
 
 NewCodeInterpreterService creates a new CodeInterpreterService.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access CodeInterpreterService through \[Sandbox.CodeInterpreter\] rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access CodeInterpreterService through [Sandbox.CodeInterpreter](<#Sandbox>) rather than creating it directly.
 
 <a name="CodeInterpreterService.CreateContext"></a>
 ### func \(\*CodeInterpreterService\) CreateContext
@@ -834,7 +834,7 @@ Returns [OutputChannels](<#OutputChannels>) for receiving streamed output, or an
 
 ComputerUseService provides desktop automation operations for a sandbox.
 
-ComputerUseService enables GUI automation including mouse control, keyboard input, screenshots, display management, and screen recording. The desktop environment must be started before using these features. Access through \[Sandbox.ComputerUse\].
+ComputerUseService enables GUI automation including mouse control, keyboard input, screenshots, display management, and screen recording. The desktop environment must be started before using these features. Access through [Sandbox.ComputerUse](<#Sandbox>).
 
 Example:
 
@@ -875,7 +875,7 @@ func NewComputerUseService(toolboxClient *toolbox.APIClient, otel *otelState) *C
 
 NewComputerUseService creates a new ComputerUseService.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ComputerUseService through \[Sandbox.ComputerUse\] rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ComputerUseService through [Sandbox.ComputerUse](<#Sandbox>) rather than creating it directly.
 
 <a name="ComputerUseService.Accessibility"></a>
 ### func \(\*ComputerUseService\) Accessibility
@@ -1521,7 +1521,7 @@ WithDownloadProgress returns an option that enables progress tracking for stream
 
 FileSystemService provides file system operations for a sandbox.
 
-FileSystemService enables file and directory management including creating, reading, writing, moving, and deleting files. It also supports file searching and permission management. Access through \[Sandbox.FileSystem\].
+FileSystemService enables file and directory management including creating, reading, writing, moving, and deleting files. It also supports file searching and permission management. Access through [Sandbox.FileSystem](<#Sandbox>).
 
 Example:
 
@@ -1554,7 +1554,7 @@ func NewFileSystemService(toolboxClient *toolbox.APIClient, otel *otelState) *Fi
 
 NewFileSystemService creates a new FileSystemService with the provided toolbox client.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access FileSystemService through \[Sandbox.FileSystem\] rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access FileSystemService through [Sandbox.FileSystem](<#Sandbox>) rather than creating it directly.
 
 <a name="FileSystemService.CreateFolder"></a>
 ### func \(\*FileSystemService\) CreateFolder
@@ -1960,7 +1960,7 @@ err := sandbox.FileSystem.UploadFileStream(ctx, f, "/home/user/big.bin",
 
 GitService provides Git operations for a sandbox.
 
-GitService enables common Git workflows including cloning repositories, staging and committing changes, managing branches, and syncing with remote repositories. It is accessed through the \[Sandbox.Git\] field.
+GitService enables common Git workflows including cloning repositories, staging and committing changes, managing branches, and syncing with remote repositories. It is accessed through the [Sandbox.Git](<#Sandbox>) field.
 
 Example:
 
@@ -1994,7 +1994,7 @@ func NewGitService(toolboxClient *toolbox.APIClient, otel *otelState) *GitServic
 
 NewGitService creates a new GitService with the provided toolbox client.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access GitService through \[Sandbox.Git\] rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access GitService through [Sandbox.Git](<#Sandbox>) rather than creating it directly.
 
 <a name="GitService.Add"></a>
 ### func \(\*GitService\) Add
@@ -2859,7 +2859,7 @@ type OutputChannels struct {
 
 ProcessService provides process execution operations for a sandbox.
 
-ProcessService enables command execution, session management, and PTY \(pseudo\-terminal\) operations. It supports both synchronous command execution and interactive terminal sessions. Access through \[Sandbox.Process\].
+ProcessService enables command execution, session management, and PTY \(pseudo\-terminal\) operations. It supports both synchronous command execution and interactive terminal sessions. Access through [Sandbox.Process](<#Sandbox>).
 
 Example:
 
@@ -2894,7 +2894,7 @@ func NewProcessService(toolboxClient *toolbox.APIClient, otel *otelState, langua
 
 NewProcessService creates a new ProcessService with the provided toolbox client.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ProcessService through \[Sandbox.Process\] rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ProcessService through [Sandbox.Process](<#Sandbox>) rather than creating it directly.
 
 <a name="ProcessService.CodeRun"></a>
 ### func \(\*ProcessService\) CodeRun
@@ -4111,6 +4111,10 @@ type Sandbox struct {
     // Not populated by [Client.List]; call [Sandbox.RefreshData] on each item to populate.
     NetworkAllowList *string
 
+    // DomainAllowList is a comma-separated list of allowed domains.
+    // Not populated by [Client.List]; call [Sandbox.RefreshData] on each item to populate.
+    DomainAllowList *string
+
     FileSystem      *FileSystemService      // File system operations
     Git             *GitService             // Git operations
     Process         *ProcessService         // Process and PTY operations
@@ -4426,7 +4430,7 @@ func (s *Sandbox) RefreshData(ctx context.Context) error
 
 RefreshData refreshes the sandbox data from the API.
 
-This updates all sandbox fields from the server, including those not populated by [Client.List](<#Client.List>) \(Env, NetworkBlockAll, NetworkAllowList, Volumes, BuildInfo, BackupCreatedAt\).
+This updates all sandbox fields from the server, including those not populated by [Client.List](<#Client.List>) \(Env, NetworkBlockAll, NetworkAllowList, DomainAllowList, Volumes, BuildInfo, BackupCreatedAt\).
 
 Example:
 

--- a/apps/docs/src/content/docs/en/go-sdk/types.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/types.mdx
@@ -291,7 +291,7 @@ type GitStatus struct {
 <a name="GpuType"></a>
 ## type GpuType
 
-GpuType identifies a specific NVIDIA GPU model. Used in [Resources.GpuType](<#Resources>) as an ordered preference list — the scheduler tries each in order and pins the sandbox/snapshot to the first that has capacity. It is an alias for the API client's GpuType type.
+GpuType identifies a specific NVIDIA GPU model. Used in \[Resources.GpuType\] as an ordered preference list — the scheduler tries each in order and pins the sandbox/snapshot to the first that has capacity. It is an alias for the API client's GpuType type.
 
 ```go
 type GpuType = apiclient.GpuType

--- a/apps/docs/src/content/docs/en/go-sdk/types.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/types.mdx
@@ -291,7 +291,7 @@ type GitStatus struct {
 <a name="GpuType"></a>
 ## type GpuType
 
-GpuType identifies a specific NVIDIA GPU model. Used in \[Resources.GpuType\] as an ordered preference list — the scheduler tries each in order and pins the sandbox/snapshot to the first that has capacity. It is an alias for the API client's GpuType type.
+GpuType identifies a specific NVIDIA GPU model. Used in [Resources.GpuType](<#Resources>) as an ordered preference list — the scheduler tries each in order and pins the sandbox/snapshot to the first that has capacity. It is an alias for the API client's GpuType type.
 
 ```go
 type GpuType = apiclient.GpuType
@@ -466,6 +466,7 @@ type SandboxBaseParams struct {
     Volumes             []VolumeMount
     NetworkBlockAll     bool
     NetworkAllowList    *string
+    DomainAllowList     *string
     Ephemeral           bool
     // LinkedSandbox is the ID or name of an existing sandbox to link the new sandbox to.
     // The new sandbox will be scheduled on the same runner as the linked sandbox so a local

--- a/apps/docs/src/content/docs/en/java-sdk/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/java-sdk/sandbox.mdx
@@ -609,6 +609,19 @@ Not returned by `Daytona#list`; call `#refreshData()` on each item to populate.
 
 - `String` - allow list, or `null`
 
+#### getDomainAllowList()
+```java
+public String getDomainAllowList()
+```
+
+Returns the comma-separated list of allowed domains, if any.
+
+Not returned by `Daytona#list`; call `#refreshData()` on each item to populate.
+
+**Returns**:
+
+- `String` - allowed domains, or `null`
+
 #### getVolumes()
 ```java
 public List<SandboxVolume> getVolumes()

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-daytona.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-daytona.mdx
@@ -474,6 +474,7 @@ Base parameters for creating a new Sandbox.
 - `volumes` _list[VolumeMount] | None_ - List of volumes mounts to attach to the Sandbox.
 - `network_block_all` _bool | None_ - Whether to block all network access for the Sandbox.
 - `network_allow_list` _str | None_ - Comma-separated list of allowed CIDR network addresses for the Sandbox.
+- `domain_allow_list` _str | None_ - Comma-separated list of allowed domains for the Sandbox.
 - `ephemeral` _bool | None_ - Whether the Sandbox should be ephemeral.
   If True, auto_delete_interval will be set to 0.
 - `linked_sandbox` _str | None_ - ID or name of an existing Sandbox to link the new Sandbox to. The new

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-sandbox.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-sandbox.mdx
@@ -53,6 +53,8 @@ Represents a Daytona Sandbox.
   (not returned by list results; call `refresh_data()` on each item to populate).
 - `network_allow_list` _str | None_ - Comma-separated list of allowed CIDR network addresses for
   the Sandbox (not returned by list results; call `refresh_data()` on each item to populate).
+- `domain_allow_list` _str | None_ - Comma-separated list of allowed domains for
+  the Sandbox (not returned by list results; call `refresh_data()` on each item to populate).
 - `toolbox_proxy_url` _str_ - The toolbox proxy URL for the Sandbox.
 
 ##### env: `dict[str, str] | None`
@@ -452,7 +454,8 @@ sandbox.set_auto_delete_interval(-1)
 async def update_network_settings(
         *,
         network_block_all: bool | None = None,
-        network_allow_list: str | None = None) -> None
+        network_allow_list: str | None = None,
+        domain_allow_list: str | None = None) -> None
 ```
 
 Updates outbound network policy on the runner (block all, restore access, or CIDR allow list).
@@ -462,6 +465,7 @@ Updates outbound network policy on the runner (block all, restore access, or CID
 - `network_block_all` - When ``True``, blocks all outbound traffic. When ``False``, restores general
   outbound access (and clears a stored allow list).
 - `network_allow_list` - Comma-separated IPv4 CIDRs to allow; implies not blocking all.
+- `domain_allow_list` - Comma-separated domains to allow; implies not blocking all.
   
 
 **Raises**:

--- a/apps/docs/src/content/docs/en/python-sdk/sync/daytona.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/daytona.mdx
@@ -421,6 +421,7 @@ Base parameters for creating a new Sandbox.
 - `volumes` _list[VolumeMount] | None_ - List of volumes mounts to attach to the Sandbox.
 - `network_block_all` _bool | None_ - Whether to block all network access for the Sandbox.
 - `network_allow_list` _str | None_ - Comma-separated list of allowed CIDR network addresses for the Sandbox.
+- `domain_allow_list` _str | None_ - Comma-separated list of allowed domains for the Sandbox.
 - `ephemeral` _bool | None_ - Whether the Sandbox should be ephemeral.
   If True, auto_delete_interval will be set to 0.
 - `linked_sandbox` _str | None_ - ID or name of an existing Sandbox to link the new Sandbox to. The new

--- a/apps/docs/src/content/docs/en/python-sdk/sync/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/sandbox.mdx
@@ -53,6 +53,8 @@ Represents a Daytona Sandbox.
   (not returned by list results; call `refresh_data()` on each item to populate).
 - `network_allow_list` _str | None_ - Comma-separated list of allowed CIDR network addresses for
   the Sandbox (not returned by list results; call `refresh_data()` on each item to populate).
+- `domain_allow_list` _str | None_ - Comma-separated list of allowed domains for
+  the Sandbox (not returned by list results; call `refresh_data()` on each item to populate).
 - `toolbox_proxy_url` _str_ - The toolbox proxy URL for the Sandbox.
 
 ##### env: `dict[str, str] | None`
@@ -468,7 +470,8 @@ sandbox.set_auto_delete_interval(-1)
 @with_instrumentation()
 def update_network_settings(*,
                             network_block_all: bool | None = None,
-                            network_allow_list: str | None = None) -> None
+                            network_allow_list: str | None = None,
+                            domain_allow_list: str | None = None) -> None
 ```
 
 Updates outbound network policy on the runner (block all, restore access, or CIDR allow list).
@@ -478,6 +481,7 @@ Updates outbound network policy on the runner (block all, restore access, or CID
 - `network_block_all` - When ``True``, blocks all outbound traffic. When ``False``, restores general
   outbound access (and clears a stored allow list).
 - `network_allow_list` - Comma-separated IPv4 CIDRs to allow; implies not blocking all.
+- `domain_allow_list` - Comma-separated domains to allow; implies not blocking all.
   
 
 **Raises**:

--- a/apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx
@@ -124,6 +124,18 @@ def network_allow_list()
 - `String, nil` - Comma-separated list of allowed CIDR network addresses for the sandbox.
 Not returned by list results; call #refresh on each item to populate.
 
+#### domain_allow_list()
+
+```ruby
+def domain_allow_list()
+
+```
+
+**Returns**:
+
+- `String, nil` - Comma-separated list of allowed domains for the sandbox.
+Not returned by list results; call #refresh on each item to populate.
+
 #### target()
 
 ```ruby
@@ -480,7 +492,7 @@ The Sandbox will automatically delete after being continuously stopped for the s
 #### update_network_settings()
 
 ```ruby
-def update_network_settings(network_block_all:, network_allow_list:)
+def update_network_settings(network_block_all:, network_allow_list:, domain_allow_list:)
 
 ```
 
@@ -490,6 +502,7 @@ Updates outbound network policy on the runner (block all, restore access, or CID
 
 - `network_block_all` _Boolean, nil_ -
 - `network_allow_list` _String, nil_ -
+- `domain_allow_list` _String, nil_ -
 
 **Returns**:
 

--- a/apps/docs/src/content/docs/en/typescript-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/daytona.mdx
@@ -380,6 +380,7 @@ Base parameters for creating a new Sandbox.
 - `autoArchiveInterval?` _number_ - Auto-archive interval in minutes (0 means the maximum interval will be used). Default is 7 days.
 - `autoDeleteInterval?` _number_ - Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping). By default, auto-delete is disabled.
 - `autoStopInterval?` _number_ - Auto-stop interval in minutes (0 means disabled). Default is 15 minutes.
+- `domainAllowList?` _string_ - Comma-separated list of allowed domains for the Sandbox
 - `envVars?` _Record\<string, string\>_ - Optional environment variables to set in the Sandbox
 - `ephemeral?` _boolean_ - Whether the Sandbox should be ephemeral. If true, autoDeleteInterval will be set to 0.
 - `labels?` _Record\<string, string\>_ - Sandbox labels
@@ -400,6 +401,7 @@ Parameters for creating a new Sandbox.
 - `autoArchiveInterval?` _number_
 - `autoDeleteInterval?` _number_
 - `autoStopInterval?` _number_
+- `domainAllowList?` _string_
 - `envVars?` _Record\<string, string\>_
 - `ephemeral?` _boolean_
 - `image` _string \| Image_ - Custom Docker image to use for the Sandbox. If an Image object is provided,
@@ -424,6 +426,7 @@ Parameters for creating a new Sandbox from a snapshot.
 - `autoArchiveInterval?` _number_
 - `autoDeleteInterval?` _number_
 - `autoStopInterval?` _number_
+- `domainAllowList?` _string_
 - `envVars?` _Record\<string, string\>_
 - `ephemeral?` _boolean_
 - `labels?` _Record\<string, string\>_

--- a/apps/docs/src/content/docs/en/typescript-sdk/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/sandbox.mdx
@@ -24,6 +24,8 @@ Represents a Daytona Sandbox.
 - `cpu` _number_ - Number of CPUs allocated to the Sandbox
 - `createdAt?` _string_ - When the Sandbox was created
 - `disk` _number_ - Amount of disk space allocated to the Sandbox in GiB
+- `domainAllowList?` _string_ - Comma-separated list of allowed domains for the Sandbox
+    (not returned by list results; call `refreshData()` on each item to populate)
 - `env?` _Record\<string, string\>_ - Environment variables set in the Sandbox
     (not returned by list results; call `refreshData()` on each item to populate)
 - `errorReason?` _string_ - Error message if Sandbox is in error state
@@ -767,12 +769,13 @@ updateNetworkSettings(settings: UpdateSandboxNetworkSettings): Promise<void>
 Updates outbound network policy for this sandbox on the runner (for example block all traffic,
 restore general internet access, or apply a CIDR allow list) without stopping the sandbox.
 
-This maps to the same mechanism as creating a sandbox with `networkBlockAll` / `networkAllowList`:
-the runner applies iptables rules to the sandbox container.
+This maps to the same mechanism as creating a sandbox with `networkBlockAll` / `networkAllowList` /
+`domainAllowList`: the runner applies iptables rules to the sandbox container.
 
 **Parameters**:
 
-- `settings` _UpdateSandboxNetworkSettings_ - At least one of `networkBlockAll` or `networkAllowList` must be set.
+- `settings` _UpdateSandboxNetworkSettings_ - At least one of `networkBlockAll`, `networkAllowList` or
+    `domainAllowList` must be set.
     Set `networkBlockAll` to `false` to restore outbound access after a block (and clear a stored allow list).
 
 
@@ -787,6 +790,8 @@ the runner applies iptables rules to the sandbox container.
 await sandbox.updateNetworkSettings({ networkBlockAll: true });
 // Resume internet
 await sandbox.updateNetworkSettings({ networkBlockAll: false });
+// Allow only specific domains
+await sandbox.updateNetworkSettings({ domainAllowList: 'example.com,*.daytona.io' });
 ```
 
 ***

--- a/apps/runner/go.mod
+++ b/apps/runner/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.5 // indirect
-	github.com/docker/go-connections v0.5.0 // indirect
+	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.9.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -158,5 +158,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/grpc v1.80.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gotest.tools/v3 v3.5.1 // indirect
+	gotest.tools/v3 v3.5.2 // indirect
 )

--- a/apps/runner/go.sum
+++ b/apps/runner/go.sum
@@ -81,8 +81,7 @@ github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaft
 github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.9.5 h1:EFNN8DHvaiK8zVqFA2DT6BjXE0GzfLOZ38ggPTKePkY=
 github.com/docker/docker-credential-helpers v0.9.5/go.mod h1:v1S+hepowrQXITkEfw6o4+BMbGot02wiKpzWhGUZK6c=
-github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
-github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
+github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -454,5 +453,4 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
-gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
+gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1556,6 +1556,9 @@ const docTemplate = `{
                     "type": "integer",
                     "minimum": 1
                 },
+                "domainAllowList": {
+                    "type": "string"
+                },
                 "entrypoint": {
                     "type": "array",
                     "items": {
@@ -2052,6 +2055,9 @@ const docTemplate = `{
         "UpdateNetworkSettingsDTO": {
             "type": "object",
             "properties": {
+                "domainAllowList": {
+                    "type": "string"
+                },
                 "networkAllowList": {
                     "type": "string"
                 },

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1451,6 +1451,9 @@
           "type": "integer",
           "minimum": 1
         },
+        "domainAllowList": {
+          "type": "string"
+        },
         "entrypoint": {
           "type": "array",
           "items": {
@@ -1914,6 +1917,9 @@
     "UpdateNetworkSettingsDTO": {
       "type": "object",
       "properties": {
+        "domainAllowList": {
+          "type": "string"
+        },
         "networkAllowList": {
           "type": "string"
         },

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -41,6 +41,8 @@ definitions:
       cpuQuota:
         minimum: 1
         type: integer
+      domainAllowList:
+        type: string
       entrypoint:
         items:
           type: string
@@ -391,6 +393,8 @@ definitions:
     type: object
   UpdateNetworkSettingsDTO:
     properties:
+      domainAllowList:
+        type: string
       networkAllowList:
         type: string
       networkBlockAll:

--- a/apps/runner/pkg/api/dto/sandbox.go
+++ b/apps/runner/pkg/api/dto/sandbox.go
@@ -23,6 +23,7 @@ type CreateSandboxDTO struct {
 	Volumes          []VolumeDTO       `json:"volumes,omitempty"`
 	NetworkBlockAll  *bool             `json:"networkBlockAll,omitempty"`
 	NetworkAllowList *string           `json:"networkAllowList,omitempty"`
+	DomainAllowList  *string           `json:"domainAllowList,omitempty"`
 	Metadata         map[string]string `json:"metadata,omitempty"`
 	AuthToken        *string           `json:"authToken,omitempty"`
 	OtelEndpoint     *string           `json:"otelEndpoint,omitempty"`
@@ -58,6 +59,7 @@ type ResizeSandboxDTO struct {
 type UpdateNetworkSettingsDTO struct {
 	NetworkBlockAll    *bool   `json:"networkBlockAll,omitempty"`
 	NetworkAllowList   *string `json:"networkAllowList,omitempty"`
+	DomainAllowList    *string `json:"domainAllowList,omitempty"`
 	NetworkLimitEgress *bool   `json:"networkLimitEgress,omitempty"`
 } //	@name	UpdateNetworkSettingsDTO
 

--- a/examples/typescript/domain-allow-list/index.ts
+++ b/examples/typescript/domain-allow-list/index.ts
@@ -1,0 +1,60 @@
+import { Daytona, Image, Sandbox } from '@daytona/sdk'
+
+/**
+ * Runs `curl` against a URL inside the sandbox and reports whether the request
+ * made it out through the sandbox's domain allow list or was blocked.
+ */
+async function checkAccess(sandbox: Sandbox, url: string) {
+  const res = await sandbox.process.executeCommand(`curl -sS --max-time 10 -o /dev/null -w "%{http_code}" ${url}`)
+  const allowed = res.exitCode === 0
+  const detail = allowed ? `HTTP ${res.result.trim()}` : `exit ${res.exitCode}`
+  console.log(`  ${allowed ? '✅ allowed' : '⛔ blocked'}  ${url}  (${detail})`)
+}
+
+async function main() {
+  const daytona = new Daytona()
+
+  // A domain allow list is a comma-separated list of domains the sandbox is
+  // allowed to reach. Everything else is blocked. Wildcards match subdomains:
+  //   - google.com    → the apex domain
+  //   - *.google.com  → www.google.com, mail.google.com, ...
+  const domainAllowList = 'google.com,*.google.com'
+
+  // The image just needs curl so we can demonstrate the allow list in action.
+  const sandbox = await daytona.create(
+    {
+      image: Image.base('ubuntu:22.04').runCommands(
+        'apt-get update',
+        'apt-get install -y --no-install-recommends curl ca-certificates',
+      ),
+      domainAllowList,
+    },
+    {
+      timeout: 200,
+      onSnapshotCreateLogs: console.log,
+    },
+  )
+
+  try {
+    console.log('domainAllowList:', sandbox.domainAllowList)
+
+    console.log(`\nWith allow list "${domainAllowList}":`)
+    await checkAccess(sandbox, 'https://www.google.com') // matches *.google.com
+    await checkAccess(sandbox, 'https://google.com') // matches google.com
+    await checkAccess(sandbox, 'https://example.com') // not on the list -> blocked
+
+    // The allow list can also be changed at runtime without restarting the
+    // sandbox. Here we swap it out so only example.com is reachable.
+    console.log('\nUpdating allow list to "example.com":')
+    await sandbox.updateNetworkSettings({ domainAllowList: 'example.com' })
+    console.log('domainAllowList:', sandbox.domainAllowList)
+
+    await checkAccess(sandbox, 'https://example.com') // now allowed
+    await checkAccess(sandbox, 'https://www.google.com') // now blocked
+  } finally {
+    // cleanup
+    await daytona.delete(sandbox)
+  }
+}
+
+main().catch(console.error)

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
           protoc-gen-go
           protoc-gen-go-grpc
           libgit2
-        ] ++ darwinDeps;
+        ] ++ darwinDeps ++ bpfPkgs;
 
         goShellHook = ''
           unset GOROOT
@@ -71,6 +71,26 @@
           _nix_install_go_tool gomarkdoc "github.com/princjef/gomarkdoc/cmd/gomarkdoc@v1.1.0"
           unset -f _nix_install_go_tool
         '';
+
+        # ──────────────────────────────────────────────
+        # eBPF toolchain (Linux only)
+        # Covers: libs/netleash — `make generate` runs bpf2go, which compiles the
+        # BPF C sources with clang and strips them with llvm-strip. libbpf and the
+        # kernel UAPI headers supply <bpf/...> and <linux/...>/<asm/...>.
+        # Pinned to LLVM 18 to match the committed generated objects.
+        # The header packages go in buildInputs (not packages) so the clang
+        # cc-wrapper injects their include dirs via NIX_CFLAGS_COMPILE — this lets
+        # `make generate` find the headers without any Makefile changes.
+        # ──────────────────────────────────────────────
+        bpfPkgs = pkgs.lib.optionals pkgs.stdenv.isLinux [
+          pkgs.llvmPackages_18.clang # bpf2go: clang -cc
+          pkgs.llvmPackages_18.llvm # bpf2go: llvm-strip
+        ];
+
+        bpfHeaderInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [
+          pkgs.libbpf # <bpf/bpf_helpers.h>, <bpf/bpf_endian.h>
+          pkgs.linuxHeaders # <linux/bpf.h>, <asm/types.h>, ...
+        ];
 
         # ──────────────────────────────────────────────
         # Node.js / TypeScript toolchain
@@ -140,6 +160,10 @@
           default = pkgs.mkShell {
             name = "daytona";
             packages = commonPkgs ++ goPkgs ++ nodePkgs ++ pythonPkgs ++ rubyPkgs ++ javaPkgs;
+            buildInputs = bpfHeaderInputs;
+            # bpf2go invokes clang with `-target bpf`; the cc-wrapper's hardening
+            # flags (e.g. -fzero-call-used-regs) are unsupported for that target.
+            hardeningDisable = [ "all" ];
             shellHook = ''
               ${goShellHook}
               ${nodeShellHook}
@@ -153,6 +177,10 @@
           go = pkgs.mkShell {
             name = "daytona-go";
             packages = commonPkgs ++ goPkgs;
+            buildInputs = bpfHeaderInputs;
+            # bpf2go invokes clang with `-target bpf`; the cc-wrapper's hardening
+            # flags (e.g. -fzero-call-used-regs) are unsupported for that target.
+            hardeningDisable = [ "all" ];
             shellHook = goShellHook;
           };
 

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -11117,6 +11117,7 @@ components:
         createdAt: 2024-10-01T12:00:00Z
         networkBlockAll: false
         autoDeleteInterval: 30
+        domainAllowList: "example.com,*.daytona.io"
         public: false
         errorReason: The sandbox is not running
         runnerId: runner123
@@ -11197,6 +11198,10 @@ components:
           description: Comma-separated list of allowed CIDR network addresses for
             the sandbox
           example: "192.168.1.0/16,10.0.0.0/24"
+          type: string
+        domainAllowList:
+          description: Comma-separated list of allowed domains for the sandbox
+          example: "example.com,*.daytona.io"
           type: string
         target:
           description: The target environment for the sandbox
@@ -11352,6 +11357,7 @@ components:
           createdAt: 2024-10-01T12:00:00Z
           networkBlockAll: false
           autoDeleteInterval: 30
+          domainAllowList: "example.com,*.daytona.io"
           public: false
           errorReason: The sandbox is not running
           runnerId: runner123
@@ -11395,6 +11401,7 @@ components:
           createdAt: 2024-10-01T12:00:00Z
           networkBlockAll: false
           autoDeleteInterval: 30
+          domainAllowList: "example.com,*.daytona.io"
           public: false
           errorReason: The sandbox is not running
           runnerId: runner123
@@ -11490,6 +11497,7 @@ components:
         networkBlockAll: false
         disk: 3
         autoDeleteInterval: 30
+        domainAllowList: "example.com,*.daytona.io"
         public: false
         linkedSandbox: sandbox123
         name: MySandbox
@@ -11538,6 +11546,10 @@ components:
           description: Comma-separated list of allowed CIDR network addresses for
             the sandbox
           example: "192.168.1.0/16,10.0.0.0/24"
+          type: string
+        domainAllowList:
+          description: Comma-separated list of allowed domains for the sandbox
+          example: "example.com,*.daytona.io"
           type: string
         target:
           description: The target (region) where the sandbox will be created
@@ -11714,6 +11726,7 @@ components:
     UpdateSandboxNetworkSettings:
       example:
         networkBlockAll: false
+        domainAllowList: "example.com,*.daytona.io"
         networkAllowList: "192.168.1.0/16,10.0.0.0/24"
       properties:
         networkBlockAll:
@@ -11724,6 +11737,10 @@ components:
           description: Comma-separated list of allowed CIDR network addresses for
             the sandbox
           example: "192.168.1.0/16,10.0.0.0/24"
+          type: string
+        domainAllowList:
+          description: Comma-separated list of allowed domains for the sandbox
+          example: "example.com,*.daytona.io"
           type: string
       type: object
     PortPreviewUrl:

--- a/libs/api-client-go/model_create_sandbox.go
+++ b/libs/api-client-go/model_create_sandbox.go
@@ -36,6 +36,8 @@ type CreateSandbox struct {
 	NetworkBlockAll *bool `json:"networkBlockAll,omitempty"`
 	// Comma-separated list of allowed CIDR network addresses for the sandbox
 	NetworkAllowList *string `json:"networkAllowList,omitempty"`
+	// Comma-separated list of allowed domains for the sandbox
+	DomainAllowList *string `json:"domainAllowList,omitempty"`
 	// The target (region) where the sandbox will be created
 	Target *string `json:"target,omitempty"`
 	// CPU cores allocated to the sandbox
@@ -336,6 +338,38 @@ func (o *CreateSandbox) HasNetworkAllowList() bool {
 // SetNetworkAllowList gets a reference to the given string and assigns it to the NetworkAllowList field.
 func (o *CreateSandbox) SetNetworkAllowList(v string) {
 	o.NetworkAllowList = &v
+}
+
+// GetDomainAllowList returns the DomainAllowList field value if set, zero value otherwise.
+func (o *CreateSandbox) GetDomainAllowList() string {
+	if o == nil || IsNil(o.DomainAllowList) {
+		var ret string
+		return ret
+	}
+	return *o.DomainAllowList
+}
+
+// GetDomainAllowListOk returns a tuple with the DomainAllowList field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CreateSandbox) GetDomainAllowListOk() (*string, bool) {
+	if o == nil || IsNil(o.DomainAllowList) {
+		return nil, false
+	}
+	return o.DomainAllowList, true
+}
+
+// HasDomainAllowList returns a boolean if a field has been set.
+func (o *CreateSandbox) HasDomainAllowList() bool {
+	if o != nil && !IsNil(o.DomainAllowList) {
+		return true
+	}
+
+	return false
+}
+
+// SetDomainAllowList gets a reference to the given string and assigns it to the DomainAllowList field.
+func (o *CreateSandbox) SetDomainAllowList(v string) {
+	o.DomainAllowList = &v
 }
 
 // GetTarget returns the Target field value if set, zero value otherwise.
@@ -756,6 +790,9 @@ func (o CreateSandbox) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.NetworkAllowList) {
 		toSerialize["networkAllowList"] = o.NetworkAllowList
 	}
+	if !IsNil(o.DomainAllowList) {
+		toSerialize["domainAllowList"] = o.DomainAllowList
+	}
 	if !IsNil(o.Target) {
 		toSerialize["target"] = o.Target
 	}
@@ -822,6 +859,7 @@ func (o *CreateSandbox) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "public")
 		delete(additionalProperties, "networkBlockAll")
 		delete(additionalProperties, "networkAllowList")
+		delete(additionalProperties, "domainAllowList")
 		delete(additionalProperties, "target")
 		delete(additionalProperties, "cpu")
 		delete(additionalProperties, "gpu")

--- a/libs/api-client-go/model_sandbox.go
+++ b/libs/api-client-go/model_sandbox.go
@@ -41,6 +41,8 @@ type Sandbox struct {
 	NetworkBlockAll bool `json:"networkBlockAll"`
 	// Comma-separated list of allowed CIDR network addresses for the sandbox
 	NetworkAllowList *string `json:"networkAllowList,omitempty"`
+	// Comma-separated list of allowed domains for the sandbox
+	DomainAllowList *string `json:"domainAllowList,omitempty"`
 	// The target environment for the sandbox
 	Target string `json:"target"`
 	// The CPU quota for the sandbox
@@ -381,6 +383,38 @@ func (o *Sandbox) HasNetworkAllowList() bool {
 // SetNetworkAllowList gets a reference to the given string and assigns it to the NetworkAllowList field.
 func (o *Sandbox) SetNetworkAllowList(v string) {
 	o.NetworkAllowList = &v
+}
+
+// GetDomainAllowList returns the DomainAllowList field value if set, zero value otherwise.
+func (o *Sandbox) GetDomainAllowList() string {
+	if o == nil || IsNil(o.DomainAllowList) {
+		var ret string
+		return ret
+	}
+	return *o.DomainAllowList
+}
+
+// GetDomainAllowListOk returns a tuple with the DomainAllowList field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Sandbox) GetDomainAllowListOk() (*string, bool) {
+	if o == nil || IsNil(o.DomainAllowList) {
+		return nil, false
+	}
+	return o.DomainAllowList, true
+}
+
+// HasDomainAllowList returns a boolean if a field has been set.
+func (o *Sandbox) HasDomainAllowList() bool {
+	if o != nil && !IsNil(o.DomainAllowList) {
+		return true
+	}
+
+	return false
+}
+
+// SetDomainAllowList gets a reference to the given string and assigns it to the DomainAllowList field.
+func (o *Sandbox) SetDomainAllowList(v string) {
+	o.DomainAllowList = &v
 }
 
 // GetTarget returns the Target field value
@@ -1159,6 +1193,9 @@ func (o Sandbox) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.NetworkAllowList) {
 		toSerialize["networkAllowList"] = o.NetworkAllowList
 	}
+	if !IsNil(o.DomainAllowList) {
+		toSerialize["domainAllowList"] = o.DomainAllowList
+	}
 	toSerialize["target"] = o.Target
 	toSerialize["cpu"] = o.Cpu
 	toSerialize["gpu"] = o.Gpu
@@ -1288,6 +1325,7 @@ func (o *Sandbox) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "public")
 		delete(additionalProperties, "networkBlockAll")
 		delete(additionalProperties, "networkAllowList")
+		delete(additionalProperties, "domainAllowList")
 		delete(additionalProperties, "target")
 		delete(additionalProperties, "cpu")
 		delete(additionalProperties, "gpu")

--- a/libs/api-client-go/model_update_sandbox_network_settings.go
+++ b/libs/api-client-go/model_update_sandbox_network_settings.go
@@ -24,6 +24,8 @@ type UpdateSandboxNetworkSettings struct {
 	NetworkBlockAll *bool `json:"networkBlockAll,omitempty"`
 	// Comma-separated list of allowed CIDR network addresses for the sandbox
 	NetworkAllowList *string `json:"networkAllowList,omitempty"`
+	// Comma-separated list of allowed domains for the sandbox
+	DomainAllowList *string `json:"domainAllowList,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -110,6 +112,38 @@ func (o *UpdateSandboxNetworkSettings) SetNetworkAllowList(v string) {
 	o.NetworkAllowList = &v
 }
 
+// GetDomainAllowList returns the DomainAllowList field value if set, zero value otherwise.
+func (o *UpdateSandboxNetworkSettings) GetDomainAllowList() string {
+	if o == nil || IsNil(o.DomainAllowList) {
+		var ret string
+		return ret
+	}
+	return *o.DomainAllowList
+}
+
+// GetDomainAllowListOk returns a tuple with the DomainAllowList field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *UpdateSandboxNetworkSettings) GetDomainAllowListOk() (*string, bool) {
+	if o == nil || IsNil(o.DomainAllowList) {
+		return nil, false
+	}
+	return o.DomainAllowList, true
+}
+
+// HasDomainAllowList returns a boolean if a field has been set.
+func (o *UpdateSandboxNetworkSettings) HasDomainAllowList() bool {
+	if o != nil && !IsNil(o.DomainAllowList) {
+		return true
+	}
+
+	return false
+}
+
+// SetDomainAllowList gets a reference to the given string and assigns it to the DomainAllowList field.
+func (o *UpdateSandboxNetworkSettings) SetDomainAllowList(v string) {
+	o.DomainAllowList = &v
+}
+
 func (o UpdateSandboxNetworkSettings) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -125,6 +159,9 @@ func (o UpdateSandboxNetworkSettings) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.NetworkAllowList) {
 		toSerialize["networkAllowList"] = o.NetworkAllowList
+	}
+	if !IsNil(o.DomainAllowList) {
+		toSerialize["domainAllowList"] = o.DomainAllowList
 	}
 
 	for key, value := range o.AdditionalProperties {
@@ -150,6 +187,7 @@ func (o *UpdateSandboxNetworkSettings) UnmarshalJSON(data []byte) (err error) {
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "networkBlockAll")
 		delete(additionalProperties, "networkAllowList")
+		delete(additionalProperties, "domainAllowList")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/CreateSandbox.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/CreateSandbox.java
@@ -97,6 +97,11 @@ public class CreateSandbox {
   @javax.annotation.Nullable
   private String networkAllowList;
 
+  public static final String SERIALIZED_NAME_DOMAIN_ALLOW_LIST = "domainAllowList";
+  @SerializedName(SERIALIZED_NAME_DOMAIN_ALLOW_LIST)
+  @javax.annotation.Nullable
+  private String domainAllowList;
+
   public static final String SERIALIZED_NAME_TARGET = "target";
   @SerializedName(SERIALIZED_NAME_TARGET)
   @javax.annotation.Nullable
@@ -325,6 +330,25 @@ public class CreateSandbox {
 
   public void setNetworkAllowList(@javax.annotation.Nullable String networkAllowList) {
     this.networkAllowList = networkAllowList;
+  }
+
+
+  public CreateSandbox domainAllowList(@javax.annotation.Nullable String domainAllowList) {
+    this.domainAllowList = domainAllowList;
+    return this;
+  }
+
+  /**
+   * Comma-separated list of allowed domains for the sandbox
+   * @return domainAllowList
+   */
+  @javax.annotation.Nullable
+  public String getDomainAllowList() {
+    return domainAllowList;
+  }
+
+  public void setDomainAllowList(@javax.annotation.Nullable String domainAllowList) {
+    this.domainAllowList = domainAllowList;
   }
 
 
@@ -634,6 +658,7 @@ public class CreateSandbox {
         Objects.equals(this._public, createSandbox._public) &&
         Objects.equals(this.networkBlockAll, createSandbox.networkBlockAll) &&
         Objects.equals(this.networkAllowList, createSandbox.networkAllowList) &&
+        Objects.equals(this.domainAllowList, createSandbox.domainAllowList) &&
         Objects.equals(this.target, createSandbox.target) &&
         Objects.equals(this.cpu, createSandbox.cpu) &&
         Objects.equals(this.gpu, createSandbox.gpu) &&
@@ -651,7 +676,7 @@ public class CreateSandbox {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, target, cpu, gpu, gpuType, memory, disk, autoStopInterval, autoArchiveInterval, autoDeleteInterval, volumes, buildInfo, linkedSandbox, additionalProperties);
+    return Objects.hash(name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, target, cpu, gpu, gpuType, memory, disk, autoStopInterval, autoArchiveInterval, autoDeleteInterval, volumes, buildInfo, linkedSandbox, additionalProperties);
   }
 
   @Override
@@ -666,6 +691,7 @@ public class CreateSandbox {
     sb.append("    _public: ").append(toIndentedString(_public)).append("\n");
     sb.append("    networkBlockAll: ").append(toIndentedString(networkBlockAll)).append("\n");
     sb.append("    networkAllowList: ").append(toIndentedString(networkAllowList)).append("\n");
+    sb.append("    domainAllowList: ").append(toIndentedString(domainAllowList)).append("\n");
     sb.append("    target: ").append(toIndentedString(target)).append("\n");
     sb.append("    cpu: ").append(toIndentedString(cpu)).append("\n");
     sb.append("    gpu: ").append(toIndentedString(gpu)).append("\n");
@@ -697,7 +723,7 @@ public class CreateSandbox {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "linkedSandbox"));
+    openapiFields = new HashSet<String>(Arrays.asList("name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "linkedSandbox"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(0);
@@ -727,6 +753,9 @@ public class CreateSandbox {
       }
       if ((jsonObj.get("networkAllowList") != null && !jsonObj.get("networkAllowList").isJsonNull()) && !jsonObj.get("networkAllowList").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `networkAllowList` to be a primitive type in the JSON string but got `%s`", jsonObj.get("networkAllowList").toString()));
+      }
+      if ((jsonObj.get("domainAllowList") != null && !jsonObj.get("domainAllowList").isJsonNull()) && !jsonObj.get("domainAllowList").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `domainAllowList` to be a primitive type in the JSON string but got `%s`", jsonObj.get("domainAllowList").toString()));
       }
       if ((jsonObj.get("target") != null && !jsonObj.get("target").isJsonNull()) && !jsonObj.get("target").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `target` to be a primitive type in the JSON string but got `%s`", jsonObj.get("target").toString()));

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
@@ -110,6 +110,11 @@ public class Sandbox {
   @javax.annotation.Nullable
   private String networkAllowList;
 
+  public static final String SERIALIZED_NAME_DOMAIN_ALLOW_LIST = "domainAllowList";
+  @SerializedName(SERIALIZED_NAME_DOMAIN_ALLOW_LIST)
+  @javax.annotation.Nullable
+  private String domainAllowList;
+
   public static final String SERIALIZED_NAME_TARGET = "target";
   @SerializedName(SERIALIZED_NAME_TARGET)
   @javax.annotation.Nonnull
@@ -559,6 +564,25 @@ public class Sandbox {
 
   public void setNetworkAllowList(@javax.annotation.Nullable String networkAllowList) {
     this.networkAllowList = networkAllowList;
+  }
+
+
+  public Sandbox domainAllowList(@javax.annotation.Nullable String domainAllowList) {
+    this.domainAllowList = domainAllowList;
+    return this;
+  }
+
+  /**
+   * Comma-separated list of allowed domains for the sandbox
+   * @return domainAllowList
+   */
+  @javax.annotation.Nullable
+  public String getDomainAllowList() {
+    return domainAllowList;
+  }
+
+  public void setDomainAllowList(@javax.annotation.Nullable String domainAllowList) {
+    this.domainAllowList = domainAllowList;
   }
 
 
@@ -1109,6 +1133,7 @@ public class Sandbox {
         Objects.equals(this._public, sandbox._public) &&
         Objects.equals(this.networkBlockAll, sandbox.networkBlockAll) &&
         Objects.equals(this.networkAllowList, sandbox.networkAllowList) &&
+        Objects.equals(this.domainAllowList, sandbox.domainAllowList) &&
         Objects.equals(this.target, sandbox.target) &&
         Objects.equals(this.cpu, sandbox.cpu) &&
         Objects.equals(this.gpu, sandbox.gpu) &&
@@ -1139,7 +1164,7 @@ public class Sandbox {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, organizationId, name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, target, cpu, gpu, gpuType, memory, disk, state, desiredState, errorReason, recoverable, backupState, backupCreatedAt, autoStopInterval, autoArchiveInterval, autoDeleteInterval, volumes, buildInfo, createdAt, updatedAt, lastActivityAt, sandboxClass, daemonVersion, runnerId, linkedSandboxId, toolboxProxyUrl, additionalProperties);
+    return Objects.hash(id, organizationId, name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, domainAllowList, target, cpu, gpu, gpuType, memory, disk, state, desiredState, errorReason, recoverable, backupState, backupCreatedAt, autoStopInterval, autoArchiveInterval, autoDeleteInterval, volumes, buildInfo, createdAt, updatedAt, lastActivityAt, sandboxClass, daemonVersion, runnerId, linkedSandboxId, toolboxProxyUrl, additionalProperties);
   }
 
   @Override
@@ -1156,6 +1181,7 @@ public class Sandbox {
     sb.append("    _public: ").append(toIndentedString(_public)).append("\n");
     sb.append("    networkBlockAll: ").append(toIndentedString(networkBlockAll)).append("\n");
     sb.append("    networkAllowList: ").append(toIndentedString(networkAllowList)).append("\n");
+    sb.append("    domainAllowList: ").append(toIndentedString(domainAllowList)).append("\n");
     sb.append("    target: ").append(toIndentedString(target)).append("\n");
     sb.append("    cpu: ").append(toIndentedString(cpu)).append("\n");
     sb.append("    gpu: ").append(toIndentedString(gpu)).append("\n");
@@ -1200,7 +1226,7 @@ public class Sandbox {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"));
+    openapiFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("id", "organizationId", "name", "user", "env", "labels", "public", "networkBlockAll", "target", "cpu", "gpu", "memory", "disk", "toolboxProxyUrl"));
@@ -1243,6 +1269,9 @@ public class Sandbox {
       }
       if ((jsonObj.get("networkAllowList") != null && !jsonObj.get("networkAllowList").isJsonNull()) && !jsonObj.get("networkAllowList").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `networkAllowList` to be a primitive type in the JSON string but got `%s`", jsonObj.get("networkAllowList").toString()));
+      }
+      if ((jsonObj.get("domainAllowList") != null && !jsonObj.get("domainAllowList").isJsonNull()) && !jsonObj.get("domainAllowList").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `domainAllowList` to be a primitive type in the JSON string but got `%s`", jsonObj.get("domainAllowList").toString()));
       }
       if (!jsonObj.get("target").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `target` to be a primitive type in the JSON string but got `%s`", jsonObj.get("target").toString()));

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/UpdateSandboxNetworkSettings.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/UpdateSandboxNetworkSettings.java
@@ -60,6 +60,11 @@ public class UpdateSandboxNetworkSettings {
   @javax.annotation.Nullable
   private String networkAllowList;
 
+  public static final String SERIALIZED_NAME_DOMAIN_ALLOW_LIST = "domainAllowList";
+  @SerializedName(SERIALIZED_NAME_DOMAIN_ALLOW_LIST)
+  @javax.annotation.Nullable
+  private String domainAllowList;
+
   public UpdateSandboxNetworkSettings() {
   }
 
@@ -98,6 +103,25 @@ public class UpdateSandboxNetworkSettings {
 
   public void setNetworkAllowList(@javax.annotation.Nullable String networkAllowList) {
     this.networkAllowList = networkAllowList;
+  }
+
+
+  public UpdateSandboxNetworkSettings domainAllowList(@javax.annotation.Nullable String domainAllowList) {
+    this.domainAllowList = domainAllowList;
+    return this;
+  }
+
+  /**
+   * Comma-separated list of allowed domains for the sandbox
+   * @return domainAllowList
+   */
+  @javax.annotation.Nullable
+  public String getDomainAllowList() {
+    return domainAllowList;
+  }
+
+  public void setDomainAllowList(@javax.annotation.Nullable String domainAllowList) {
+    this.domainAllowList = domainAllowList;
   }
 
   /**
@@ -156,13 +180,14 @@ public class UpdateSandboxNetworkSettings {
     }
     UpdateSandboxNetworkSettings updateSandboxNetworkSettings = (UpdateSandboxNetworkSettings) o;
     return Objects.equals(this.networkBlockAll, updateSandboxNetworkSettings.networkBlockAll) &&
-        Objects.equals(this.networkAllowList, updateSandboxNetworkSettings.networkAllowList)&&
+        Objects.equals(this.networkAllowList, updateSandboxNetworkSettings.networkAllowList) &&
+        Objects.equals(this.domainAllowList, updateSandboxNetworkSettings.domainAllowList)&&
         Objects.equals(this.additionalProperties, updateSandboxNetworkSettings.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(networkBlockAll, networkAllowList, additionalProperties);
+    return Objects.hash(networkBlockAll, networkAllowList, domainAllowList, additionalProperties);
   }
 
   @Override
@@ -171,6 +196,7 @@ public class UpdateSandboxNetworkSettings {
     sb.append("class UpdateSandboxNetworkSettings {\n");
     sb.append("    networkBlockAll: ").append(toIndentedString(networkBlockAll)).append("\n");
     sb.append("    networkAllowList: ").append(toIndentedString(networkAllowList)).append("\n");
+    sb.append("    domainAllowList: ").append(toIndentedString(domainAllowList)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -190,7 +216,7 @@ public class UpdateSandboxNetworkSettings {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("networkBlockAll", "networkAllowList"));
+    openapiFields = new HashSet<String>(Arrays.asList("networkBlockAll", "networkAllowList", "domainAllowList"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(0);
@@ -211,6 +237,9 @@ public class UpdateSandboxNetworkSettings {
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if ((jsonObj.get("networkAllowList") != null && !jsonObj.get("networkAllowList").isJsonNull()) && !jsonObj.get("networkAllowList").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `networkAllowList` to be a primitive type in the JSON string but got `%s`", jsonObj.get("networkAllowList").toString()));
+      }
+      if ((jsonObj.get("domainAllowList") != null && !jsonObj.get("domainAllowList").isJsonNull()) && !jsonObj.get("domainAllowList").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `domainAllowList` to be a primitive type in the JSON string but got `%s`", jsonObj.get("domainAllowList").toString()));
       }
   }
 

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/CreateSandboxTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/CreateSandboxTest.java
@@ -109,6 +109,14 @@ public class CreateSandboxTest {
     }
 
     /**
+     * Test the property 'domainAllowList'
+     */
+    @Test
+    public void domainAllowListTest() {
+        // TODO: test domainAllowList
+    }
+
+    /**
      * Test the property 'target'
      */
     @Test

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/SandboxTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/SandboxTest.java
@@ -128,6 +128,14 @@ public class SandboxTest {
     }
 
     /**
+     * Test the property 'domainAllowList'
+     */
+    @Test
+    public void domainAllowListTest() {
+        // TODO: test domainAllowList
+    }
+
+    /**
      * Test the property 'target'
      */
     @Test

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/UpdateSandboxNetworkSettingsTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/UpdateSandboxNetworkSettingsTest.java
@@ -53,4 +53,12 @@ public class UpdateSandboxNetworkSettingsTest {
         // TODO: test networkAllowList
     }
 
+    /**
+     * Test the property 'domainAllowList'
+     */
+    @Test
+    public void domainAllowListTest() {
+        // TODO: test domainAllowList
+    }
+
 }

--- a/libs/api-client-python-async/daytona_api_client_async/models/create_sandbox.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/create_sandbox.py
@@ -41,6 +41,7 @@ class CreateSandbox(BaseModel):
     public: Optional[StrictBool] = Field(default=None, description="Whether the sandbox http preview is publicly accessible")
     network_block_all: Optional[StrictBool] = Field(default=None, description="Whether to block all network access for the sandbox", serialization_alias="networkBlockAll")
     network_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed CIDR network addresses for the sandbox", serialization_alias="networkAllowList")
+    domain_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed domains for the sandbox", serialization_alias="domainAllowList")
     target: Optional[StrictStr] = Field(default=None, description="The target (region) where the sandbox will be created")
     cpu: Optional[StrictInt] = Field(default=None, description="CPU cores allocated to the sandbox")
     gpu: Optional[StrictInt] = Field(default=None, description="GPU units allocated to the sandbox")
@@ -54,7 +55,7 @@ class CreateSandbox(BaseModel):
     build_info: Optional[CreateBuildInfo] = Field(default=None, description="Build information for the sandbox", serialization_alias="buildInfo")
     linked_sandbox: Optional[StrictStr] = Field(default=None, description="ID or name of an existing sandbox to link the new sandbox to. The new sandbox will be scheduled on the same runner as the linked sandbox so a local network can be established between them. Linked sandboxes must be ephemeral (autoDeleteInterval=0) and cannot themselves be linked to another sandbox.", serialization_alias="linkedSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "linkedSandbox"]
+    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "linkedSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -131,6 +132,7 @@ class CreateSandbox(BaseModel):
             "public": obj.get("public"),
             "network_block_all": obj.get("networkBlockAll"),
             "network_allow_list": obj.get("networkAllowList"),
+            "domain_allow_list": obj.get("domainAllowList"),
             "target": obj.get("target"),
             "cpu": obj.get("cpu"),
             "gpu": obj.get("gpu"),

--- a/libs/api-client-python-async/daytona_api_client_async/models/sandbox.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/sandbox.py
@@ -45,6 +45,7 @@ class Sandbox(BaseModel):
     public: StrictBool = Field(description="Whether the sandbox http preview is public")
     network_block_all: StrictBool = Field(description="Whether to block all network access for the sandbox", serialization_alias="networkBlockAll")
     network_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed CIDR network addresses for the sandbox", serialization_alias="networkAllowList")
+    domain_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed domains for the sandbox", serialization_alias="domainAllowList")
     target: StrictStr = Field(description="The target environment for the sandbox")
     cpu: Union[StrictFloat, StrictInt] = Field(description="The CPU quota for the sandbox")
     gpu: Union[StrictFloat, StrictInt] = Field(description="The GPU quota for the sandbox")
@@ -71,7 +72,7 @@ class Sandbox(BaseModel):
     linked_sandbox_id: Optional[StrictStr] = Field(default=None, description="ID of the sandbox this sandbox is linked to. When set, the sandbox is co-located on the same runner as the linked sandbox.", serialization_alias="linkedSandboxId")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -150,6 +151,7 @@ class Sandbox(BaseModel):
             "public": obj.get("public"),
             "network_block_all": obj.get("networkBlockAll"),
             "network_allow_list": obj.get("networkAllowList"),
+            "domain_allow_list": obj.get("domainAllowList"),
             "target": obj.get("target"),
             "cpu": obj.get("cpu"),
             "gpu": obj.get("gpu"),

--- a/libs/api-client-python-async/daytona_api_client_async/models/update_sandbox_network_settings.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/update_sandbox_network_settings.py
@@ -32,8 +32,9 @@ class UpdateSandboxNetworkSettings(BaseModel):
     """ # noqa: E501
     network_block_all: Optional[StrictBool] = Field(default=None, description="Whether to block all network access for the sandbox", serialization_alias="networkBlockAll")
     network_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed CIDR network addresses for the sandbox", serialization_alias="networkAllowList")
+    domain_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed domains for the sandbox", serialization_alias="domainAllowList")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["networkBlockAll", "networkAllowList"]
+    __properties: ClassVar[List[str]] = ["networkBlockAll", "networkAllowList", "domainAllowList"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -93,7 +94,8 @@ class UpdateSandboxNetworkSettings(BaseModel):
 
         _obj = cls.model_validate({
             "network_block_all": obj.get("networkBlockAll"),
-            "network_allow_list": obj.get("networkAllowList")
+            "network_allow_list": obj.get("networkAllowList"),
+            "domain_allow_list": obj.get("domainAllowList")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/create_sandbox.py
+++ b/libs/api-client-python/daytona_api_client/models/create_sandbox.py
@@ -41,6 +41,7 @@ class CreateSandbox(BaseModel):
     public: Optional[StrictBool] = Field(default=None, description="Whether the sandbox http preview is publicly accessible")
     network_block_all: Optional[StrictBool] = Field(default=None, description="Whether to block all network access for the sandbox", serialization_alias="networkBlockAll")
     network_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed CIDR network addresses for the sandbox", serialization_alias="networkAllowList")
+    domain_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed domains for the sandbox", serialization_alias="domainAllowList")
     target: Optional[StrictStr] = Field(default=None, description="The target (region) where the sandbox will be created")
     cpu: Optional[StrictInt] = Field(default=None, description="CPU cores allocated to the sandbox")
     gpu: Optional[StrictInt] = Field(default=None, description="GPU units allocated to the sandbox")
@@ -54,7 +55,7 @@ class CreateSandbox(BaseModel):
     build_info: Optional[CreateBuildInfo] = Field(default=None, description="Build information for the sandbox", serialization_alias="buildInfo")
     linked_sandbox: Optional[StrictStr] = Field(default=None, description="ID or name of an existing sandbox to link the new sandbox to. The new sandbox will be scheduled on the same runner as the linked sandbox so a local network can be established between them. Linked sandboxes must be ephemeral (autoDeleteInterval=0) and cannot themselves be linked to another sandbox.", serialization_alias="linkedSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "linkedSandbox"]
+    __properties: ClassVar[List[str]] = ["name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "linkedSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -131,6 +132,7 @@ class CreateSandbox(BaseModel):
             "public": obj.get("public"),
             "network_block_all": obj.get("networkBlockAll"),
             "network_allow_list": obj.get("networkAllowList"),
+            "domain_allow_list": obj.get("domainAllowList"),
             "target": obj.get("target"),
             "cpu": obj.get("cpu"),
             "gpu": obj.get("gpu"),

--- a/libs/api-client-python/daytona_api_client/models/sandbox.py
+++ b/libs/api-client-python/daytona_api_client/models/sandbox.py
@@ -45,6 +45,7 @@ class Sandbox(BaseModel):
     public: StrictBool = Field(description="Whether the sandbox http preview is public")
     network_block_all: StrictBool = Field(description="Whether to block all network access for the sandbox", serialization_alias="networkBlockAll")
     network_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed CIDR network addresses for the sandbox", serialization_alias="networkAllowList")
+    domain_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed domains for the sandbox", serialization_alias="domainAllowList")
     target: StrictStr = Field(description="The target environment for the sandbox")
     cpu: Union[StrictFloat, StrictInt] = Field(description="The CPU quota for the sandbox")
     gpu: Union[StrictFloat, StrictInt] = Field(description="The GPU quota for the sandbox")
@@ -71,7 +72,7 @@ class Sandbox(BaseModel):
     linked_sandbox_id: Optional[StrictStr] = Field(default=None, description="ID of the sandbox this sandbox is linked to. When set, the sandbox is co-located on the same runner as the linked sandbox.", serialization_alias="linkedSandboxId")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "domainAllowList", "target", "cpu", "gpu", "gpuType", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "sandboxClass", "daemonVersion", "runnerId", "linkedSandboxId", "toolboxProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -150,6 +151,7 @@ class Sandbox(BaseModel):
             "public": obj.get("public"),
             "network_block_all": obj.get("networkBlockAll"),
             "network_allow_list": obj.get("networkAllowList"),
+            "domain_allow_list": obj.get("domainAllowList"),
             "target": obj.get("target"),
             "cpu": obj.get("cpu"),
             "gpu": obj.get("gpu"),

--- a/libs/api-client-python/daytona_api_client/models/update_sandbox_network_settings.py
+++ b/libs/api-client-python/daytona_api_client/models/update_sandbox_network_settings.py
@@ -32,8 +32,9 @@ class UpdateSandboxNetworkSettings(BaseModel):
     """ # noqa: E501
     network_block_all: Optional[StrictBool] = Field(default=None, description="Whether to block all network access for the sandbox", serialization_alias="networkBlockAll")
     network_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed CIDR network addresses for the sandbox", serialization_alias="networkAllowList")
+    domain_allow_list: Optional[StrictStr] = Field(default=None, description="Comma-separated list of allowed domains for the sandbox", serialization_alias="domainAllowList")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["networkBlockAll", "networkAllowList"]
+    __properties: ClassVar[List[str]] = ["networkBlockAll", "networkAllowList", "domainAllowList"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -93,7 +94,8 @@ class UpdateSandboxNetworkSettings(BaseModel):
 
         _obj = cls.model_validate({
             "network_block_all": obj.get("networkBlockAll"),
-            "network_allow_list": obj.get("networkAllowList")
+            "network_allow_list": obj.get("networkAllowList"),
+            "domain_allow_list": obj.get("domainAllowList")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-ruby/lib/daytona_api_client/models/create_sandbox.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/create_sandbox.rb
@@ -39,6 +39,9 @@ module DaytonaApiClient
     # Comma-separated list of allowed CIDR network addresses for the sandbox
     attr_accessor :network_allow_list
 
+    # Comma-separated list of allowed domains for the sandbox
+    attr_accessor :domain_allow_list
+
     # The target (region) where the sandbox will be created
     attr_accessor :target
 
@@ -86,6 +89,7 @@ module DaytonaApiClient
         :'public' => :'public',
         :'network_block_all' => :'networkBlockAll',
         :'network_allow_list' => :'networkAllowList',
+        :'domain_allow_list' => :'domainAllowList',
         :'target' => :'target',
         :'cpu' => :'cpu',
         :'gpu' => :'gpu',
@@ -122,6 +126,7 @@ module DaytonaApiClient
         :'public' => :'Boolean',
         :'network_block_all' => :'Boolean',
         :'network_allow_list' => :'String',
+        :'domain_allow_list' => :'String',
         :'target' => :'String',
         :'cpu' => :'Integer',
         :'gpu' => :'Integer',
@@ -193,6 +198,10 @@ module DaytonaApiClient
 
       if attributes.key?(:'network_allow_list')
         self.network_allow_list = attributes[:'network_allow_list']
+      end
+
+      if attributes.key?(:'domain_allow_list')
+        self.domain_allow_list = attributes[:'domain_allow_list']
       end
 
       if attributes.key?(:'target')
@@ -276,6 +285,7 @@ module DaytonaApiClient
           public == o.public &&
           network_block_all == o.network_block_all &&
           network_allow_list == o.network_allow_list &&
+          domain_allow_list == o.domain_allow_list &&
           target == o.target &&
           cpu == o.cpu &&
           gpu == o.gpu &&
@@ -299,7 +309,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [name, snapshot, user, env, labels, public, network_block_all, network_allow_list, target, cpu, gpu, gpu_type, memory, disk, auto_stop_interval, auto_archive_interval, auto_delete_interval, volumes, build_info, linked_sandbox].hash
+      [name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, target, cpu, gpu, gpu_type, memory, disk, auto_stop_interval, auto_archive_interval, auto_delete_interval, volumes, build_info, linked_sandbox].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
@@ -45,6 +45,9 @@ module DaytonaApiClient
     # Comma-separated list of allowed CIDR network addresses for the sandbox
     attr_accessor :network_allow_list
 
+    # Comma-separated list of allowed domains for the sandbox
+    attr_accessor :domain_allow_list
+
     # The target environment for the sandbox
     attr_accessor :target
 
@@ -155,6 +158,7 @@ module DaytonaApiClient
         :'public' => :'public',
         :'network_block_all' => :'networkBlockAll',
         :'network_allow_list' => :'networkAllowList',
+        :'domain_allow_list' => :'domainAllowList',
         :'target' => :'target',
         :'cpu' => :'cpu',
         :'gpu' => :'gpu',
@@ -206,6 +210,7 @@ module DaytonaApiClient
         :'public' => :'Boolean',
         :'network_block_all' => :'Boolean',
         :'network_allow_list' => :'String',
+        :'domain_allow_list' => :'String',
         :'target' => :'String',
         :'cpu' => :'Float',
         :'gpu' => :'Float',
@@ -314,6 +319,10 @@ module DaytonaApiClient
 
       if attributes.key?(:'network_allow_list')
         self.network_allow_list = attributes[:'network_allow_list']
+      end
+
+      if attributes.key?(:'domain_allow_list')
+        self.domain_allow_list = attributes[:'domain_allow_list']
       end
 
       if attributes.key?(:'target')
@@ -695,6 +704,7 @@ module DaytonaApiClient
           public == o.public &&
           network_block_all == o.network_block_all &&
           network_allow_list == o.network_allow_list &&
+          domain_allow_list == o.domain_allow_list &&
           target == o.target &&
           cpu == o.cpu &&
           gpu == o.gpu &&
@@ -731,7 +741,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, organization_id, name, snapshot, user, env, labels, public, network_block_all, network_allow_list, target, cpu, gpu, gpu_type, memory, disk, state, desired_state, error_reason, recoverable, backup_state, backup_created_at, auto_stop_interval, auto_archive_interval, auto_delete_interval, volumes, build_info, created_at, updated_at, last_activity_at, sandbox_class, daemon_version, runner_id, linked_sandbox_id, toolbox_proxy_url].hash
+      [id, organization_id, name, snapshot, user, env, labels, public, network_block_all, network_allow_list, domain_allow_list, target, cpu, gpu, gpu_type, memory, disk, state, desired_state, error_reason, recoverable, backup_state, backup_created_at, auto_stop_interval, auto_archive_interval, auto_delete_interval, volumes, build_info, created_at, updated_at, last_activity_at, sandbox_class, daemon_version, runner_id, linked_sandbox_id, toolbox_proxy_url].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/update_sandbox_network_settings.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/update_sandbox_network_settings.rb
@@ -21,11 +21,15 @@ module DaytonaApiClient
     # Comma-separated list of allowed CIDR network addresses for the sandbox
     attr_accessor :network_allow_list
 
+    # Comma-separated list of allowed domains for the sandbox
+    attr_accessor :domain_allow_list
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         :'network_block_all' => :'networkBlockAll',
-        :'network_allow_list' => :'networkAllowList'
+        :'network_allow_list' => :'networkAllowList',
+        :'domain_allow_list' => :'domainAllowList'
       }
     end
 
@@ -43,7 +47,8 @@ module DaytonaApiClient
     def self.openapi_types
       {
         :'network_block_all' => :'Boolean',
-        :'network_allow_list' => :'String'
+        :'network_allow_list' => :'String',
+        :'domain_allow_list' => :'String'
       }
     end
 
@@ -76,6 +81,10 @@ module DaytonaApiClient
       if attributes.key?(:'network_allow_list')
         self.network_allow_list = attributes[:'network_allow_list']
       end
+
+      if attributes.key?(:'domain_allow_list')
+        self.domain_allow_list = attributes[:'domain_allow_list']
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -99,7 +108,8 @@ module DaytonaApiClient
       return true if self.equal?(o)
       self.class == o.class &&
           network_block_all == o.network_block_all &&
-          network_allow_list == o.network_allow_list
+          network_allow_list == o.network_allow_list &&
+          domain_allow_list == o.domain_allow_list
     end
 
     # @see the `==` method
@@ -111,7 +121,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [network_block_all, network_allow_list].hash
+      [network_block_all, network_allow_list, domain_allow_list].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client/src/models/create-sandbox.ts
+++ b/libs/api-client/src/models/create-sandbox.ts
@@ -57,6 +57,10 @@ export interface CreateSandbox {
      */
     'networkAllowList'?: string;
     /**
+     * Comma-separated list of allowed domains for the sandbox
+     */
+    'domainAllowList'?: string;
+    /**
      * The target (region) where the sandbox will be created
      */
     'target'?: string;

--- a/libs/api-client/src/models/sandbox.ts
+++ b/libs/api-client/src/models/sandbox.ts
@@ -71,6 +71,10 @@ export interface Sandbox {
      */
     'networkAllowList'?: string;
     /**
+     * Comma-separated list of allowed domains for the sandbox
+     */
+    'domainAllowList'?: string;
+    /**
      * The target environment for the sandbox
      */
     'target': string;

--- a/libs/api-client/src/models/update-sandbox-network-settings.ts
+++ b/libs/api-client/src/models/update-sandbox-network-settings.ts
@@ -23,5 +23,9 @@ export interface UpdateSandboxNetworkSettings {
      * Comma-separated list of allowed CIDR network addresses for the sandbox
      */
     'networkAllowList'?: string;
+    /**
+     * Comma-separated list of allowed domains for the sandbox
+     */
+    'domainAllowList'?: string;
 }
 

--- a/libs/runner-api-client/src/models/create-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/create-sandbox-dto.ts
@@ -23,6 +23,7 @@ import type { RegistryDTO } from './registry-dto';
 export interface CreateSandboxDTO {
     'authToken'?: string;
     'cpuQuota'?: number;
+    'domainAllowList'?: string;
     'entrypoint'?: Array<string>;
     'env'?: { [key: string]: string; };
     'fromVolumeId'?: string;

--- a/libs/runner-api-client/src/models/update-network-settings-dto.ts
+++ b/libs/runner-api-client/src/models/update-network-settings-dto.ts
@@ -15,6 +15,7 @@
 
 
 export interface UpdateNetworkSettingsDTO {
+    'domainAllowList'?: string;
     'networkAllowList'?: string;
     'networkBlockAll'?: boolean;
     'networkLimitEgress'?: boolean;

--- a/libs/sdk-go/pkg/daytona/client.go
+++ b/libs/sdk-go/pkg/daytona/client.go
@@ -491,6 +491,9 @@ func (c *Client) doCreate(ctx context.Context, params any, opts ...func(*options
 	if baseParams.NetworkAllowList != nil {
 		createReq.SetNetworkAllowList(*baseParams.NetworkAllowList)
 	}
+	if baseParams.DomainAllowList != nil {
+		createReq.SetDomainAllowList(*baseParams.DomainAllowList)
+	}
 	if baseParams.LinkedSandbox != "" {
 		createReq.SetLinkedSandbox(baseParams.LinkedSandbox)
 	}

--- a/libs/sdk-go/pkg/daytona/sandbox.go
+++ b/libs/sdk-go/pkg/daytona/sandbox.go
@@ -107,6 +107,10 @@ type Sandbox struct {
 	// Not populated by [Client.List]; call [Sandbox.RefreshData] on each item to populate.
 	NetworkAllowList *string
 
+	// DomainAllowList is a comma-separated list of allowed domains.
+	// Not populated by [Client.List]; call [Sandbox.RefreshData] on each item to populate.
+	DomainAllowList *string
+
 	FileSystem      *FileSystemService      // File system operations
 	Git             *GitService             // Git operations
 	Process         *ProcessService         // Process and PTY operations
@@ -120,8 +124,8 @@ type Sandbox struct {
 // [Sandbox.populateFromDTO] accept either DTO without duplicating logic.
 //
 // Fields that exist only on the full [apiclient.Sandbox] DTO (Env,
-// NetworkBlockAll, NetworkAllowList, Volumes, BuildInfo, BackupCreatedAt) are
-// populated via a type assertion inside populateFromDTO.
+// NetworkBlockAll, NetworkAllowList, DomainAllowList, Volumes, BuildInfo,
+// BackupCreatedAt) are populated via a type assertion inside populateFromDTO.
 type sandboxDTO interface {
 	GetId() string
 	GetName() string
@@ -320,7 +324,7 @@ func NewSandbox(client *Client, toolboxClient *toolbox.APIClient, dto sandboxDTO
 // populateFromDTO copies fields from a sandbox API DTO onto the receiver.
 //
 // Fields present only on the full *[apiclient.Sandbox] DTO (Env, NetworkBlockAll,
-// NetworkAllowList, Volumes, BuildInfo, BackupCreatedAt) are populated via a
+// NetworkAllowList, DomainAllowList, Volumes, BuildInfo, BackupCreatedAt) are populated via a
 // type assertion. When dto is a *[apiclient.SandboxListItem] they remain at
 // their zero values.
 func (s *Sandbox) populateFromDTO(dto sandboxDTO) {
@@ -374,6 +378,7 @@ func (s *Sandbox) populateFromDTO(dto sandboxDTO) {
 		s.Env = full.Env
 		s.NetworkBlockAll = &full.NetworkBlockAll
 		s.NetworkAllowList = full.NetworkAllowList
+		s.DomainAllowList = full.DomainAllowList
 		s.Volumes = full.Volumes
 		s.BuildInfo = full.BuildInfo
 		s.BackupCreatedAt = full.BackupCreatedAt
@@ -383,7 +388,7 @@ func (s *Sandbox) populateFromDTO(dto sandboxDTO) {
 // RefreshData refreshes the sandbox data from the API.
 //
 // This updates all sandbox fields from the server, including those not
-// populated by [Client.List] (Env, NetworkBlockAll, NetworkAllowList, Volumes,
+// populated by [Client.List] (Env, NetworkBlockAll, NetworkAllowList, DomainAllowList, Volumes,
 // BuildInfo, BackupCreatedAt).
 //
 // Example:

--- a/libs/sdk-go/pkg/types/types.go
+++ b/libs/sdk-go/pkg/types/types.go
@@ -90,6 +90,7 @@ type SandboxBaseParams struct {
 	Volumes             []VolumeMount
 	NetworkBlockAll     bool
 	NetworkAllowList    *string
+	DomainAllowList     *string
 	Ephemeral           bool
 	// LinkedSandbox is the ID or name of an existing sandbox to link the new sandbox to.
 	// The new sandbox will be scheduled on the same runner as the linked sandbox so a local

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/Daytona.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/Daytona.java
@@ -509,6 +509,7 @@ public class Daytona implements AutoCloseable {
         if (params.getAutoArchiveInterval() != null) body.setAutoArchiveInterval(params.getAutoArchiveInterval());
         if (params.getAutoDeleteInterval() != null) body.setAutoDeleteInterval(params.getAutoDeleteInterval());
         if (params.getNetworkBlockAll() != null) body.setNetworkBlockAll(params.getNetworkBlockAll());
+        if (params.getDomainAllowList() != null) body.setDomainAllowList(params.getDomainAllowList());
         if (params.getLinkedSandbox() != null) body.setLinkedSandbox(params.getLinkedSandbox());
         if (params.getVolumes() != null) {
             List<SandboxVolume> volumes = new ArrayList<SandboxVolume>();

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
@@ -63,6 +63,7 @@ public class Sandbox {
     private Map<String, String> env;
     private Boolean networkBlockAll;
     private String networkAllowList;
+    private String domainAllowList;
     private List<SandboxVolume> volumes;
     private BuildInfo buildInfo;
     private String backupCreatedAt;
@@ -404,6 +405,7 @@ public class Sandbox {
         this.env = d.getEnv() == null ? new HashMap<String, String>() : new HashMap<String, String>(d.getEnv());
         this.networkBlockAll = d.getNetworkBlockAll();
         this.networkAllowList = d.getNetworkAllowList();
+        this.domainAllowList = d.getDomainAllowList();
         this.volumes = d.getVolumes() == null ? null : Collections.unmodifiableList(d.getVolumes());
         this.buildInfo = d.getBuildInfo();
         this.backupCreatedAt = d.getBackupCreatedAt();
@@ -685,6 +687,14 @@ public class Sandbox {
      * @return allow list, or {@code null}
      */
     public String getNetworkAllowList() { return networkAllowList; }
+    /**
+     * Returns the comma-separated list of allowed domains, if any.
+     *
+     * <p>Not returned by {@link Daytona#list}; call {@link #refreshData()} on each item to populate.
+     *
+     * @return allowed domains, or {@code null}
+     */
+    public String getDomainAllowList() { return domainAllowList; }
     /**
      * Returns volumes attached to the Sandbox.
      *

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/model/CreateSandboxParams.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/model/CreateSandboxParams.java
@@ -27,6 +27,7 @@ public class CreateSandboxParams {
     private Integer autoDeleteInterval;
     private List<VolumeMount> volumes;
     private Boolean networkBlockAll;
+    private String domainAllowList;
     private String linkedSandbox;
 
     /**
@@ -182,6 +183,20 @@ public class CreateSandboxParams {
      * @param networkBlockAll network block flag
      */
     public void setNetworkBlockAll(Boolean networkBlockAll) { this.networkBlockAll = networkBlockAll; }
+
+    /**
+     * Returns the comma-separated list of allowed domains.
+     *
+     * @return allowed domains, or {@code null}
+     */
+    public String getDomainAllowList() { return domainAllowList; }
+
+    /**
+     * Sets the comma-separated list of allowed domains.
+     *
+     * @param domainAllowList allowed domains
+     */
+    public void setDomainAllowList(String domainAllowList) { this.domainAllowList = domainAllowList; }
 
     /**
      * Returns the ID or name of an existing Sandbox to link the new Sandbox to.

--- a/libs/sdk-python/src/daytona/_async/daytona.py
+++ b/libs/sdk-python/src/daytona/_async/daytona.py
@@ -545,6 +545,7 @@ class AsyncDaytona:
             volumes=volumes,
             network_block_all=params.network_block_all,
             network_allow_list=params.network_allow_list,
+            domain_allow_list=params.domain_allow_list,
             linked_sandbox=params.linked_sandbox,
         )
 

--- a/libs/sdk-python/src/daytona/_async/sandbox.py
+++ b/libs/sdk-python/src/daytona/_async/sandbox.py
@@ -93,6 +93,8 @@ class AsyncSandbox(SandboxDto):
             (not returned by list results; call `refresh_data()` on each item to populate).
         network_allow_list (str | None): Comma-separated list of allowed CIDR network addresses for
             the Sandbox (not returned by list results; call `refresh_data()` on each item to populate).
+        domain_allow_list (str | None): Comma-separated list of allowed domains for
+            the Sandbox (not returned by list results; call `refresh_data()` on each item to populate).
         toolbox_proxy_url (str): The toolbox proxy URL for the Sandbox.
     """
 
@@ -514,6 +516,7 @@ class AsyncSandbox(SandboxDto):
         *,
         network_block_all: bool | None = None,
         network_allow_list: str | None = None,
+        domain_allow_list: str | None = None,
     ) -> None:
         """Updates outbound network policy on the runner (block all, restore access, or CIDR allow list).
 
@@ -521,6 +524,7 @@ class AsyncSandbox(SandboxDto):
             network_block_all: When ``True``, blocks all outbound traffic. When ``False``, restores general
                 outbound access (and clears a stored allow list).
             network_allow_list: Comma-separated IPv4 CIDRs to allow; implies not blocking all.
+            domain_allow_list: Comma-separated domains to allow; implies not blocking all.
 
         Raises:
             DaytonaValidationError: If neither argument is set.
@@ -531,16 +535,20 @@ class AsyncSandbox(SandboxDto):
             await sandbox.update_network_settings(network_block_all=False)
             ```
         """
-        if network_block_all is None and network_allow_list is None:
-            raise DaytonaValidationError("At least one of network_block_all or network_allow_list must be set")
+        if network_block_all is None and network_allow_list is None and domain_allow_list is None:
+            raise DaytonaValidationError(
+                "At least one of network_block_all, network_allow_list or domain_allow_list must be set"
+            )
 
         body = UpdateSandboxNetworkSettings(
             network_block_all=network_block_all,
             network_allow_list=network_allow_list,
+            domain_allow_list=domain_allow_list,
         )
         updated = await self._sandbox_api.update_network_settings(self.id, body)
         self.network_block_all = updated.network_block_all
         self.network_allow_list = updated.network_allow_list
+        self.domain_allow_list = updated.domain_allow_list
 
     @intercept_errors(message_prefix="Failed to get preview link: ")
     @with_instrumentation()
@@ -881,6 +889,7 @@ class AsyncSandbox(SandboxDto):
                 sandbox_dto.network_block_all
             )
             self.network_allow_list: str | None = sandbox_dto.network_allow_list
+            self.domain_allow_list: str | None = sandbox_dto.domain_allow_list
             self.volumes: list[SandboxVolume] | None = sandbox_dto.volumes
             self.build_info: BuildInfo | None = sandbox_dto.build_info
             self.backup_created_at: str | None = sandbox_dto.backup_created_at

--- a/libs/sdk-python/src/daytona/_sync/daytona.py
+++ b/libs/sdk-python/src/daytona/_sync/daytona.py
@@ -430,6 +430,7 @@ class Daytona:
             volumes=volumes,
             network_block_all=params.network_block_all,
             network_allow_list=params.network_allow_list,
+            domain_allow_list=params.domain_allow_list,
             linked_sandbox=params.linked_sandbox,
         )
 

--- a/libs/sdk-python/src/daytona/_sync/sandbox.py
+++ b/libs/sdk-python/src/daytona/_sync/sandbox.py
@@ -93,6 +93,8 @@ class Sandbox(SandboxDto):
             (not returned by list results; call `refresh_data()` on each item to populate).
         network_allow_list (str | None): Comma-separated list of allowed CIDR network addresses for
             the Sandbox (not returned by list results; call `refresh_data()` on each item to populate).
+        domain_allow_list (str | None): Comma-separated list of allowed domains for
+            the Sandbox (not returned by list results; call `refresh_data()` on each item to populate).
         toolbox_proxy_url (str): The toolbox proxy URL for the Sandbox.
     """
 
@@ -528,6 +530,7 @@ class Sandbox(SandboxDto):
         *,
         network_block_all: bool | None = None,
         network_allow_list: str | None = None,
+        domain_allow_list: str | None = None,
     ) -> None:
         """Updates outbound network policy on the runner (block all, restore access, or CIDR allow list).
 
@@ -535,6 +538,7 @@ class Sandbox(SandboxDto):
             network_block_all: When ``True``, blocks all outbound traffic. When ``False``, restores general
                 outbound access (and clears a stored allow list).
             network_allow_list: Comma-separated IPv4 CIDRs to allow; implies not blocking all.
+            domain_allow_list: Comma-separated domains to allow; implies not blocking all.
 
         Raises:
             DaytonaValidationError: If neither argument is set.
@@ -545,16 +549,20 @@ class Sandbox(SandboxDto):
             sandbox.update_network_settings(network_block_all=False)
             ```
         """
-        if network_block_all is None and network_allow_list is None:
-            raise DaytonaValidationError("At least one of network_block_all or network_allow_list must be set")
+        if network_block_all is None and network_allow_list is None and domain_allow_list is None:
+            raise DaytonaValidationError(
+                "At least one of network_block_all, network_allow_list or domain_allow_list must be set"
+            )
 
         body = UpdateSandboxNetworkSettings(
             network_block_all=network_block_all,
             network_allow_list=network_allow_list,
+            domain_allow_list=domain_allow_list,
         )
         updated = self._sandbox_api.update_network_settings(self.id, body)
         self.network_block_all = updated.network_block_all
         self.network_allow_list = updated.network_allow_list
+        self.domain_allow_list = updated.domain_allow_list
 
     @intercept_errors(message_prefix="Failed to get preview link: ")
     @with_instrumentation()
@@ -896,6 +904,7 @@ class Sandbox(SandboxDto):
                 sandbox_dto.network_block_all
             )
             self.network_allow_list: str | None = sandbox_dto.network_allow_list
+            self.domain_allow_list: str | None = sandbox_dto.domain_allow_list
             self.volumes: list[SandboxVolume] | None = sandbox_dto.volumes
             self.build_info: BuildInfo | None = sandbox_dto.build_info
             self.backup_created_at: str | None = sandbox_dto.backup_created_at

--- a/libs/sdk-python/src/daytona/common/daytona.py
+++ b/libs/sdk-python/src/daytona/common/daytona.py
@@ -138,6 +138,7 @@ class CreateSandboxBaseParams(BaseModel):
         volumes (list[VolumeMount] | None): List of volumes mounts to attach to the Sandbox.
         network_block_all (bool | None): Whether to block all network access for the Sandbox.
         network_allow_list (str | None): Comma-separated list of allowed CIDR network addresses for the Sandbox.
+        domain_allow_list (str | None): Comma-separated list of allowed domains for the Sandbox.
         ephemeral (bool | None): Whether the Sandbox should be ephemeral.
             If True, auto_delete_interval will be set to 0.
         linked_sandbox (str | None): ID or name of an existing Sandbox to link the new Sandbox to. The new
@@ -158,6 +159,7 @@ class CreateSandboxBaseParams(BaseModel):
     volumes: list[VolumeMount] | None = None
     network_block_all: bool | None = None
     network_allow_list: str | None = None
+    domain_allow_list: str | None = None
     ephemeral: bool | None = None
     linked_sandbox: str | None = None
 

--- a/libs/sdk-python/tests/conftest.py
+++ b/libs/sdk-python/tests/conftest.py
@@ -62,6 +62,7 @@ def make_sandbox_dto(
         updated_at=cast(str | None, kwargs.get("updated_at", "2025-01-01T00:00:00Z")),
         network_block_all=cast(bool, kwargs.get("network_block_all", False)),
         network_allow_list=cast(str | None, kwargs.get("network_allow_list", None)),
+        domain_allow_list=cast(str | None, kwargs.get("domain_allow_list", None)),
         toolbox_proxy_url=cast(str, kwargs.get("toolbox_proxy_url", "http://localhost:2280")),
     )
 

--- a/libs/sdk-ruby/lib/daytona/common/daytona.rb
+++ b/libs/sdk-ruby/lib/daytona/common/daytona.rb
@@ -43,6 +43,9 @@ module Daytona
     # @return [String, nil] Comma-separated list of allowed CIDR network addresses for the Sandbox
     attr_accessor :network_allow_list
 
+    # @return [String, nil] Comma-separated list of allowed domains for the Sandbox
+    attr_accessor :domain_allow_list
+
     # @return [Boolean, nil] Whether the Sandbox should be ephemeral
     attr_accessor :ephemeral
 
@@ -66,6 +69,7 @@ module Daytona
     # @param volumes [Array<DaytonaApiClient::SandboxVolume>, nil] List of volumes mounts to attach to the Sandbox
     # @param network_block_all [Boolean, nil] Whether to block all network access for the Sandbox
     # @param network_allow_list [String, nil] Comma-separated list of allowed CIDR network addresses for the Sandbox
+    # @param domain_allow_list [String, nil] Comma-separated list of allowed domains for the Sandbox
     # @param ephemeral [Boolean, nil] Whether the Sandbox should be ephemeral
     # @param linked_sandbox [String, nil] ID or name of an existing Sandbox to link the new Sandbox to
     def initialize( # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
@@ -81,6 +85,7 @@ module Daytona
       volumes: nil,
       network_block_all: nil,
       network_allow_list: nil,
+      domain_allow_list: nil,
       ephemeral: nil,
       linked_sandbox: nil
     )
@@ -96,6 +101,7 @@ module Daytona
       @volumes = volumes
       @network_block_all = network_block_all
       @network_allow_list = network_allow_list
+      @domain_allow_list = domain_allow_list
       @ephemeral = ephemeral
       @linked_sandbox = linked_sandbox
 
@@ -120,6 +126,7 @@ module Daytona
         volumes:,
         network_block_all:,
         network_allow_list:,
+        domain_allow_list:,
         ephemeral:,
         linked_sandbox:
       }.compact
@@ -166,6 +173,7 @@ module Daytona
     # @param volumes [Array<DaytonaApiClient::SandboxVolume>, nil] List of volumes mounts to attach to the Sandbox
     # @param network_block_all [Boolean, nil] Whether to block all network access for the Sandbox
     # @param network_allow_list [String, nil] Comma-separated list of allowed CIDR network addresses for the Sandbox
+    # @param domain_allow_list [String, nil] Comma-separated list of allowed domains for the Sandbox
     # @param ephemeral [Boolean, nil] Whether the Sandbox should be ephemeral
     def initialize(image:, resources: nil, **args)
       @image = image
@@ -204,6 +212,7 @@ module Daytona
     # @param volumes [Array<DaytonaApiClient::SandboxVolume>, nil] List of volumes mounts to attach to the Sandbox
     # @param network_block_all [Boolean, nil] Whether to block all network access for the Sandbox
     # @param network_allow_list [String, nil] Comma-separated list of allowed CIDR network addresses for the Sandbox
+    # @param domain_allow_list [String, nil] Comma-separated list of allowed domains for the Sandbox
     # @param ephemeral [Boolean, nil] Whether the Sandbox should be ephemeral
     def initialize(snapshot: nil, **args)
       @snapshot = snapshot

--- a/libs/sdk-ruby/lib/daytona/daytona.rb
+++ b/libs/sdk-ruby/lib/daytona/daytona.rb
@@ -215,6 +215,7 @@ module Daytona
         volumes: params.volumes,
         network_block_all: params.network_block_all,
         network_allow_list: params.network_allow_list,
+        domain_allow_list: params.domain_allow_list,
         linked_sandbox: params.linked_sandbox
       )
 

--- a/libs/sdk-ruby/lib/daytona/sandbox.rb
+++ b/libs/sdk-ruby/lib/daytona/sandbox.rb
@@ -41,6 +41,10 @@ module Daytona
     #   Not returned by list results; call #refresh on each item to populate.
     attr_reader :network_allow_list
 
+    # @return [String, nil] Comma-separated list of allowed domains for the sandbox.
+    #   Not returned by list results; call #refresh on each item to populate.
+    attr_reader :domain_allow_list
+
     # @return [String] The target environment for the sandbox
     attr_reader :target
 
@@ -216,21 +220,24 @@ module Daytona
     #
     # @param network_block_all [Boolean, nil]
     # @param network_allow_list [String, nil]
+    # @param domain_allow_list [String, nil]
     # @return [void]
     # @raise [Daytona::Sdk::Error]
-    def update_network_settings(network_block_all: nil, network_allow_list: nil)
-      if network_block_all.nil? && network_allow_list.nil?
+    def update_network_settings(network_block_all: nil, network_allow_list: nil, domain_allow_list: nil)
+      if network_block_all.nil? && network_allow_list.nil? && domain_allow_list.nil?
         raise Sdk::Error,
-              'At least one of network_block_all or network_allow_list must be provided'
+              'At least one of network_block_all, network_allow_list or domain_allow_list must be provided'
       end
 
       body = DaytonaApiClient::UpdateSandboxNetworkSettings.new(
         network_block_all:,
-        network_allow_list:
+        network_allow_list:,
+        domain_allow_list:
       )
       data = sandbox_api.update_network_settings(id, body)
       @network_block_all = data.network_block_all
       @network_allow_list = data.network_allow_list
+      @domain_allow_list = data.domain_allow_list
     end
 
     # Sets the auto-stop interval for the Sandbox.
@@ -629,6 +636,7 @@ module Daytona
       @env = sandbox_dto.env
       @network_block_all = sandbox_dto.network_block_all
       @network_allow_list = sandbox_dto.network_allow_list
+      @domain_allow_list = sandbox_dto.domain_allow_list
       @volumes = sandbox_dto.volumes
       @build_info = sandbox_dto.build_info
       @backup_created_at = sandbox_dto.backup_created_at

--- a/libs/sdk-ruby/spec/spec_helper.rb
+++ b/libs/sdk-ruby/spec/spec_helper.rb
@@ -91,6 +91,7 @@ def build_sandbox_dto(overrides = {}) # rubocop:disable Metrics/MethodLength
     daemon_version: '1.0.0',
     network_block_all: false,
     network_allow_list: nil,
+    domain_allow_list: nil,
     toolbox_proxy_url: 'https://proxy.example.com/'
   }.merge(overrides)
 

--- a/libs/sdk-typescript/src/Daytona.ts
+++ b/libs/sdk-typescript/src/Daytona.ts
@@ -151,6 +151,7 @@ export interface Resources {
  * @property {VolumeMount[]} [volumes] - Optional array of volumes to mount to the Sandbox
  * @property {boolean} [networkBlockAll] - Whether to block all network access for the Sandbox
  * @property {string} [networkAllowList] - Comma-separated list of allowed CIDR network addresses for the Sandbox
+ * @property {string} [domainAllowList] - Comma-separated list of allowed domains for the Sandbox
  * @property {boolean} [ephemeral] - Whether the Sandbox should be ephemeral. If true, autoDeleteInterval will be set to 0.
  * @property {string} [linkedSandbox] - ID or name of an existing sandbox to link the new sandbox to. The new sandbox will be scheduled on the same runner as the linked sandbox so a local network can be established between them. Linked sandboxes must be ephemeral (autoDeleteInterval=0) and cannot themselves be linked to another sandbox.
  */
@@ -167,6 +168,7 @@ export type CreateSandboxBaseParams = {
   volumes?: VolumeMount[]
   networkBlockAll?: boolean
   networkAllowList?: string
+  domainAllowList?: string
   ephemeral?: boolean
   linkedSandbox?: string
 }
@@ -568,6 +570,7 @@ export class Daytona implements AsyncDisposable {
           volumes: params.volumes,
           networkBlockAll: params.networkBlockAll,
           networkAllowList: params.networkAllowList,
+          domainAllowList: params.domainAllowList,
           linkedSandbox: params.linkedSandbox,
         },
         undefined,

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -83,6 +83,8 @@ import { WithInstrumentation } from './utils/otel.decorator'
  * (not returned by list results; call `refreshData()` on each item to populate)
  * @property {string} [networkAllowList] - Comma-separated list of allowed CIDR network addresses for the Sandbox
  * (not returned by list results; call `refreshData()` on each item to populate)
+ * @property {string} [domainAllowList] - Comma-separated list of allowed domains for the Sandbox
+ * (not returned by list results; call `refreshData()` on each item to populate)
  * @property {string} [linkedSandboxId] - ID of the Sandbox this Sandbox is linked to. When set, the Sandbox is co-located on the same runner as the linked Sandbox.
  * (not returned by list results; call `refreshData()` on each item to populate)
  *
@@ -123,6 +125,7 @@ export class Sandbox {
   public lastActivityAt?: string
   public networkBlockAll?: boolean
   public networkAllowList?: string
+  public domainAllowList?: string
   public linkedSandboxId?: string
   public toolboxProxyUrl: string
 
@@ -716,10 +719,11 @@ export class Sandbox {
    * Updates outbound network policy for this sandbox on the runner (for example block all traffic,
    * restore general internet access, or apply a CIDR allow list) without stopping the sandbox.
    *
-   * This maps to the same mechanism as creating a sandbox with `networkBlockAll` / `networkAllowList`:
-   * the runner applies iptables rules to the sandbox container.
+   * This maps to the same mechanism as creating a sandbox with `networkBlockAll` / `networkAllowList` /
+   * `domainAllowList`: the runner applies iptables rules to the sandbox container.
    *
-   * @param {UpdateSandboxNetworkSettings} settings - At least one of `networkBlockAll` or `networkAllowList` must be set.
+   * @param {UpdateSandboxNetworkSettings} settings - At least one of `networkBlockAll`, `networkAllowList` or
+   *   `domainAllowList` must be set.
    *   Set `networkBlockAll` to `false` to restore outbound access after a block (and clear a stored allow list).
    *
    * @example
@@ -727,11 +731,19 @@ export class Sandbox {
    * await sandbox.updateNetworkSettings({ networkBlockAll: true });
    * // Resume internet
    * await sandbox.updateNetworkSettings({ networkBlockAll: false });
+   * // Allow only specific domains
+   * await sandbox.updateNetworkSettings({ domainAllowList: 'example.com,*.daytona.io' });
    */
   @WithInstrumentation()
   public async updateNetworkSettings(settings: UpdateSandboxNetworkSettings): Promise<void> {
-    if (settings.networkBlockAll === undefined && settings.networkAllowList === undefined) {
-      throw new DaytonaValidationError('At least one of networkBlockAll or networkAllowList must be set')
+    if (
+      settings.networkBlockAll === undefined &&
+      settings.networkAllowList === undefined &&
+      settings.domainAllowList === undefined
+    ) {
+      throw new DaytonaValidationError(
+        'At least one of networkBlockAll, networkAllowList or domainAllowList must be set',
+      )
     }
     const response = await this.sandboxApi.updateNetworkSettings(this.id, settings)
     this.processSandboxDto(response.data)
@@ -946,6 +958,7 @@ export class Sandbox {
       this.env = sandboxDto.env
       this.networkBlockAll = sandboxDto.networkBlockAll
       this.networkAllowList = sandboxDto.networkAllowList
+      this.domainAllowList = sandboxDto.domainAllowList
       this.linkedSandboxId = sandboxDto.linkedSandboxId
       this.volumes = sandboxDto.volumes
       this.buildInfo = sandboxDto.buildInfo

--- a/nx.json
+++ b/nx.json
@@ -162,10 +162,10 @@
       "options": {
         "context": "{workspaceRoot}",
         "file": "{projectRoot}/Dockerfile",
-        "tags": ["daytonaio/daytona-{projectName}:$VERSION$ARCH"],
+        "tags": ["ghcr.io/daytonaio/daytona-{projectName}:$VERSION$ARCH"],
         "build-args": ["VERSION=$VERSION"],
-        "cache-from": ["type=registry,ref=daytonaio/daytona-{projectName}:buildcache$ARCH"],
-        "cache-to": ["type=registry,ref=daytonaio/daytona-{projectName}:buildcache$ARCH,mode=max"]
+        "cache-from": ["type=registry,ref=ghcr.io/daytonaio/daytona-{projectName}:buildcache$ARCH"],
+        "cache-to": ["type=registry,ref=ghcr.io/daytonaio/daytona-{projectName}:buildcache$ARCH,mode=max"]
       },
       "configurations": {
         "production": {
@@ -174,24 +174,26 @@
         "production-multi-platform": {
           "push": true,
           "platforms": ["linux/amd64", "linux/arm64"],
-          "tags": ["daytonaio/daytona-{projectName}:$VERSION"],
-          "cache-from": ["type=registry,ref=daytonaio/daytona-{projectName}:buildcache"],
-          "cache-to": ["type=registry,ref=daytonaio/daytona-{projectName}:buildcache,mode=max"]
+          "tags": ["ghcr.io/daytonaio/daytona-{projectName}:$VERSION"],
+          "cache-from": ["type=registry,ref=ghcr.io/daytonaio/daytona-{projectName}:buildcache"],
+          "cache-to": ["type=registry,ref=ghcr.io/daytonaio/daytona-{projectName}:buildcache,mode=max"]
         },
         "local-registry": {
           "push": true,
           "tags": [
-            "registry:5000/daytonaio/test-daytona-{projectName}:$VERSION",
-            "registry:5000/daytonaio/test-daytona-{projectName}:latest"
+            "registry:5000/ghcr.io/daytonaio/test-daytona-{projectName}:$VERSION",
+            "registry:5000/ghcr.io/daytonaio/test-daytona-{projectName}:latest"
           ],
-          "cache-from": ["type=registry,ref=registry:5000/daytonaio/test-daytona-{projectName}:buildcache"],
-          "cache-to": ["type=registry,ref=registry:5000/daytonaio/test-daytona-{projectName}:buildcache,mode=max"]
+          "cache-from": ["type=registry,ref=registry:5000/ghcr.io/daytonaio/test-daytona-{projectName}:buildcache"],
+          "cache-to": [
+            "type=registry,ref=registry:5000/ghcr.io/daytonaio/test-daytona-{projectName}:buildcache,mode=max"
+          ]
         },
         "pr-build": {
           "push": false,
           "load": false,
           "platforms": ["linux/amd64"],
-          "tags": ["daytonaio/daytona-{projectName}:$VERSION"],
+          "tags": ["ghcr.io/daytonaio/daytona-{projectName}:$VERSION"],
           "cache-from": ["type=gha,scope=docker-{projectName}"],
           "cache-to": ["type=gha,scope=docker-{projectName},mode=max"]
         }
@@ -203,10 +205,10 @@
       "options": {
         "parallel": false,
         "commands": [
-          "docker manifest create daytonaio/daytona-{projectName}:$VERSION daytonaio/daytona-{projectName}:$VERSION-amd64 daytonaio/daytona-{projectName}:$VERSION-arm64",
-          "docker manifest push daytonaio/daytona-{projectName}:$VERSION",
-          "docker manifest create daytonaio/daytona-{projectName}:latest daytonaio/daytona-{projectName}:$VERSION-amd64 daytonaio/daytona-{projectName}:$VERSION-arm64",
-          "docker manifest push daytonaio/daytona-{projectName}:latest"
+          "docker manifest create ghcr.io/daytonaio/daytona-{projectName}:$VERSION ghcr.io/daytonaio/daytona-{projectName}:$VERSION-amd64 ghcr.io/daytonaio/daytona-{projectName}:$VERSION-arm64",
+          "docker manifest push ghcr.io/daytonaio/daytona-{projectName}:$VERSION",
+          "docker manifest create ghcr.io/daytonaio/daytona-{projectName}:latest ghcr.io/daytonaio/daytona-{projectName}:$VERSION-amd64 ghcr.io/daytonaio/daytona-{projectName}:$VERSION-arm64",
+          "docker manifest push ghcr.io/daytonaio/daytona-{projectName}:latest"
         ]
       }
     },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds domain-based allow lists for sandbox egress. Set `domainAllowList` at create time and update it live via API and all SDKs to restrict outbound traffic by domain.

- **New Features**
  - API: added `domainAllowList` on create/update and Sandbox DTOs; empty string clears it. Validation allows `*.domain.com` and up to 10 domains. Metrics include request/response flags.
  - Runner: forwards `domainAllowList` on start and via `updateNetworkSettings` without restart; runner API/Swagger updated.
  - SDKs: `@daytona/sdk` (TypeScript), Go, Java, Python (sync/async), and Ruby can set/read `domainAllowList` and update it via `updateNetworkSettings`. Parameter checks accept one of `networkBlockAll`, `networkAllowList`, or `domainAllowList`. Docs updated across SDKs.
  - Example: `examples/typescript/domain-allow-list` demonstrates allow/deny behavior.

- **Migration**
  - Run the pre-deploy migration adding the nullable `domainAllowList` column.
  - Update runners and SDKs to versions that support `domainAllowList`. No breaking changes to existing calls.

<sup>Written for commit 1494027b3699e61294bc8799e564fa8937cbaf44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

