### PR TITLE
fix(api): evict API-side public-status cache on visibility change

### DIFF
--- a/apps/api/src/sandbox/services/proxy-cache-invalidation.service.spec.ts
+++ b/apps/api/src/sandbox/services/proxy-cache-invalidation.service.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import Redis from 'ioredis'
+
+import { ProxyCacheInvalidationService } from './proxy-cache-invalidation.service'
+import { SandboxPublicStatusUpdatedEvent } from '../events/sandbox-public-status-updated.event'
+import { Sandbox } from '../entities/sandbox.entity'
+
+describe('ProxyCacheInvalidationService', () => {
+  let service: ProxyCacheInvalidationService
+  let del: jest.Mock
+
+  const SANDBOX_ID = 'sbx-1'
+  const API_KEY = `preview:public:${SANDBOX_ID}`
+  const PROXY_KEY = `proxy:sandbox-public:${SANDBOX_ID}`
+
+  const makeEvent = () => new SandboxPublicStatusUpdatedEvent({ id: SANDBOX_ID } as Sandbox, true, false)
+
+  beforeEach(() => {
+    del = jest.fn().mockResolvedValue(1)
+    service = new ProxyCacheInvalidationService({ del } as unknown as Redis)
+  })
+
+  describe('handleSandboxPublicStatusUpdated', () => {
+    it('evicts both the API-side and the proxy-side public-status caches', async () => {
+      await service.handleSandboxPublicStatusUpdated(makeEvent())
+
+      expect(del).toHaveBeenCalledWith(API_KEY)
+      expect(del).toHaveBeenCalledWith(PROXY_KEY)
+    })
+
+    // Ordering is the correctness property, not an incidental detail: the proxy only
+    // re-queries the API on a cache miss, and a miss can only happen after the proxy
+    // key is gone. If the proxy key were evicted first, a request landing in the gap
+    // would re-read the still-cached API decision and re-populate the proxy's long-lived
+    // cache. The API-side key must be evicted first.
+    it('evicts the API-side cache before the proxy-side cache', async () => {
+      await service.handleSandboxPublicStatusUpdated(makeEvent())
+
+      const apiCallIndex = del.mock.calls.findIndex((args) => args[0] === API_KEY)
+      const proxyCallIndex = del.mock.calls.findIndex((args) => args[0] === PROXY_KEY)
+
+      expect(apiCallIndex).toBeGreaterThanOrEqual(0)
+      expect(proxyCallIndex).toBeGreaterThanOrEqual(0)
+      expect(del.mock.invocationCallOrder[apiCallIndex]).toBeLessThan(del.mock.invocationCallOrder[proxyCallIndex])
+    })
+
+    it('still evicts the proxy-side cache when the API-side eviction fails', async () => {
+      del.mockImplementation((key: string) => {
+        if (key === API_KEY) {
+          return Promise.reject(new Error('redis down'))
+        }
+        return Promise.resolve(1)
+      })
+
+      await expect(service.handleSandboxPublicStatusUpdated(makeEvent())).resolves.not.toThrow()
+      expect(del).toHaveBeenCalledWith(PROXY_KEY)
+    })
+
+    it('does not throw when both evictions fail (visibility change must not 500)', async () => {
+      del.mockRejectedValue(new Error('redis down'))
+
+      await expect(service.handleSandboxPublicStatusUpdated(makeEvent())).resolves.not.toThrow()
+    })
+  })
+})

--- a/apps/api/src/sandbox/services/proxy-cache-invalidation.service.ts
+++ b/apps/api/src/sandbox/services/proxy-cache-invalidation.service.ts
@@ -17,6 +17,7 @@ export class ProxyCacheInvalidationService {
   private readonly logger = new Logger(ProxyCacheInvalidationService.name)
   private static readonly RUNNER_INFO_CACHE_PREFIX = 'proxy:sandbox-runner-info:'
   private static readonly PUBLIC_CACHE_PREFIX = 'proxy:sandbox-public:'
+  private static readonly API_PUBLIC_CACHE_PREFIX = 'preview:public:'
 
   constructor(@InjectRedis() private readonly redis: Redis) {}
 
@@ -40,6 +41,18 @@ export class ProxyCacheInvalidationService {
   }
 
   private async invalidatePublicCache(sandboxId: string): Promise<void> {
+    // Evict the API-side decision cache BEFORE the proxy-side cache.
+    // The proxy only re-queries the API on a cache miss, and a miss can only
+    // occur after the proxy key is gone. Deleting the API key first guarantees
+    // any such re-query does a fresh lookup (now private) instead of reading a
+    // stale 'public' decision and re-poisoning the proxy's longer-lived cache.
+    try {
+      await this.redis.del(`${ProxyCacheInvalidationService.API_PUBLIC_CACHE_PREFIX}${sandboxId}`)
+      this.logger.debug(`Invalidated API public-status cache for ${sandboxId}`)
+    } catch (error) {
+      this.logger.warn(`Failed to invalidate API public-status cache for sandbox ${sandboxId}: ${error.message}`)
+    }
+
     try {
       await this.redis.del(`${ProxyCacheInvalidationService.PUBLIC_CACHE_PREFIX}${sandboxId}`)
       this.logger.debug(`Invalidated sandbox public cache for ${sandboxId}`)


### PR DESCRIPTION
## What

`ProxyCacheInvalidationService.invalidatePublicCache` evicted only the proxy-side public-status cache (`proxy:sandbox-public:`) on a visibility change. The API-side decision cache (`preview:public:`, short TTL) was left in place and re-populated the proxy cache on the next request, so a public→private change could take effect later than intended.

This evicts the API-side entry **before** the proxy-side entry. The proxy only re-queries the API on a cache miss, and such a miss can only happen after the proxy key is gone — so deleting the API key first means any re-query reads fresh state instead of the stale decision.

## Test

Adds `proxy-cache-invalidation.service.spec.ts`:
- both keys are evicted on `PUBLIC_STATUS_UPDATED`
- the API-side key is evicted **before** the proxy-side key (the load-bearing ordering)
- eviction is best-effort — a Redis failure does not fail the visibility change

Verified the ordering test fails against a proxy-first implementation; `nx run api:test` for the suite passes, prettier + eslint clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale public-status cache after sandbox visibility changes by evicting the API-side cache before the proxy cache. Prevents public→private changes from lagging and ensures requests read fresh state.

- **Bug Fixes**
  - Evict API decision cache first (`preview:public:${sandboxId}`), then proxy cache (`proxy:sandbox-public:${sandboxId}`) to avoid repopulating with stale data.
  - Added tests verifying both keys are evicted in that order and that eviction is best-effort (Redis failures don’t block visibility updates).

<sup>Written for commit 0a95dd86e7315d68226c9da2ed2f4c6fa5fc9c3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

