### PR TITLE
feat(api): manage api keys permissions

### DIFF
--- a/apps/api/src/api-key/api-key.controller.ts
+++ b/apps/api/src/api-key/api-key.controller.ts
@@ -44,6 +44,7 @@ export class ApiKeyController {
     description: 'API key created successfully.',
     type: ApiKeyResponseDto,
   })
+  @AuthStrategy([AuthStrategyType.JWT, AuthStrategyType.API_KEY])
   @Audit({
     action: AuditAction.CREATE,
     targetType: AuditTarget.API_KEY,
@@ -60,6 +61,7 @@ export class ApiKeyController {
     @IsOrganizationAuthContext() authContext: OrganizationAuthContext,
     @Body() createApiKeyDto: CreateApiKeyDto,
   ): Promise<ApiKeyResponseDto> {
+    this.validateApiKeyCreator(authContext)
     this.validateRequestedApiKeyPermissions(authContext, createApiKeyDto.permissions)
 
     const { apiKey, value } = await this.apiKeyService.createApiKey(
@@ -179,10 +181,51 @@ export class ApiKeyController {
     await this.apiKeyService.deleteApiKey(authContext.organizationId, userId, name)
   }
 
+  /**
+   * When the request itself is authenticated with an API key (rather than an interactive JWT
+   * session), creating API keys is only allowed if the organization has opted in and the calling
+   * key carries the dedicated MANAGE_API_KEYS permission. This prevents a leaked key from silently
+   * minting persistent keys.
+   */
+  private validateApiKeyCreator(authContext: OrganizationAuthContext): void {
+    if (!authContext.apiKey) {
+      return
+    }
+
+    if (!authContext.organization.allowManageApiKeysPermission) {
+      throw new ForbiddenException('Managing API keys with an API key is not enabled for this organization')
+    }
+
+    if (!authContext.apiKey.permissions.includes(OrganizationResourcePermission.MANAGE_API_KEYS)) {
+      throw new ForbiddenException('This API key is not authorized to manage API keys')
+    }
+  }
+
   private validateRequestedApiKeyPermissions(
     authContext: OrganizationAuthContext,
     requestedPermissions: OrganizationResourcePermission[],
   ): void {
+    // The MANAGE_API_KEYS permission can only be assigned when the organization has opted in.
+    if (
+      requestedPermissions.includes(OrganizationResourcePermission.MANAGE_API_KEYS) &&
+      !authContext.organization.allowManageApiKeysPermission
+    ) {
+      throw new ForbiddenException('The manage:api_keys permission is not enabled for this organization')
+    }
+
+    // A request authenticated with an API key can never create a key more powerful than itself,
+    // regardless of the owning user's role.
+    if (authContext.apiKey) {
+      const callerPermissions = new Set(authContext.apiKey.permissions)
+      const forbiddenPermissions = requestedPermissions.filter((permission) => !callerPermissions.has(permission))
+
+      if (forbiddenPermissions.length) {
+        throw new ForbiddenException(`Insufficient permissions for assigning: ${forbiddenPermissions.join(', ')}`)
+      }
+
+      return
+    }
+
     if (authContext.organizationUser.role === OrganizationMemberRole.OWNER) {
       return
     }

--- a/apps/api/src/migrations/pre-deploy/1782151769654-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1782151769654-migration.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1782151769654 implements MigrationInterface {
+  name = 'Migration1782151769654'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "organization" ADD "allowManageApiKeysPermission" boolean NOT NULL DEFAULT false`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "organization" DROP COLUMN "allowManageApiKeysPermission"`)
+  }
+}

--- a/apps/api/src/organization/entities/organization.entity.ts
+++ b/apps/api/src/organization/entities/organization.entity.ts
@@ -181,6 +181,11 @@ export class Organization {
   })
   sandboxLimitedNetworkEgress: boolean
 
+  @Column({
+    default: false,
+  })
+  allowManageApiKeysPermission: boolean
+
   @CreateDateColumn({
     type: 'timestamp with time zone',
   })

--- a/apps/api/src/organization/enums/organization-resource-permission.enum.ts
+++ b/apps/api/src/organization/enums/organization-resource-permission.enum.ts
@@ -35,4 +35,7 @@ export enum OrganizationResourcePermission {
 
   // audit
   READ_AUDIT_LOGS = 'read:audit_logs',
+
+  // api keys
+  MANAGE_API_KEYS = 'manage:api_keys',
 }


### PR DESCRIPTION
## Description

Adds the ability to create API keys using an API key instead of only being able to use JWTs for select organizations 

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable managing API keys with an API key, gated by a new org opt-in and the `MANAGE_API_KEYS` permission, with stricter checks to prevent permission escalation.

- **New Features**
  - Allow API key creation via JWT or API key with `@AuthStrategy([JWT, API_KEY])`.
  - Add org flag `allowManageApiKeysPermission` to opt in to managing keys with API keys.
  - Add `MANAGE_API_KEYS` (`manage:api_keys`) permission; required on the calling key to create/manage keys.
  - Block assigning `manage:api_keys` unless the org has opted in.
  - When authenticated with an API key, new keys cannot include permissions the caller doesn’t have.

- **Migration**
  - Adds `allowManageApiKeysPermission` (boolean, default false) to `organization`.
  - No action required unless enabling this feature; set the flag to true per organization to allow it.

<sup>Written for commit 3f24dce9f2139dacd6f0444932deece751d1f749. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

