### PR TITLE
feat: registry pull-through cache for Docker-in-Docker sandboxes

### DIFF
--- a/apps/daemon/cmd/daemon/config/config.go
+++ b/apps/daemon/cmd/daemon/config/config.go
@@ -25,6 +25,11 @@ type Config struct {
 	OrganizationId           *string       `envconfig:"DAYTONA_ORGANIZATION_ID"`
 	RegionId                 *string       `envconfig:"DAYTONA_REGION_ID"`
 	Snapshot                 *string       `envconfig:"DAYTONA_SANDBOX_SNAPSHOT"`
+	// DindRegistryMirror is the URL of a registry pull-through cache that a
+	// nested Docker daemon (Docker-in-Docker) started inside the sandbox should
+	// use for docker.io pulls, avoiding Docker Hub's anonymous pull rate limit.
+	// It is injected by the runner and empty when the feature is disabled.
+	DindRegistryMirror string `envconfig:"DAYTONA_DIND_REGISTRY_MIRROR"`
 }
 
 var defaultDaemonLogFilePath = "/tmp/daytona-daemon.log"

--- a/apps/daemon/cmd/daemon/main.go
+++ b/apps/daemon/cmd/daemon/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/daytonaio/daemon/cmd/daemon/config"
 	"github.com/daytonaio/daemon/internal/util"
 	"github.com/daytonaio/daemon/pkg/childreap"
+	"github.com/daytonaio/daemon/pkg/dind"
 	"github.com/daytonaio/daemon/pkg/recording"
 	"github.com/daytonaio/daemon/pkg/recordingdashboard"
 	"github.com/daytonaio/daemon/pkg/session"
