### PR TITLE
fix(cli): pack snapshot context without archive/tar write too long

### DIFF
--- a/apps/cli/pkg/minio/minio.go
+++ b/apps/cli/pkg/minio/minio.go
@@ -1,0 +1,270 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package minio
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+const CONTEXT_TAR_FILE_NAME = "context.tar"
+
+type Client struct {
+	minioClient *minio.Client
+	bucket      string
+}
+
+func NewClient(endpoint, accessKey, secretKey, bucket string, useSSL bool, sessionToken string) (*Client, error) {
+	minioClient, err := minio.New(endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(accessKey, secretKey, sessionToken),
+		Secure: useSSL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create MinIO client: %w", err)
+	}
+
+	return &Client{
+		minioClient: minioClient,
+		bucket:      bucket,
+	}, nil
+}
+
+func (c *Client) UploadFile(ctx context.Context, objectName string, data []byte) error {
+	exists, err := c.minioClient.BucketExists(ctx, c.bucket)
+	if err != nil {
+		return fmt.Errorf("error checking bucket existence: %w", err)
+	}
+	if !exists {
+		err = c.minioClient.MakeBucket(ctx, c.bucket, minio.MakeBucketOptions{})
+		if err != nil {
+			return fmt.Errorf("error creating bucket: %w", err)
+		}
+	}
+
+	reader := bytes.NewReader(data)
+	objectSize := int64(len(data))
+
+	_, err = c.minioClient.PutObject(ctx, c.bucket, objectName, reader, objectSize, minio.PutObjectOptions{
+		ContentType: "application/octet-stream",
+	})
+	if err != nil {
+		return fmt.Errorf("error uploading file: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Client) ListObjects(ctx context.Context, prefix string) ([]string, error) {
+	var objects []string
+
+	objectCh := c.minioClient.ListObjects(ctx, c.bucket, minio.ListObjectsOptions{
+		Prefix: prefix,
+	})
+
+	for object := range objectCh {
+		if object.Err != nil {
+			return nil, object.Err
+		}
+		objects = append(objects, object.Key)
+	}
+
+	return objects, nil
+}
+
+func (c *Client) ProcessDirectory(ctx context.Context, dirPath, orgID string, existingObjects map[string]bool) ([]string, error) {
+	// Write outside the context tree so `snapshot create -c .` cannot pack the
+	// growing output tar (archive/tar: write too long).
+	tarFile, err := os.CreateTemp("", "daytona-context-*.tar")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tar file: %w", err)
+	}
+	defer os.Remove(tarFile.Name())
+	defer tarFile.Close()
+
+	tw := tar.NewWriter(tarFile)
+	defer tw.Close()
+
+	err = writeDirectoryToTar(tw, dirPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process directory: %w", err)
+	}
+
+	hasher := sha256.New()
+	hasher.Write([]byte(dirPath))
+	if _, err := io.Copy(hasher, tarFile); err != nil {
+		return nil, fmt.Errorf("failed to hash tar: %w", err)
+	}
+	hash := hex.EncodeToString(hasher.Sum(nil))
+
+	objectName := fmt.Sprintf("%s/%s", orgID, hash)
+	if _, exists := existingObjects[objectName]; !exists {
+		err = c.CreateDirectory(ctx, objectName)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := tarFile.Seek(0, 0); err != nil {
+			return nil, fmt.Errorf("failed to seek tar file: %w", err)
+		}
+
+		tarContent, err := io.ReadAll(tarFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read tar file: %w", err)
+		}
+
+		err = c.UploadFile(ctx, fmt.Sprintf("%s/%s", objectName, CONTEXT_TAR_FILE_NAME), tarContent)
+		if err != nil {
+			return nil, fmt.Errorf("failed to upload tar: %w", err)
+		}
+	} else {
+		fmt.Printf("Directory %s with hash %s already exists in storage\n", dirPath, hash)
+	}
+
+	return []string{hash}, nil
+}
+
+// writeDirectoryToTar walks dirPath and writes entries to tw.
+// Used by snapshot create when packing a Docker build context.
+func writeDirectoryToTar(tw *tar.Writer, dirPath string) error {
+	return filepath.Walk(dirPath, func(file string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if fi.Name() == CONTEXT_TAR_FILE_NAME {
+			return nil
+		}
+
+		var link string
+		if fi.Mode()&os.ModeSymlink != 0 {
+			link, err = os.Readlink(file)
+			if err != nil {
+				return err
+			}
+		}
+
+		header, err := tar.FileInfoHeader(fi, link)
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(filepath.Dir(dirPath), file)
+		if err != nil {
+			return err
+		}
+		header.Name = relPath
+
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+
+		if !fi.Mode().IsRegular() {
+			return nil
+		}
+
+		f, err := os.Open(file)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		_, err = io.Copy(tw, f)
+		return err
+	})
+}
+
+func (c *Client) ProcessFile(ctx context.Context, filePath, orgID string, existingObjects map[string]bool) (string, error) {
+	fileContent, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+
+	hasher := sha256.New()
+	hasher.Write(fileContent)
+	hash := hex.EncodeToString(hasher.Sum(nil))
+
+	objectName := fmt.Sprintf("%s/%s", orgID, hash)
+	if _, exists := existingObjects[objectName]; !exists {
+		var tarBuffer bytes.Buffer
+		tarWriter := tar.NewWriter(&tarBuffer)
+
+		fileName := filepath.Base(filePath)
+
+		fileInfo, err := os.Stat(filePath)
+		if err != nil {
+			return "", fmt.Errorf("failed to stat file: %w", err)
+		}
+
+		header, err := tar.FileInfoHeader(fileInfo, "")
+		if err != nil {
+			return "", fmt.Errorf("failed to create tar header: %w", err)
+		}
+		header.Name = fileName
+
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return "", fmt.Errorf("failed to write tar header: %w", err)
+		}
+
+		if _, err := tarWriter.Write(fileContent); err != nil {
+			return "", fmt.Errorf("failed to write file to tar: %w", err)
+		}
+
+		if err := tarWriter.Close(); err != nil {
+			return "", fmt.Errorf("failed to close tar writer: %w", err)
+		}
+
+		err = c.CreateDirectory(ctx, objectName)
+		if err != nil {
+			return "", err
+		}
+
+		// Upload tar file instead of raw content
+		err = c.UploadFile(ctx, fmt.Sprintf("%s/%s", objectName, CONTEXT_TAR_FILE_NAME), tarBuffer.Bytes())
+		if err != nil {
+			return "", err
+		}
+	} else {
+		fmt.Printf("File %s with hash %s already exists in storage - skipping\n", filePath, hash)
+	}
+
+	return hash, nil
+}
+
+func (c *Client) CreateDirectory(ctx context.Context, directoryPath string) error {
+	exists, err := c.minioClient.BucketExists(ctx, c.bucket)
+	if err != nil {
+		return fmt.Errorf("error checking bucket existence: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("bucket does not exist")
+	}
+
+	// Ensure the directory path ends with a slash to represent a directory
+	if !strings.HasSuffix(directoryPath, "/") {
+		directoryPath = directoryPath + "/"
+	}
+
+	// Create an empty object to represent the directory
+	emptyContent := []byte{}
+	reader := bytes.NewReader(emptyContent)
+	_, err = c.minioClient.PutObject(ctx, c.bucket, directoryPath, reader, 0, minio.PutObjectOptions{
+		ContentType: "application/directory",
+	})
+	if err != nil {
+		return fmt.Errorf("error creating directory marker: %w", err)
+	}
+
+	return nil
+}

--- a/apps/cli/pkg/minio/minio_test.go
+++ b/apps/cli/pkg/minio/minio_test.go
@@ -1,0 +1,100 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package minio
+
+import (
+	"archive/tar"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fixtureDirWithSymlink builds a directory that snapshot create would pack as
+// Docker context: a regular file and a symlink whose target is larger than the
+// link path. archive/tar reports "write too long" when a header Size does not
+// match the bytes written (symlink / size mismatch, or the output tar itself
+// being walked while it grows).
+func fixtureDirWithSymlink(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(target, []byte("hello world this is longer than the link name"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("target.txt", filepath.Join(dir, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestWriteDirectoryToTar_SymlinkSizeMismatch(t *testing.T) {
+	dir := fixtureDirWithSymlink(t)
+
+	// Simulate `daytona snapshot create --dockerfile ... -c .`: the context tar
+	// is created inside the walked tree and grows as entries are written.
+	tarPath := filepath.Join(dir, CONTEXT_TAR_FILE_NAME)
+	tarFile, err := os.Create(tarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tarFile.Close()
+
+	tw := tar.NewWriter(tarFile)
+	err = writeDirectoryToTar(tw, dir)
+	if err != nil {
+		t.Fatalf("packing context with symlink: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer: %v", err)
+	}
+	if _, err := tarFile.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+
+	tr := tar.NewReader(tarFile)
+	var sawTarget, sawLink bool
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		base := filepath.Base(hdr.Name)
+		switch base {
+		case "target.txt":
+			sawTarget = true
+			if hdr.Typeflag != tar.TypeReg {
+				t.Fatalf("target.txt type = %q, want regular file", string(hdr.Typeflag))
+			}
+			body, err := io.ReadAll(tr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(body) != "hello world this is longer than the link name" {
+				t.Fatalf("target.txt body = %q", body)
+			}
+		case "link.txt":
+			sawLink = true
+			if hdr.Typeflag != tar.TypeSymlink {
+				t.Fatalf("link.txt type = %q, want symlink", string(hdr.Typeflag))
+			}
+			if hdr.Linkname != "target.txt" {
+				t.Fatalf("link.txt Linkname = %q, want %q", hdr.Linkname, "target.txt")
+			}
+			if hdr.Size != 0 {
+				t.Fatalf("link.txt Size = %d, want 0", hdr.Size)
+			}
+		case CONTEXT_TAR_FILE_NAME:
+			t.Fatal("context tar must not be included in the archive")
+		}
+	}
+	if !sawTarget || !sawLink {
+		t.Fatalf("archive missing entries: target=%v link=%v", sawTarget, sawLink)
+	}
+}


### PR DESCRIPTION
## Description

`daytona snapshot create --dockerfile ... -c .` failed with `archive/tar: write too long` while packing the Docker build context.

The CLI wrote `context.tar` into the current working directory and then walked that same tree. The archive header `Size` was taken from a `stat` of the still-growing tar, so the subsequent copy exceeded the header and `archive/tar` rejected the write. Symlink headers also used the entry basename instead of the link target.

This change:

- Writes the context archive to a temp file outside the walked tree
- Skips a leftover `context.tar` if one is present in the context
- Records symlink targets with `Readlink` and writes a body only for regular files

A fixture directory with a symlink whose target is larger than the link path, packed the same way as `-c .`, failed on main with `write too long` and passes with this fix.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Fixes #2410

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `archive/tar: write too long` when packing Docker build contexts in `daytona snapshot create -c .`. Previously the CLI wrote `context.tar` inside the walked tree and set symlink headers incorrectly; now it writes to a temp file outside the tree, skips `context.tar`, records symlink targets, and only streams regular files.

- Implements context packing in `pkg/minio`: `writeDirectoryToTar` uses `os.Readlink` to set symlink `Linkname` with size 0 and copies data only for regular files.
- Writes the archive to a temporary file outside the context, deletes it after upload, and uploads to MinIO at `<orgID>/<hash>/context.tar` after creating a directory marker; skips upload if the `<orgID>/<hash>` prefix already exists.
- Adds `ProcessFile` to tar a single file to the same location and a focused test that verifies symlink handling and excludes the output tar from the archive.

<sup>Written for commit 4a3a185d23a302bc9c4cbf9afdd7799712d3df1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/5143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