@@ -86,6 +87,15 @@ func run() int {
 	if err != nil {
 		logger.Error("Failed to get config", "error", err)
 		return 2
+	}
+
+	// Point a nested Docker daemon (Docker-in-Docker) at the registry
+	// pull-through cache before the user starts it, so `docker pull` inside the
+	// sandbox avoids Docker Hub's anonymous rate limit (HTTP 429). This is
+	// best-effort: sandboxes without Docker, or without write access to
+	// /etc/docker, simply skip it.
+	if err := dind.ConfigureRegistryMirror(logger, c.DindRegistryMirror); err != nil {
+		logger.Warn("Failed to configure Docker-in-Docker registry mirror", "error", err)
 	}
 
 	// If workdir in image is not set, use user home as workdir

--- a/apps/daemon/pkg/dind/mirror.go
+++ b/apps/daemon/pkg/dind/mirror.go
@@ -1,0 +1,156 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+// Package dind configures the nested Docker daemon that users run inside a
+// sandbox (Docker-in-Docker). Its main job is to point that daemon at a
+// registry pull-through cache so that `docker pull` of public images does not
+// hit Docker Hub's anonymous pull rate limit (HTTP 429). Because many sandboxes
+// on a single runner share one outbound NAT IP, the shared anonymous quota is
+// exhausted quickly; a pull-through cache (optionally authenticated to Docker
+// Hub) both raises that quota and serves repeated pulls straight from cache.
+package dind
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// DaemonConfigPath is where the Docker daemon reads its configuration from.
+// dockerd loads this file on startup, so writing it before the user starts
+// their nested daemon is enough for the mirror to take effect.
+const DaemonConfigPath = "/etc/docker/daemon.json"
+
+// ConfigureRegistryMirror writes mirrorURL into the nested Docker daemon's
+// configuration file so that Docker-in-Docker pulls are served through the
+// pull-through cache.
+//
+// It is intentionally best-effort and conservative:
+//   - When mirrorURL is empty the feature is disabled and it is a no-op.
+//   - An existing user/base-image "registry-mirrors" entry is never overwritten,
+//     so callers who deliberately configured their own mirror keep it.
+//   - Any existing daemon.json content is preserved (only the mirror-related
+//     keys are added).
+//
+// It returns an error describing what went wrong, but the caller should treat
+// failures as non-fatal: a sandbox may not run Docker at all, or the daemon may
+// lack permission to write /etc/docker.
+func ConfigureRegistryMirror(logger *slog.Logger, mirrorURL string) error {
+	return configureRegistryMirrorAt(logger, DaemonConfigPath, mirrorURL)
+}
+
+// configureRegistryMirrorAt is the path-parameterized implementation behind
+// ConfigureRegistryMirror, split out so tests can target a temporary file.
+func configureRegistryMirrorAt(logger *slog.Logger, path, mirrorURL string) error {
+	if mirrorURL == "" {
+		return nil
+	}
+
+	if _, err := url.ParseRequestURI(mirrorURL); err != nil {
+		return fmt.Errorf("invalid registry mirror URL %q: %w", mirrorURL, err)
+	}
+
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read %s: %w", path, err)
+	}
+
+	updated, changed, err := mergeRegistryMirror(existing, mirrorURL)
+	if err != nil {
+		return err
+	}
+
+	if !changed {
+		if logger != nil {
+			logger.Debug("Docker daemon already configures a registry mirror; leaving it unchanged", "path", path)
+		}
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("failed to create %s: %w", filepath.Dir(path), err)
+	}
+
+	if err := os.WriteFile(path, updated, 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
+
+	if logger != nil {
+		logger.Info("Configured Docker-in-Docker registry mirror", "path", path, "mirror", mirrorURL)
+	}
+
+	return nil
+}
+
+// mergeRegistryMirror merges a registry mirror into the raw daemon.json bytes.
+// It returns the new content, whether anything changed, and an error. It is
+// pure (no filesystem access) to keep it easy to unit test.
+//
+// The merge rules are:
+//   - If the existing config already sets a non-empty "registry-mirrors", the
+//     config is returned unchanged (changed=false).
+//   - Otherwise the mirror is added as the sole "registry-mirrors" entry.
+//   - When the mirror is served over plain HTTP, its host is also added to
+//     "insecure-registries" (dockerd otherwise refuses to use an HTTP mirror),
+//     without dropping any hosts the user already listed there.
+func mergeRegistryMirror(existing []byte, mirrorURL string) ([]byte, bool, error) {
+	parsed, err := url.ParseRequestURI(mirrorURL)
+	if err != nil {
+		return nil, false, fmt.Errorf("invalid registry mirror URL %q: %w", mirrorURL, err)
+	}
+
+	config := map[string]any{}
+	if len(existing) > 0 {
+		if err := json.Unmarshal(existing, &config); err != nil {
+			return nil, false, fmt.Errorf("failed to parse existing %s: %w", DaemonConfigPath, err)
+		}
+	}
+
+	if mirrors, ok := config["registry-mirrors"].([]any); ok && len(mirrors) > 0 {
+		return existing, false, nil
+	}
+
+	config["registry-mirrors"] = []string{mirrorURL}
+
+	// dockerd rejects an HTTP mirror unless the host is trusted as insecure.
+	if parsed.Scheme == "http" {
+		config["insecure-registries"] = addInsecureRegistry(config["insecure-registries"], parsed.Host)
+	}
+
+	out, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to encode %s: %w", DaemonConfigPath, err)
+	}
+	out = append(out, '\n')
+
+	return out, true, nil
+}
+
+// addInsecureRegistry returns the union of the already-configured insecure
+// registries and host, preserving existing entries and avoiding duplicates.
+func addInsecureRegistry(current any, host string) []string {
+	seen := map[string]struct{}{}
+	result := []string{}
+
+	if list, ok := current.([]any); ok {
+		for _, entry := range list {
+			if s, ok := entry.(string); ok {
+				if _, dup := seen[s]; !dup {
+					seen[s] = struct{}{}
+					result = append(result, s)
+				}
+			}
+		}
+	}
+
+	if _, dup := seen[host]; !dup {
+		result = append(result, host)
+	}
+
+	sort.Strings(result)
+	return result
+}

--- a/apps/daemon/pkg/dind/mirror_internal_test.go
+++ b/apps/daemon/pkg/dind/mirror_internal_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package dind
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func decode(t *testing.T, b []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+	return m
+}
+
+func TestMergeRegistryMirror_EmptyConfigAddsMirror(t *testing.T) {
+	out, changed, err := mergeRegistryMirror(nil, "https://mirror.example.com")
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	cfg := decode(t, out)
+	require.Equal(t, []any{"https://mirror.example.com"}, cfg["registry-mirrors"])
+	// HTTPS mirrors must not be added to insecure-registries.
+	_, hasInsecure := cfg["insecure-registries"]
+	require.False(t, hasInsecure)
+}
+
+func TestMergeRegistryMirror_HTTPMirrorTrustedAsInsecure(t *testing.T) {
+	out, changed, err := mergeRegistryMirror(nil, "http://mirror.example.com:5001")
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	cfg := decode(t, out)
+	require.Equal(t, []any{"http://mirror.example.com:5001"}, cfg["registry-mirrors"])
+	require.Equal(t, []any{"mirror.example.com:5001"}, cfg["insecure-registries"])
+}
+
+func TestMergeRegistryMirror_PreservesExistingKeys(t *testing.T) {
+	existing := []byte(`{"insecure-registries":["registry:6000"],"log-level":"warn"}`)
+
+	out, changed, err := mergeRegistryMirror(existing, "http://mirror.example.com:5001")
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	cfg := decode(t, out)
+	require.Equal(t, "warn", cfg["log-level"])
+	require.ElementsMatch(t, []any{"registry:6000", "mirror.example.com:5001"}, cfg["insecure-registries"])
+	require.Equal(t, []any{"http://mirror.example.com:5001"}, cfg["registry-mirrors"])
+}
+
+func TestMergeRegistryMirror_DoesNotOverwriteExistingMirror(t *testing.T) {
+	existing := []byte(`{"registry-mirrors":["https://user-mirror.example.com"]}`)
+
+	out, changed, err := mergeRegistryMirror(existing, "https://mirror.example.com")
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Equal(t, existing, out)
+}
+
+func TestMergeRegistryMirror_InvalidExistingJSON(t *testing.T) {
+	_, _, err := mergeRegistryMirror([]byte("not json"), "https://mirror.example.com")
+	require.Error(t, err)
+}
+
+func TestMergeRegistryMirror_InvalidMirrorURL(t *testing.T) {
+	_, _, err := mergeRegistryMirror(nil, "://bad")
+	require.Error(t, err)
+}
+
+func TestAddInsecureRegistry_DeduplicatesAndSorts(t *testing.T) {
+	got := addInsecureRegistry([]any{"b:1", "a:1", "b:1"}, "a:1")
+	require.Equal(t, []string{"a:1", "b:1"}, got)
+}
+
+func TestConfigureRegistryMirror_EmptyURLIsNoop(t *testing.T) {
+	require.NoError(t, ConfigureRegistryMirror(nil, ""))
+}
+
+func TestConfigureRegistryMirror_InvalidURL(t *testing.T) {
+	require.Error(t, ConfigureRegistryMirror(nil, "://nope"))
+}
+
+// TestConfigureRegistryMirror_WritesFile exercises the full write path against
+// a temporary daemon.json.
+func TestConfigureRegistryMirror_WritesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daemon.json")
+
+	require.NoError(t, configureRegistryMirrorAt(nil, path, "https://mirror.example.com"))
+
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	cfg := decode(t, b)
+	require.Equal(t, []any{"https://mirror.example.com"}, cfg["registry-mirrors"])
+}
+
+// TestConfigureRegistryMirror_DoesNotOverwriteExistingFile ensures a user's
+// pre-existing mirror in daemon.json is left untouched.
+func TestConfigureRegistryMirror_DoesNotOverwriteExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daemon.json")
+	original := []byte(`{"registry-mirrors":["https://user-mirror.example.com"]}`)
+	require.NoError(t, os.WriteFile(path, original, 0644))
+
+	require.NoError(t, configureRegistryMirrorAt(nil, path, "https://mirror.example.com"))
+
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, original, b)
+}

--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -67,6 +67,12 @@ type Config struct {
 	BuildEngine                        string        `envconfig:"BUILD_ENGINE" default:"buildkit" validate:"oneof=buildkit legacy"`
 	ForceSnapshotRemoval               bool          `envconfig:"FORCE_SNAPSHOT_REMOVAL" default:"true"`
 	MountKvmToAndroidSandbox           bool          `envconfig:"MOUNT_KVM_TO_ANDROID_SANDBOX" default:"false"`
+	// DindRegistryMirror is the URL of a registry pull-through cache that nested
+	// Docker daemons (Docker-in-Docker) inside sandboxes should use for docker.io
+	// pulls, so they avoid Docker Hub's anonymous pull rate limit (HTTP 429).
+	// It is injected into every sandbox as DAYTONA_DIND_REGISTRY_MIRROR and must
+	// be reachable from within sandboxes. The feature is disabled when empty.
+	DindRegistryMirror string `envconfig:"DAYTONA_DIND_REGISTRY_MIRROR" validate:"omitempty,url"`
 }
 
 var DEFAULT_API_PORT int = 8080
@@ -149,6 +155,13 @@ func GetContainerRuntime() string {
 
 func GetContainerNetwork() string {
 	return config.ContainerNetwork
+}
+
+func GetDindRegistryMirror() string {
+	if config == nil {
+		return ""
+	}
+	return config.DindRegistryMirror
 }
 
 func GetEnvironment() string {

--- a/apps/runner/cmd/runner/config/config_internal_test.go
+++ b/apps/runner/cmd/runner/config/config_internal_test.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package config
+
+import "testing"
+
+func TestGetDindRegistryMirror(t *testing.T) {
+	orig := config
+	t.Cleanup(func() { config = orig })
+
+	// Nil config must not panic and returns an empty string (feature disabled).
+	config = nil
+	if got := GetDindRegistryMirror(); got != "" {
+		t.Fatalf("expected empty mirror for nil config, got %q", got)
+	}
+
+	config = &Config{DindRegistryMirror: "http://registry-mirror:5001"}
+	if got := GetDindRegistryMirror(); got != "http://registry-mirror:5001" {
+		t.Fatalf("unexpected mirror: %q", got)
+	}
+}

--- a/apps/runner/pkg/docker/container_configs.go
+++ b/apps/runner/pkg/docker/container_configs.go
@@ -68,6 +68,14 @@ func (d *DockerClient) getContainerCreateConfig(sandboxDto dto.CreateSandboxDTO,
 		"DAYTONA_SANDBOX_USER=" + sandboxDto.OsUser,
 	}
 
+	// Advertise the registry pull-through cache to the sandbox so a nested
+	// Docker daemon (Docker-in-Docker) pulls docker.io images through it instead
+	// of hitting Docker Hub's anonymous rate limit (HTTP 429). Injected before
+	// the user's env below so an explicit per-sandbox value can still override it.
+	if mirror := config.GetDindRegistryMirror(); mirror != "" {
+		envVars = append(envVars, "DAYTONA_DIND_REGISTRY_MIRROR="+mirror)
+	}
+
 	// GPU sandboxes run non-privileged so CDI's per-device cgroup rules
 	// actually take effect. CDI already restricts the container to the one
 	// allocated physical GPU (see DeviceRequests below), and Linux/CUDA

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,6 +19,7 @@ The Docker Compose configuration includes all the necessary services to run Dayt
 - **Redis**: In-memory data store for caching and sessions
 - **Dex**: OIDC authentication provider
 - **Registry**: Docker image registry with web UI
+- **Registry Mirror**: Docker Hub pull-through cache for Docker-in-Docker in sandboxes
 - **MinIO**: S3-compatible object storage
 - **MailDev**: Email testing service
 - **Jaeger**: Distributed tracing
@@ -58,6 +59,43 @@ This configures dnsmasq with `address=/proxy.localhost/127.0.0.1`.
 - Database and storage data is persisted in Docker volumes
 - The registry is configured to allow image deletion for testing
 - Sandbox resource limits are disabled due to inability to partition cgroups in DinD environment where the sock is not mounted
+
+## Avoiding Docker Hub Rate Limits in Docker-in-Docker Sandboxes
+
+When users run Docker-in-Docker (DinD) inside a sandbox and pull public images,
+those pulls go to Docker Hub **anonymously**. Because every sandbox on a runner
+shares the runner's single outbound IP, they collectively burn through Docker
+Hub's [anonymous pull rate limit](https://docs.docker.com/docker-hub/usage/) fast
+and start receiving `HTTP 429 Too Many Requests`.
+
+To fix this, Daytona can point each sandbox's nested Docker daemon at a
+**registry pull-through cache** (a Docker Hub mirror). This both serves repeated
+pulls straight from cache and — when the cache is given Docker Hub credentials —
+raises the upstream limit to the authenticated tier.
+
+**How it works**
+
+1. The `registry-mirror` service runs a standard `registry:2` in
+   [pull-through cache mode](https://distribution.github.io/distribution/recipes/mirror/)
+   (`REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io`). Set
+   `REGISTRY_PROXY_USERNAME` / `REGISTRY_PROXY_PASSWORD` to a Docker Hub account
+   or access token to lift the upstream rate limit.
+2. The runner is given `DAYTONA_DIND_REGISTRY_MIRROR`, the URL of that cache.
+3. The runner injects it into every sandbox as the `DAYTONA_DIND_REGISTRY_MIRROR`
+   environment variable.
+4. On startup, the sandbox daemon writes it into `/etc/docker/daemon.json` as a
+   `registry-mirror` (adding it to `insecure-registries` too when the mirror is
+   plain HTTP), **before** the user starts their nested `dockerd`. A mirror that
+   the user already configured in `daemon.json` is never overwritten.
+
+**Enabling it**
+
+Uncomment the `DAYTONA_DIND_REGISTRY_MIRROR` variable on the `runner` service in
+`docker-compose.yaml`. The value must be an address **reachable from inside the
+sandbox network** — a sandbox's nested `dockerd` cannot resolve Compose service
+names such as `registry-mirror` on its own, so set it to an address routable from
+your sandbox network (for example the runner host's IP and the published
+`5001` port).
 
 <br><br><br>
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -141,6 +141,14 @@ services:
       - AWS_DEFAULT_BUCKET=daytona
       - DAYTONA_API_URL=http://api:3000/api
       - RUNNER_DOMAIN=runner
+      # URL of the Docker Hub pull-through cache (see the `registry-mirror`
+      # service) that Docker-in-Docker inside sandboxes should use as a registry
+      # mirror to avoid Docker Hub 429 rate limits. The runner injects it into
+      # every sandbox as DAYTONA_DIND_REGISTRY_MIRROR and the sandbox daemon
+      # writes it into /etc/docker/daemon.json before the nested dockerd starts.
+      # This must be an address reachable from *inside* sandboxes; uncomment and
+      # set it to a value routable from your sandbox network before enabling.
+      # - DAYTONA_DIND_REGISTRY_MIRROR=http://registry-mirror:5001
       - SSH_GATEWAY_ENABLE=true
       - SSH_PUBLIC_KEY=c3NoLXJzYSBBQUFBQjNOemFDMXljMkVBQUFBREFRQUJBQUFCZ1FEZUtocFdOYVhVNkpSMnJXekc1NlZJeksrcmsrdForcCtVUmwyeWF5cWRnZGg2bnVOL1NtVnJsYmV4MGlrRVZZemdRWUIwWno5M2dqOVhxSkd4WjJiMHVoSDFzNkp2bnhKZVdIK05rbjBNMzRiRjZkeVloZ3o4M0JaTitWcElJdnVDT1pxYWE4VnlRWjhPdjVLMU00enlmQnFCMld3ejcwZEVWUnFaMnVZckd5U0RqUUIrU3hRQ3phY0djb2JRQTFUd2QxdEJvSk5BaVpPWXFSU3d6TmNoTk5hZHlxSHRGdkZRQ0hhNjZWaVBmQ0FVUGt2cEN6ZGh3TmJGdVhGVWkxbnZOWkx4M056RU41M05LWUhZcWU3Y3dXZkI4QjBoRDhDd3hmSDd6T0o1b1RCMnBMVVlsUWpZRDNsN3k4SkFTbDZpYkpuR1A1SWczVXpZWlRIdUdkNzVXWktnNTRJTVROQlFPMWpJdE9HL0orUm1XbzB0YTdpRkF6ZExyL1BmbDdXTVMwbEZhSm9scTdUVmJLUG1JODFTOU04VEgrbXhLbGZ5b2NqZzhwSUdlQUllcEo3dXl1Vk1xT2wxeVVuSFNycDRlVEVlR0k3NlpCOFRoUzhkYnBLUTIvb2RYMHkwc3FSZDI0Y2lGdnM0dnZVaW80NFdYNlNWRG54dXpWRHc1Rzg9IGRheXRvbmFAMDQwNjZiZDIwY2Vi
       - INTER_SANDBOX_NETWORK_ENABLED=false
@@ -233,6 +241,28 @@ services:
     ports:
       - 5100:80
 
+  # Docker Hub pull-through cache. A nested Docker daemon (Docker-in-Docker)
+  # running inside a sandbox uses this as a registry mirror so that repeated
+  # `docker pull` of public images is served from cache instead of hitting
+  # Docker Hub's anonymous pull rate limit (HTTP 429). Set REGISTRY_PROXY_USERNAME
+  # / REGISTRY_PROXY_PASSWORD to a Docker Hub account or access token to raise
+  # the upstream limit even further.
+  registry-mirror:
+    image: registry:2.8.2
+    restart: always
+    environment:
+      REGISTRY_PROXY_REMOTEURL: https://registry-1.docker.io
+      # REGISTRY_PROXY_USERNAME: your-dockerhub-username
+      # REGISTRY_PROXY_PASSWORD: your-dockerhub-access-token
+      REGISTRY_STORAGE_DELETE_ENABLED: 'true'
+      REGISTRY_HTTP_ADDR: 0.0.0.0:5001
+    volumes:
+      - registry_mirror:/var/lib/registry
+    networks:
+      - daytona-network
+    ports:
+      - 5001:5001
+
   registry:
     image: registry:2.8.2
     restart: always
@@ -288,6 +318,7 @@ services:
 
 volumes:
   registry: {}
+  registry_mirror: {}
   minio_data: {}
   db_data: {}
   dex_db: {}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Users who run Docker-in-Docker (DinD) inside sandboxes pull public images from Docker Hub **anonymously**. Because every sandbox on a runner shares the runner's single outbound NAT IP, they collectively exhaust Docker Hub's anonymous pull rate limit and start getting `HTTP 429 Too Many Requests`.

This change lets sandboxes route those pulls through a **registry pull-through cache** (a Docker Hub mirror). The cache serves repeated pulls from its local store and — when given Docker Hub credentials — pulls upstream on the authenticated (higher) rate-limit tier.

### How it works

1. **Deployment** — a standard `registry:2` runs in pull-through cache mode (`REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io`, optionally `REGISTRY_PROXY_USERNAME` / `REGISTRY_PROXY_PASSWORD`). Added as the `registry-mirror` service in `docker/docker-compose.yaml`.
2. **Runner** — new `DAYTONA_DIND_REGISTRY_MIRROR` option. When set, the runner injects it into every sandbox as the `DAYTONA_DIND_REGISTRY_MIRROR` env var (before user env, so a per-sandbox override still wins).
3. **Sandbox daemon** — on startup the daemon writes the mirror into `/etc/docker/daemon.json` as a `registry-mirror` **before** the user starts their nested `dockerd`, so it "just works". Behavior is conservative:
   - No-op when the mirror URL is empty (feature disabled).
   - Never overwrites a `registry-mirrors` entry the user/base image already set.
   - Preserves any other existing `daemon.json` keys.
   - Adds the host to `insecure-registries` when the mirror is plain HTTP (dockerd otherwise refuses an HTTP mirror).
   - Best-effort and non-fatal — sandboxes without Docker or without write access to `/etc/docker` simply skip it.

### Changes

- `apps/daemon/pkg/dind` — new package that merges the mirror into `daemon.json` (pure, unit-tested merge logic).
- `apps/daemon/cmd/daemon` — new `DAYTONA_DIND_REGISTRY_MIRROR` config + call on startup.
- `apps/runner/cmd/runner/config` — new `DAYTONA_DIND_REGISTRY_MIRROR` option + getter.
- `apps/runner/pkg/docker/container_configs.go` — inject the env var into sandbox containers.
- `docker/docker-compose.yaml` — `registry-mirror` pull-through cache service + volume + documented runner wiring.
- `docker/README.md` — operator documentation.

> Note: this PR targets a base branch pinned at the last pre-archive code commit (`b5a5d9e78`) so the diff shows only the feature changes; `main` currently contains just the maintenance notice.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

Avoids Docker Hub anonymous pull `429` rate limits for DinD workloads in sandboxes.

## Notes

The mirror URL must be reachable **from inside the sandbox network** — a sandbox's nested `dockerd` cannot resolve Compose service names on its own, so operators should set `DAYTONA_DIND_REGISTRY_MIRROR` to an address routable from their sandbox network (e.g. the runner host IP + published `5001` port). The Compose wiring is shipped commented-out for this reason. Verified with `go build`, `go vet`, and unit tests for both the daemon and runner modules.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4826-3823-72da-8746-624599a86545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4826-3823-72da-8746-624599a86545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pull-through cache path for Docker-in-Docker to avoid Docker Hub anonymous pull 429s. The runner injects a mirror URL into each sandbox, and the daemon writes it to `/etc/docker/daemon.json` so nested `dockerd` pulls through the cache.

- **New Features**
  - Runner: new `DAYTONA_DIND_REGISTRY_MIRROR` option; injected into sandbox env.
  - Daemon: configures `registry-mirrors` in `/etc/docker/daemon.json` before nested Docker starts; preserves existing config, never overwrites a user-set mirror, and adds `insecure-registries` for HTTP mirrors; best-effort.
  - Compose: adds `registry-mirror` (`registry:2`) in pull-through mode with a persistent volume; docs updated.
  - Tests: merge logic and config getters covered.

- **Migration**
  - Optional to enable. Deploy the `registry-mirror` service and set `DAYTONA_DIND_REGISTRY_MIRROR` to a URL reachable from inside sandboxes (e.g., runner host IP:5001). Optionally set `REGISTRY_PROXY_USERNAME`/`REGISTRY_PROXY_PASSWORD` for higher Docker Hub limits. Unset = no behavior change.

<sup>Written for commit fe9cffa662e374a74fceb29acc1a58bc85e8fb8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

